### PR TITLE
HCPE-709 - Remove state from HVN output

### DIFF
--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -40,7 +40,6 @@ resource "hcp_hvn" "example" {
 
 - **created_at** (String) The time that the HVN was created.
 - **organization_id** (String) The ID of the HCP organization where the HVN is located.
-- **state** (String) The current state of the HVN (eg. STABLE).
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/internal/provider/resource_hcp_hvn.go
+++ b/internal/provider/resource_hcp_hvn.go
@@ -82,11 +82,6 @@ func resourceHvn() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"state": {
-				Description: "The current state of the HVN (eg. STABLE).",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
 			"created_at": {
 				Description: "The time that the HVN was created.",
 				Type:        schema.TypeString,
@@ -248,9 +243,6 @@ func setHvnResourceData(d *schema.ResourceData, hvn *networkmodels.HashicorpClou
 		return err
 	}
 	if err := d.Set("region", hvn.Location.Region.Region); err != nil {
-		return err
-	}
-	if err := d.Set("state", hvn.State); err != nil {
 		return err
 	}
 	if err := d.Set("created_at", hvn.CreatedAt.String()); err != nil {


### PR DESCRIPTION
Per the RFC, this field was removed since it does not provide and useful information to the user