### PR TITLE
HCS-1760: Add Consul versions data source

### DIFF
--- a/docs/data-sources/consul_versions.md
+++ b/docs/data-sources/consul_versions.md
@@ -1,0 +1,38 @@
+---
+page_title: "hcp_consul_versions Data Source - terraform-provider-hcp"
+subcategory: ""
+description: |-
+  The Consul versions data source provides the Consul versions supported by HCP.
+---
+
+# Data Source `hcp_consul_versions`
+
+The Consul versions data source provides the Consul versions supported by HCP.
+
+## Example Usage
+
+```terraform
+data "hcp_consul_versions" "default" {}
+```
+
+## Schema
+
+### Optional
+
+- **id** (String) The ID of this resource.
+- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+### Read-only
+
+- **available** (List of String) The Consul versions available on HCP.
+- **preview** (List of String) The preview versions of Consul available on HCP.
+- **recommended** (String) The recommended Consul version for HCP clusters.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- **default** (String)
+
+

--- a/examples/data-sources/hcp_consul_versions/data-source.tf
+++ b/examples/data-sources/hcp_consul_versions/data-source.tf
@@ -1,0 +1,1 @@
+data "hcp_consul_versions" "default" {}

--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -112,14 +112,29 @@ func CreateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 	return resp.Payload, nil
 }
 
-// GetAvailableHCPConsulVersions gets the list of available Consul versions that HCP supports.
-func GetAvailableHCPConsulVersions(ctx context.Context, loc *sharedmodels.HashicorpCloudLocationLocation, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
+// GetAvailableHCPConsulVersionsForLocation gets the list of available Consul versions that HCP supports for
+// the provided location.
+func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmodels.HashicorpCloudLocationLocation, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
 	p := consul_service.NewListVersionsParams()
 	p.Context = ctx
 	p.LocationProjectID = loc.ProjectID
 	p.LocationOrganizationID = loc.OrganizationID
 
 	resp, err := client.Consul.ListVersions(p, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload.Versions, nil
+}
+
+// GetAvailableHCPConsulVersions gets the list of available Consul versions that HCP supports.
+func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
+	p := consul_service.NewListVersions2Params()
+	p.Context = ctx
+
+	resp, err := client.Consul.ListVersions2(p, nil)
 
 	if err != nil {
 		return nil, err
@@ -147,7 +162,7 @@ func DeleteConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 	return deleteResp.Payload, nil
 }
 
-// GetAvailableHCPConsulVersions gets the list of available Consul versions that HCP supports.
+// GetAvailableHCPConsulVersionsForLocation gets the list of available Consul versions that HCP supports.
 func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	clusterID string) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
 

--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -162,7 +162,8 @@ func DeleteConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 	return deleteResp.Payload, nil
 }
 
-// GetAvailableHCPConsulVersionsForLocation gets the list of available Consul versions that HCP supports.
+// ListConsulUpgradeVersions gets the list of available Consul versions that the supplied cluster
+// can upgrade to.
 func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	clusterID string) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
 

--- a/internal/consul/version.go
+++ b/internal/consul/version.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"fmt"
 	"strings"
 
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
@@ -36,4 +37,34 @@ func IsValidVersion(version string, versions []*consulmodels.HashicorpCloudConsu
 // NormalizeVersion ensures the version starts with a 'v'
 func NormalizeVersion(version string) string {
 	return "v" + strings.TrimPrefix(version, "v")
+}
+
+// VersionsToString converts a slice of version pointers to a string of their comma delimited values.
+func VersionsToString(versions []*consulmodels.HashicorpCloudConsul20200826Version) string {
+	var recommendedVersion string
+	var otherVersions []string
+
+	for _, v := range versions {
+		if v == nil {
+			continue
+		}
+
+		if v.Status == consulmodels.HashicorpCloudConsul20200826VersionStatusRECOMMENDED {
+			recommendedVersion = v.Version
+		} else {
+			otherVersions = append(otherVersions, v.Version)
+		}
+	}
+
+	// No other versions found, return recommended even if it's empty
+	if len(otherVersions) == 0 {
+		return recommendedVersion
+	}
+
+	// No recommended found, return others
+	if recommendedVersion == "" {
+		return strings.Join(otherVersions, ", ")
+	}
+
+	return fmt.Sprintf("%s, %s", recommendedVersion, strings.Join(otherVersions, ", "))
 }

--- a/internal/consul/version.go
+++ b/internal/consul/version.go
@@ -66,5 +66,5 @@ func VersionsToString(versions []*consulmodels.HashicorpCloudConsul20200826Versi
 		return strings.Join(otherVersions, ", ")
 	}
 
-	return fmt.Sprintf("%s, %s", recommendedVersion, strings.Join(otherVersions, ", "))
+	return fmt.Sprintf("%s (recommended), %s", recommendedVersion, strings.Join(otherVersions, ", "))
 }

--- a/internal/consul/version_test.go
+++ b/internal/consul/version_test.go
@@ -141,3 +141,74 @@ func Test_NormalizeVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_VersionsToString(t *testing.T) {
+	tcs := map[string]struct {
+		expected string
+		input    []*consulmodels.HashicorpCloudConsul20200826Version
+	}{
+		"with a recommended version": {
+			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+				{
+					Version: "v1.9.0",
+					Status:  "RECOMMENDED",
+				},
+				{
+					Version: "v1.8.6",
+					Status:  "AVAILABLE",
+				},
+				{
+					Version: "v1.8.4",
+					Status:  "AVAILABLE",
+				},
+			},
+			expected: "v1.9.0, v1.8.6, v1.8.4",
+		},
+		"without a recommended version": {
+			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+				{
+					Version: "v1.8.6",
+					Status:  "AVAILABLE",
+				},
+				{
+					Version: "v1.8.4",
+					Status:  "AVAILABLE",
+				},
+			},
+			expected: "v1.8.6, v1.8.4",
+		},
+		"no other versions but recommended": {
+			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+				{
+					Version: "v1.9.0",
+					Status:  "RECOMMENDED",
+				},
+			},
+			expected: "v1.9.0",
+		},
+		"nil input": {
+			input:    nil,
+			expected: "",
+		},
+		"nil values": {
+			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+				nil,
+				{
+					Version: "v1.9.0",
+					Status:  "RECOMMENDED",
+				},
+				nil,
+			},
+			expected: "v1.9.0",
+		},
+	}
+
+	for n, tc := range tcs {
+		t.Run(n, func(t *testing.T) {
+			r := require.New(t)
+
+			result := VersionsToString(tc.input)
+			r.Equal(tc.expected, result)
+		})
+	}
+}

--- a/internal/consul/version_test.go
+++ b/internal/consul/version_test.go
@@ -162,7 +162,7 @@ func Test_VersionsToString(t *testing.T) {
 					Status:  "AVAILABLE",
 				},
 			},
-			expected: "v1.9.0, v1.8.6, v1.8.4",
+			expected: "v1.9.0 (recommended), v1.8.6, v1.8.4",
 		},
 		"without a recommended version": {
 			input: []*consulmodels.HashicorpCloudConsul20200826Version{

--- a/internal/provider/data_source_consul_versions.go
+++ b/internal/provider/data_source_consul_versions.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"crypto/md5"
 	"fmt"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+	"github.com/hashicorp/terraform-provider-hcp/internal/consul"
 )
 
 // defaultConsulVersionsTimeoutDuration is the default timeout
@@ -90,7 +92,7 @@ func dataSourceConsulVersionsRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprintf("recommended/%s/available_len/%d/preview_len/%d", recommendedVersion, len(availableVersions), len(previewVersions)))
+	d.SetId(fmt.Sprintf("%x", md5.Sum([]byte(consul.VersionsToString(availableConsulVersions)))))
 
 	return nil
 }

--- a/internal/provider/data_source_consul_versions.go
+++ b/internal/provider/data_source_consul_versions.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+)
+
+// defaultConsulVersionsTimeoutDuration is the default timeout
+// for reading the agent Helm config.
+var defaultConsulVersionsTimeoutDuration = time.Minute * 5
+
+// dataSourceConsulVersions is the data source for the Consul versions supported by HCP.
+func dataSourceConsulVersions() *schema.Resource {
+	return &schema.Resource{
+		Description: "The Consul versions data source provides the Consul versions supported by HCP.",
+		Timeouts: &schema.ResourceTimeout{
+			Default: &defaultConsulVersionsTimeoutDuration,
+		},
+		ReadContext: dataSourceConsulVersionsRead,
+		Schema: map[string]*schema.Schema{
+			// Computed outputs
+			"recommended": {
+				Description: "The recommended Consul version for HCP clusters.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"available": {
+				Description: "The Consul versions available on HCP.",
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"preview": {
+				Description: "The preview versions of Consul available on HCP.",
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceConsulVersionsRead is the func to implement reading of the
+// supported Consul versions on HCP.
+func dataSourceConsulVersionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	availableConsulVersions, err := clients.GetAvailableHCPConsulVersions(ctx, meta.(*clients.Client))
+	if err != nil || len(availableConsulVersions) == 0 {
+		return diag.Errorf("error fetching available HCP Consul versions: %v", err)
+	}
+
+	var recommendedVersion string
+	availableVersions := make([]string, 0)
+	previewVersions := make([]string, 0)
+
+	for _, v := range availableConsulVersions {
+		switch v.Status {
+		case consulmodels.HashicorpCloudConsul20200826VersionStatusRECOMMENDED:
+			recommendedVersion = v.Version
+			availableVersions = append(availableVersions, v.Version)
+		case consulmodels.HashicorpCloudConsul20200826VersionStatusAVAILABLE:
+			availableVersions = append(availableVersions, v.Version)
+		case consulmodels.HashicorpCloudConsul20200826VersionStatusPREVIEW:
+			previewVersions = append(previewVersions, v.Version)
+		}
+	}
+
+	err = d.Set("recommended", recommendedVersion)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("available", availableVersions)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("preview", previewVersions)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("recommended/%s/available_len/%d/preview_len/%d", recommendedVersion, len(availableVersions), len(previewVersions)))
+
+	return nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,7 @@ func New() func() *schema.Provider {
 				"hcp_consul_agent_helm_config":       dataSourceConsulAgentHelmConfig(),
 				"hcp_consul_agent_kubernetes_secret": dataSourceConsulAgentKubernetesSecret(),
 				"hcp_consul_cluster":                 dataSourceConsulCluster(),
+				"hcp_consul_versions":                dataSourceConsulVersions(),
 				"hcp_hvn":                            dataSourceHvn(),
 			},
 			ResourcesMap: map[string]*schema.Resource{

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -244,7 +244,7 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// fetch available version from HCP
-	availableConsulVersions, err := clients.GetAvailableHCPConsulVersions(ctx, loc, client)
+	availableConsulVersions, err := clients.GetAvailableHCPConsulVersionsForLocation(ctx, loc, client)
 	if err != nil || availableConsulVersions == nil {
 		return diag.Errorf("error fetching available HCP Consul versions: %v", err)
 	}

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -258,7 +258,7 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	// check if version is valid and available
 	if !consul.IsValidVersion(consulVersion, availableConsulVersions) {
-		return diag.Errorf("specified Consul version (%s) is unavailable; must be one of: %v", consulVersion, availableConsulVersions)
+		return diag.Errorf("specified Consul version (%s) is unavailable; must be one of: [%s]", consulVersion, consul.VersionsToString(availableConsulVersions))
 	}
 
 	datacenter := strings.ToLower(clusterID)
@@ -509,7 +509,7 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	// Validate that the upgrade version is valid
 	if !consul.IsValidVersion(newConsulVersion, upgradeVersions) {
-		return diag.Errorf("specified Consul version (%s) is unavailable; must be one of: %v", newConsulVersion, upgradeVersions)
+		return diag.Errorf("specified Consul version (%s) is unavailable; must be one of: [%s]", newConsulVersion, consul.VersionsToString(upgradeVersions))
 	}
 
 	// Invoke update cluster endpoint


### PR DESCRIPTION
Based off the [`hcs_consul_versions` data source](https://registry.terraform.io/providers/hashicorp/hcs/latest/docs/data-sources/consul_versions), we can allows users to explicitly set their Consul cluster version to the latest recommended Consul version that HCP supports. This means that any time the recommended HCP Consul version changes, someone utilizing the `recommended` field of the `consul_versions` data source will be prompted to upgrade their cluster the next time they run `terraform plan`:
```
❯ terraform plan
hcp_hvn.example_hvn: Refreshing state... 
hcp_consul_cluster.example_consul_cluster: Refreshing state... 

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # hcp_consul_cluster.example_consul_cluster will be updated in-place
  ~ resource "hcp_consul_cluster" "example_consul_cluster" {
        id                            = "/project/XXX/hashicorp.consul.cluster/hcp-tf-example-consul-cluster"
      ~ min_consul_version            = "v1.9.2" -> "v1.9.3"
        # (19 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This data source also informs users of the Consul versions that HCP supports, in the case where they are looking to use a specific Consul version.

If HCP offers preview versions of Consul in the future, users would be able to discover and set `min_consul_version` of their cluster using this data source.

```
❯ tf show
# data.hcp_consul_versions.versions:
data "hcp_consul_versions" "versions" {
    available   = [
        "v1.9.3",
        "v1.9.2",
        "v1.9.1",
        "v1.9.0",
        "v1.8.8",
        "v1.8.7",
        "v1.8.6",
        "v1.8.4",
        "v1.8.0",
    ]
    id          = "recommended/v1.9.3/available_len/9/preview_len/0"
    preview     = []
    recommended = "v1.9.3"
}
```

Usage:
```
data "hcp_consul_versions" "versions" {}

resource "hcp_consul_cluster" "example_consul_cluster" {
  hvn_id             = hcp_hvn.example_hvn.hvn_id
  cluster_id         = "hcp-tf-example-consul-cluster"
  tier               = "development"
  min_consul_version = data.hcp_consul_versions.versions.recommended
}
```

