### PR TITLE
Address some bugs found during smoke testing

### DIFF
--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -113,9 +113,11 @@ func CreateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 }
 
 // GetAvailableHCPConsulVersions gets the list of available Consul versions that HCP supports.
-func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
+func GetAvailableHCPConsulVersions(ctx context.Context, loc *sharedmodels.HashicorpCloudLocationLocation, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
 	p := consul_service.NewListVersionsParams()
 	p.Context = ctx
+	p.LocationProjectID = loc.ProjectID
+	p.LocationOrganizationID = loc.OrganizationID
 
 	resp, err := client.Consul.ListVersions(p, nil)
 

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -199,7 +199,7 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// fetch available version from HCP
-	availableConsulVersions, err := clients.GetAvailableHCPConsulVersions(ctx, client)
+	availableConsulVersions, err := clients.GetAvailableHCPConsulVersions(ctx, loc, client)
 	if err != nil || availableConsulVersions == nil {
 		return diag.Errorf("error fetching available HCP Consul versions: %v", err)
 	}
@@ -447,18 +447,18 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Invoke update cluster endpoint
-	updateResp, err := clients.UpdateConsulCluster(ctx, client, loc, clusterID, newConsulVersion)
+	updateResp, err := clients.UpdateConsulCluster(ctx, client, cluster.Location, clusterID, newConsulVersion)
 	if err != nil {
 		return diag.Errorf("error updating Consul cluster (%s): %v", clusterID, err)
 	}
 
 	// Wait for the update cluster operation
-	if err := clients.WaitForOperation(ctx, client, "update Consul cluster", loc, updateResp.Operation.ID); err != nil {
+	if err := clients.WaitForOperation(ctx, client, "update Consul cluster", cluster.Location, updateResp.Operation.ID); err != nil {
 		return diag.Errorf("unable to update Consul cluster (%s): %v", clusterID, err)
 	}
 
 	// get the cluster's Consul client config files
-	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
+	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, cluster.Location, clusterID)
 	if err != nil {
 		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", clusterID, err)
 	}


### PR DESCRIPTION
This PR: 
 * Properly pass `organizationID` and `projectID` to the get available Consul version request
 * Leverages the fetched cluster's location when execute cluster update logic