### PR TITLE
Set resource id before polling operation and re-create failed deployments

### DIFF
--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -235,6 +235,14 @@ func resourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("unable to retrieve Network peering (%s): %v", peeringID, err)
 	}
 
+	// The Network peering failed to provision properly so we want to let the user know and
+	// remove it from state
+	if peering.State == networkmodels.HashicorpCloudNetwork20200907PeeringStateFAILED {
+		log.Printf("[WARN] network peering (%s) failed to provision, removing from state", peering.ID)
+		d.SetId("")
+		return nil
+	}
+
 	// Network peering found, update resource data
 	if err := setPeeringResourceData(d, peering); err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -444,6 +444,14 @@ func resourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("unable to fetch Consul cluster (%s): %v", clusterID, err)
 	}
 
+	// The Consul cluster failed to provision properly so we want to let the user know and
+	// remove it from state
+	if cluster.State == consulmodels.HashicorpCloudConsul20200826ClusterStateFAILED {
+		log.Printf("[WARN] Consul cluster (%s) failed to provision, removing from state", clusterID)
+		d.SetId("")
+		return nil
+	}
+
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -281,13 +281,6 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("unable to create Consul cluster (%s): %v", clusterID, err)
 	}
 
-	// wait for the Consul cluster to be created
-	if err := clients.WaitForOperation(ctx, client, "create Consul cluster", loc, payload.Operation.ID); err != nil {
-		return diag.Errorf("unable to create Consul cluster (%s): %v", payload.Cluster.ID, err)
-	}
-
-	log.Printf("[INFO] Created Consul cluster (%s)", payload.Cluster.ID)
-
 	link := newLink(loc, ConsulClusterResourceType, clusterID)
 	url, err := linkURL(link)
 	if err != nil {
@@ -295,6 +288,13 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	d.SetId(url)
+
+	// wait for the Consul cluster to be created
+	if err := clients.WaitForOperation(ctx, client, "create Consul cluster", loc, payload.Operation.ID); err != nil {
+		return diag.Errorf("unable to create Consul cluster (%s): %v", payload.Cluster.ID, err)
+	}
+
+	log.Printf("[INFO] Created Consul cluster (%s)", payload.Cluster.ID)
 
 	// get the created Consul cluster
 	cluster, err := clients.GetConsulClusterByID(ctx, client, loc, payload.Cluster.ID)

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -142,19 +142,19 @@ func resourceHvnCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("unable to create HVN (%s): %v", hvnID, err)
 	}
 
-	// Wait for HVN to be created
-	if err := clients.WaitForOperation(ctx, client, "create HVN", loc, createNetworkResponse.Payload.Operation.ID); err != nil {
-		return diag.Errorf("unable to create HVN (%s): %v", createNetworkResponse.Payload.Network.ID, err)
-	}
-
-	log.Printf("[INFO] Created HVN (%s)", createNetworkResponse.Payload.Network.ID)
-
 	link := newLink(loc, HvnResourceType, hvnID)
 	url, err := linkURL(link)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(url)
+
+	// Wait for HVN to be created
+	if err := clients.WaitForOperation(ctx, client, "create HVN", loc, createNetworkResponse.Payload.Operation.ID); err != nil {
+		return diag.Errorf("unable to create HVN (%s): %v", createNetworkResponse.Payload.Network.ID, err)
+	}
+
+	log.Printf("[INFO] Created HVN (%s)", createNetworkResponse.Payload.Network.ID)
 
 	// Get the updated HVN
 	hvn, err := clients.GetHvnByID(ctx, client, loc, createNetworkResponse.Payload.Network.ID)

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -192,6 +192,14 @@ func resourceHvnRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.Errorf("unable to retrieve HVN (%s): %v", hvnID, err)
 	}
 
+	// The HVN failed to provision properly so we want to let the user know and remove it from
+	// state
+	if hvn.State == networkmodels.HashicorpCloudNetwork20200907NetworkStateFAILED {
+		log.Printf("[WARN] HVN (%s) failed to provision, removing from state", hvnID)
+		d.SetId("")
+		return nil
+	}
+
 	// HVN found, update resource data
 	if err := setHvnResourceData(d, hvn); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Set the `ID` of resources that need to poll for an operation _before_ polling the operation. This prevents the case where a resource is created in the DB but the async resource operation fails and Terraform has no state entry so it thinks the resource does not exist (even though it does and is in a failed state), so the user can't run `terraform destroy` to clean up the failed resource.

This PR also sets the Terraform `ID` of resources  in a failed state to `""` during read. This allows HCP resources (ie a Consul cluster) to be automatically replaced if they failed to provision in the first place. Without this logic, the user would need to look at the HCP UI to determine their cluster/HVN/peering is in a `FAILED` state, and delete/recreate manually using Terraform (or the UI and remove from state manually).

Failed provision:
```
❯ terraform apply --auto-approve
hcp_hvn.example_hvn: Refreshing state... [id=/project/51545062-b7a8-4066-8e32-ca283cb147fc/hashicorp.network.hvn/hcp-tf-example-hvn]
hcp_consul_cluster.example_consul_cluster: Creating...
hcp_consul_cluster.example_consul_cluster: Still creating... [10s elapsed]
hcp_consul_cluster.example_consul_cluster: Still creating... [20s elapsed]

Error: unable to create Consul cluster (hcp-tf-example-consul-cluster): create Consul cluster operation (7920f945-933d-4bcc-bdfa-b151e6e50e8b) failed [code=3, message=failed to deploy consul cluster: failed to generate Consul config file: failed to create consul config generator: invalid configuration options: 1 error occurred:
	* rpc error: code = InvalidArgument desc = datacenter cannot be "HCP-TF-EXAMPLE-CONSUL-CLUSTER". Please use only [a-z0-9-_].

]
```

On next `terraform plan`:
```
❯ tf plan
hcp_hvn.example_hvn: Refreshing state... [id=/project/51545062-b7a8-4066-8e32-ca283cb147fc/hashicorp.network.hvn/hcp-tf-example-hvn]
hcp_consul_cluster.example_consul_cluster: Refreshing state... [id=/project/51545062-b7a8-4066-8e32-ca283cb147fc/hashicorp.consul.cluster/hcp-tf-example-consul-cluster]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # hcp_consul_cluster.example_consul_cluster must be replaced
-/+ resource "hcp_consul_cluster" "example_consul_cluster" {
      + cloud_provider                = (known after apply)
      + cluster_id                    = "hcp-tf-example-consul-cluster"
      + connect_enabled               = true
      + consul_automatic_upgrades     = (known after apply)
      + consul_ca_file                = (known after apply)
      + consul_config_file            = (known after apply)
      + consul_private_endpoint_url   = (known after apply)
      + consul_public_endpoint_url    = (known after apply)
      + consul_root_token_accessor_id = (known after apply)
      + consul_root_token_secret_id   = (sensitive value)
      + consul_snapshot_interval      = (known after apply)
      + consul_snapshot_retention     = (known after apply)
      + consul_version                = (known after apply)
      + datacenter                    = (known after apply)
      + hvn_id                        = "hcp-tf-example-hvn"
      + id                            = (known after apply)
      + organization_id               = (known after apply)
      + project_id                    = (known after apply)
      + public_endpoint               = false
      + region                        = (known after apply)
      + scale                         = (known after apply)
      + tier                          = "development"
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

I really wish we could return a warning diag instead of just logging and return `nil` but 🤷 