### PR TITLE
HCPE-909 - Add TGW attachment imports

### DIFF
--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -99,4 +99,11 @@ Optional:
 - **default** (String)
 - **delete** (String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# The import ID is {hvn_id}:{transit_gateway_attachment_id}
+terraform import hcp_aws_transit_gateway_attachment.example main-hvn:example-tgw-attachment
+```

--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -101,6 +101,8 @@ Optional:
 
 ## Import
 
+-> **Note:** When importing a transit gateway attachment, you will want to configure a `lifecycle` configuration block with an `ignore_changes` argument including `resource_share_arn`. This is needed because its value is no longer retrievable after creation.
+
 Import is supported using the following syntax:
 
 ```shell

--- a/examples/resources/hcp_aws_transit_gateway_attachment/import.sh
+++ b/examples/resources/hcp_aws_transit_gateway_attachment/import.sh
@@ -1,0 +1,2 @@
+# The import ID is {hvn_id}:{transit_gateway_attachment_id}
+terraform import hcp_aws_transit_gateway_attachment.example main-hvn:example-tgw-attachment

--- a/templates/resources/aws_transit_gateway_attachment.md.tmpl
+++ b/templates/resources/aws_transit_gateway_attachment.md.tmpl
@@ -1,0 +1,24 @@
+---
+page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} `{{.Type}}`
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{ tffile "examples/resources/hcp_aws_transit_gateway_attachment/resource.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+-> **Note:** When importing a transit gateway attachment, you will want to configure a `lifecycle` configuration block with an `ignore_changes` argument including `resource_share_arn`. This is needed because its value is no longer retrievable after creation.
+
+Import is supported using the following syntax:
+
+{{ codefile "shell" "examples/resources/hcp_aws_transit_gateway_attachment/import.sh" }}


### PR DESCRIPTION
Adds import functionality, where the import id is `{hvn_id}:{transit_gateway_attachment_id}`

Most of the functionality matches what is already done with network peering.

One note: because `resource_share_arn` is not available in our responses, it cannot be populated into Terraform state from an import. This is a known case that can be handled with an `ignore_changes` block (I've included this in the documentation here), but the preferred solution would be to include this value in the response, if that is an option here.