### PR TITLE
Handle non-404 errors on Consul cluster read

### DIFF
--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -388,6 +388,8 @@ func resourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, meta
 			d.SetId("")
 			return nil
 		}
+
+		return diag.Errorf("unable to fetch Consul cluster (%s): %v", clusterID, err)
 	}
 
 	// get the cluster's Consul client config files


### PR DESCRIPTION
Missed some error handling on Consul cluster read. 