### PR TITLE
[HCPE-770] Updating error messages for consistency

### DIFF
--- a/internal/provider/data_source_consul_agent_helm_config.go
+++ b/internal/provider/data_source_consul_agent_helm_config.go
@@ -122,16 +122,14 @@ func dataSourceConsulAgentHelmConfigRead(ctx context.Context, d *schema.Resource
 	cluster, err := clients.GetConsulClusterByID(ctx, client, loc, clusterID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
-			return diag.Errorf("unable to read Consul agent Helm config; no HCP Consul Cluster found with (cluster_id %q) (project_id %q)",
+			return diag.Errorf("unable to read Consul agent Helm config; Consul cluster (%s) not found",
 				clusterID,
-				projectID,
 			)
 
 		}
 
-		return diag.Errorf("error checking for presence of existing HCP Consul Cluster (cluster_id %q) (project_id %q): %+v",
+		return diag.Errorf("unable to check for presence of an existing Consul cluster (%s): %v",
 			clusterID,
-			projectID,
 			err,
 		)
 	}
@@ -139,7 +137,7 @@ func dataSourceConsulAgentHelmConfigRead(ctx context.Context, d *schema.Resource
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", clusterID, err)
+		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
 	}
 
 	// pull off the config string
@@ -148,7 +146,7 @@ func dataSourceConsulAgentHelmConfigRead(ctx context.Context, d *schema.Resource
 	// decode it
 	consulConfigJSON, err := base64.StdEncoding.DecodeString(configStr)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to base64 decode consul config (%v): %w", configStr, err))
+		return diag.FromErr(fmt.Errorf("unable to base64 decode Consul config (%v): %v", configStr, err))
 	}
 
 	// unmarshal from JSON

--- a/internal/provider/data_source_consul_agent_kubernetes_secret.go
+++ b/internal/provider/data_source_consul_agent_kubernetes_secret.go
@@ -72,7 +72,7 @@ func dataSourceConsulAgentKubernetesSecretRead(ctx context.Context, d *schema.Re
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", clusterID, err)
+		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
 	}
 
 	// pull off the config string

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -149,7 +149,7 @@ func dataSourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, me
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", clusterID, err)
+		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
 	}
 
 	// Cluster found, update resource data

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -131,7 +131,7 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 	_, err := clients.GetHvnByID(ctx, client, loc, hvnID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
-			return diag.Errorf("unable to find the HVN (%s) for the network peering", hvnID)
+			return diag.Errorf("unable to find HVN (%s) for network peering", hvnID)
 		}
 
 		return diag.Errorf("unable to check for presence of an existing HVN (%s): %v", hvnID, err)

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -233,7 +233,7 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	_, err = clients.GetConsulClusterByID(ctx, client, loc, clusterID)
 	if err != nil {
 		if !clients.IsResponseCodeNotFound(err) {
-			return diag.Errorf("unable to check for presence of an existing Consul Cluster (%s): %v", clusterID, err)
+			return diag.Errorf("unable to check for presence of an existing Consul cluster (%s): %v", clusterID, err)
 		}
 
 		// a 404 indicates a Consul cluster was not found
@@ -304,7 +304,7 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, payload.Cluster.ID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", payload.Cluster.ID, err)
+		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", payload.Cluster.ID, err)
 	}
 
 	// create customer root ACL token
@@ -446,7 +446,7 @@ func resourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", clusterID, err)
+		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
 	}
 
 	// Cluster found, update resource data
@@ -517,7 +517,7 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, cluster.Location, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster client config files (%s): %v", clusterID, err)
+		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
 	}
 
 	if err := setConsulClusterResourceData(d, cluster, clientConfigFiles); err != nil {

--- a/internal/provider/resource_consul_cluster_root_token.go
+++ b/internal/provider/resource_consul_cluster_root_token.go
@@ -91,16 +91,14 @@ func resourceConsulClusterRootTokenCreate(ctx context.Context, d *schema.Resourc
 	_, err := clients.GetConsulClusterByID(ctx, client, loc, clusterID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
-			return diag.Errorf("unable to create root ACL token; no HCP Consul Cluster found with (cluster_id %q) (project_id %q)",
+			return diag.Errorf("unable to create root ACL token; Consul cluster (%s) not found",
 				clusterID,
-				projectID,
 			)
 
 		}
 
-		return diag.Errorf("error checking for presence of existing HCP Consul Cluster (cluster_id %q) (project_id %q): %+v",
+		return diag.Errorf("unable to check for presence of an existing Consul cluster (%s): %v",
 			clusterID,
-			projectID,
 			err,
 		)
 	}
@@ -164,7 +162,7 @@ func resourceConsulClusterRootTokenRead(ctx context.Context, d *schema.ResourceD
 			return nil
 		}
 
-		return diag.Errorf("error checking for presence of existing HCP Consul Cluster (cluster_id %q) (project_id %q): %+v",
+		return diag.Errorf("unable to check for presence of an existing Consul cluster (%s): %v",
 			clusterID,
 			projectID,
 			err,
@@ -201,9 +199,8 @@ func resourceConsulClusterRootTokenDelete(ctx context.Context, d *schema.Resourc
 			return nil
 		}
 
-		return diag.Errorf("error checking for presence of existing HCP Consul Cluster (cluster_id %q) (project_id %q): %+v",
+		return diag.Errorf("unable to check for presence of an existing Consul cluster (%s): %v",
 			clusterID,
-			projectID,
 			err,
 		)
 	}
@@ -211,9 +208,8 @@ func resourceConsulClusterRootTokenDelete(ctx context.Context, d *schema.Resourc
 	// generate a new token to invalidate the previous one, but discard the response
 	_, err = clients.CreateCustomerRootACLToken(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("error deleting HCP Consul Cluster root ACL token (cluster_id %q) (project_id %q): %+v",
+		return diag.Errorf("unable to delete Consul cluster (%s) root ACL token: %v",
 			clusterID,
-			projectID,
 			err,
 		)
 	}

--- a/internal/provider/resource_consul_snapshot.go
+++ b/internal/provider/resource_consul_snapshot.go
@@ -106,11 +106,11 @@ func resourceConsulSnapshotCreate(ctx context.Context, d *schema.ResourceData, m
 	cluster, err := clients.GetConsulClusterByID(ctx, client, loc, clusterID)
 	if err != nil {
 		if !clients.IsResponseCodeNotFound(err) {
-			return diag.Errorf("unable to check for presence of an existing Consul Cluster (%s): %v", clusterID, err)
+			return diag.Errorf("unable to check for presence of an existing Consul cluster (%s): %v", clusterID, err)
 		}
 
 		// a 404 indicates a Consul cluster was not found
-		return diag.Errorf("unable to create snapshot; no HCS Cluster found for Consul cluster (%s)", clusterID)
+		return diag.Errorf("unable to create snapshot; Consul cluster (%s) not found", clusterID)
 	}
 
 	name := d.Get("snapshot_name").(string)

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -122,7 +122,7 @@ func resourceHvnCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 		log.Printf("[INFO] HVN (%s) not found, proceeding with create", hvnID)
 	} else {
-		return diag.Errorf("an HVN with hvn_id=%s and project_id=%s already exists - to be managed via Terraform this resource needs to be imported into the state. Please see the resource documentation for hcp_hvn for more information", hvnID, loc.ProjectID)
+		return diag.Errorf("unable to create HVN (%s) - an HVN with this ID already exists; see resouce documentation for hcp_hvn for instructions on how to add an already existing HVN to the state", hvnID, loc.ProjectID)
 	}
 
 	createNetworkParams := network_service.NewCreateParams()


### PR DESCRIPTION
Updated to match the following:
* error messages use the `"unable to <verb>"` format
* "Consul cluster" instead of "HCP Consul cluster" / "Consul Cluster" / etc
* `"<Resource Name> (%s)"`, ID  i.e. `Consul cluster (%s)` 
* removed project id references in error messages 
* errors are formatted with %v, not %+v, %w