### PR TITLE
HCPE-745: Set operation wait timeout to 5s

### DIFF
--- a/internal/clients/operation.go
+++ b/internal/clients/operation.go
@@ -14,7 +14,7 @@ import (
 // from the operation wait endpoint.
 const maxConsecutiveWaitErrors = 4
 
-const operationWaitTimeout = time.Minute * 1
+const operationWaitTimeout = time.Second * 5
 
 // WaitForOperation will poll the operation wait endpoint until an operation
 // is DONE, ctx is canceled, or consecutive errors occur waiting for operation to complete.


### PR DESCRIPTION
[HCPE-745](https://hashicorp.atlassian.net/browse/HCPE-745)
When using a wait timeout of `1m`, we saw 504s from the elb while waiting for operations to complete.
```
2021-01-25T11:45:50.022-0600 [INFO]  plugin.terraform-provider-hcp: 2021/01/25 11:45:50 [DEBUG] [HTTP/1.1 504 Gateway Time-out
Content-Length: 132
Connection: keep-alive
Content-Type: text/html
Date: Mon, 25 Jan 2021 17:45:49 GMT
Server: awselb/2.0

<html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
</body>
</html>
]: timestamp=2021-01-25T11:45:50.021-0600
```

Using a wait timeout of 5s aligns with what we use in the internal provider and have had months of success with 😄 