### PR TITLE
fix peering guide note + missed generated docs

### DIFF
--- a/docs/guides/consul-root-token.md
+++ b/docs/guides/consul-root-token.md
@@ -14,8 +14,8 @@ the existing root token will be invalidated.
 ```terraform
 resource "hcp_hvn" "example" {
   hvn_id         = var.hvn_id
-  cloud_provider = var.cloud_provider
-  region         = var.region
+  cloud_provider = "aws"
+  region         = "us-west-2"
 }
 
 // The root_token_accessor_id and root_token_secret_id properties will

--- a/docs/guides/peering.md
+++ b/docs/guides/peering.md
@@ -10,7 +10,8 @@ description: |-
 In order to connect AWS workloads to an HCP Consul cluster, you must peer the VPC in which the workloads reside to the HVN in which the HCP cluster resides.
 This is accomplished by using the `hcp_aws_network_peering` resource to create a Network peering between the HVN's VPC and your own VPC.
 The [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) resource is useful for accepting the Network peering that is initiated from the `hcp_aws_network_peering`.
--> **Note** The CIDR blocks of the HVN and the peer VPC cannot overlap.
+
+-> **Note:** The CIDR blocks of the HVN and the peer VPC cannot overlap.
 
 For more details about deploying Consul on HCP, check out the [Deploy HashiCorp Cloud Platform (HCP) Consul](https://learn.hashicorp.com/tutorials/cloud/consul-deploy?in=consul/cloud) guide.
 
@@ -18,7 +19,7 @@ For more details about deploying Consul on HCP, check out the [Deploy HashiCorp 
 // Create a HashiCorp Virtual Network (HVN).
 resource "hcp_hvn" "example" {
   hvn_id         = var.hvn_id
-  cloud_provider = var.cloud_provider
+  cloud_provider = "aws"
   region         = var.region
   cidr_block     = "172.25.16.0/20"
 }
@@ -44,7 +45,7 @@ resource "hcp_aws_network_peering" "example" {
   hvn_id              = hcp_hvn.example.hvn_id
   peer_vpc_id         = aws_vpc.peer.id
   peer_account_id     = aws_vpc.peer.owner_id
-  peer_vpc_region     = var.peer_vpc_region
+  peer_vpc_region     = var.region
   peer_vpc_cidr_block = aws_vpc.peer.cidr_block
 }
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -33,8 +33,7 @@ resource "hcp_consul_cluster" "example_consul_cluster" {
 }
 
 resource "hcp_aws_network_peering" "example_peering" {
-  hvn_id = hcp_hvn.example_hvn.hvn_id
-
+  hvn_id              = hcp_hvn.example_hvn.hvn_id
   peer_vpc_id         = "vpc-2f09a348"
   peer_account_id     = "1234567890"
   peer_vpc_region     = "us-west-2"

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ provider "aws" {
 // Create an HVN
 resource "hcp_hvn" "example_hvn" {
   hvn_id         = "hcp-tf-example-hvn"
-  cloud_provider = var.cloud_provider
+  cloud_provider = "aws"
   region         = var.region
   cidr_block     = "172.25.16.0/20"
 }
@@ -58,8 +58,7 @@ resource "aws_vpc_peering_connection_accepter" "main" {
 
 // Create a Network peering between the HVN and the AWS VPC
 resource "hcp_aws_network_peering" "example_peering" {
-  hvn_id = hcp_hvn.example_hvn.hvn_id
-
+  hvn_id              = hcp_hvn.example_hvn.hvn_id
   peer_vpc_id         = aws_vpc.main.id
   peer_account_id     = aws_vpc.main.owner_id
   peer_vpc_region     = data.aws_arn.main.region
@@ -68,16 +67,15 @@ resource "hcp_aws_network_peering" "example_peering" {
 
 // Create a Consul cluster in the same region and cloud provider as the HVN
 resource "hcp_consul_cluster" "example" {
-  hvn_id         = hcp_hvn.example_hvn.hvn_id
-  cluster_id     = "hcp-tf-example-consul-cluster"
-  cloud_provider = var.cloud_provider
-  region         = var.region
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+  cluster_id = "hcp-tf-example-consul-cluster"
+  tier       = "development"
 }
 ```
 
 ## Schema
 
-### Required
+### Optional
 
 - **client_id** (String) The OAuth2 Client ID for API operations.
 - **client_secret** (String) The OAuth2 Client Secret for API operations.

--- a/examples/guides/quick_start/main.tf
+++ b/examples/guides/quick_start/main.tf
@@ -12,7 +12,7 @@ resource "hcp_consul_cluster" "example_consul_cluster" {
 }
 
 resource "hcp_aws_network_peering" "example_peering" {
-  hvn_id = hcp_hvn.example_hvn.hvn_id
+  hvn_id              = hcp_hvn.example_hvn.hvn_id
   peer_vpc_id         = "vpc-2f09a348"
   peer_account_id     = "1234567890"
   peer_vpc_region     = "us-west-2"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -40,7 +40,7 @@ resource "aws_vpc_peering_connection_accepter" "main" {
 
 // Create a Network peering between the HVN and the AWS VPC
 resource "hcp_aws_network_peering" "example_peering" {
-  hvn_id = hcp_hvn.example_hvn.hvn_id
+  hvn_id              = hcp_hvn.example_hvn.hvn_id
   peer_vpc_id         = aws_vpc.main.id
   peer_account_id     = aws_vpc.main.owner_id
   peer_vpc_region     = data.aws_arn.main.region
@@ -49,7 +49,7 @@ resource "hcp_aws_network_peering" "example_peering" {
 
 // Create a Consul cluster in the same region and cloud provider as the HVN
 resource "hcp_consul_cluster" "example" {
-  hvn_id         = hcp_hvn.example_hvn.hvn_id
-  cluster_id     = "hcp-tf-example-consul-cluster"
-  tier           = "development"
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+  cluster_id = "hcp-tf-example-consul-cluster"
+  tier       = "development"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,13 +34,13 @@ func New() func() *schema.Provider {
 			Schema: map[string]*schema.Schema{
 				"client_id": {
 					Type:        schema.TypeString,
-					Required:    true,
+					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("HCP_CLIENT_ID", nil),
 					Description: "The OAuth2 Client ID for API operations.",
 				},
 				"client_secret": {
 					Type:        schema.TypeString,
-					Required:    true,
+					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("HCP_CLIENT_SECRET", nil),
 					Description: "The OAuth2 Client Secret for API operations.",
 				},

--- a/templates/guides/peering.md.tmpl
+++ b/templates/guides/peering.md.tmpl
@@ -10,7 +10,8 @@ description: |-
 In order to connect AWS workloads to an HCP Consul cluster, you must peer the VPC in which the workloads reside to the HVN in which the HCP cluster resides.
 This is accomplished by using the `hcp_aws_network_peering` resource to create a Network peering between the HVN's VPC and your own VPC.
 The [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) resource is useful for accepting the Network peering that is initiated from the `hcp_aws_network_peering`.
--> **Note** The CIDR blocks of the HVN and the peer VPC cannot overlap.
+
+-> **Note:** The CIDR blocks of the HVN and the peer VPC cannot overlap.
 
 For more details about deploying Consul on HCP, check out the [Deploy HashiCorp Cloud Platform (HCP) Consul](https://learn.hashicorp.com/tutorials/cloud/consul-deploy?in=consul/cloud) guide.
 


### PR DESCRIPTION
Fixes this line in the Peering guide:
<img width="594" alt="Screen Shot 2021-02-02 at 2 22 58 PM" src="https://user-images.githubusercontent.com/21015366/106672900-b18f6880-6565-11eb-9349-aceb7c3b27b8.png">

Which should look like:
<img width="617" alt="Screen Shot 2021-02-02 at 2 23 06 PM" src="https://user-images.githubusercontent.com/21015366/106672910-b3f1c280-6565-11eb-8a2c-91109da30de6.png">

Also adds up-to-date generated docs, looks like one of the last cleanup PRs missed them.