### PR TITLE
Add beta banner to docs for TGW attachment resources

### DIFF
--- a/docs/data-sources/aws_transit_gateway_attachment.md
+++ b/docs/data-sources/aws_transit_gateway_attachment.md
@@ -7,6 +7,8 @@ description: |-
 
 # Data Source `hcp_aws_transit_gateway_attachment`
 
+-> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+
 The AWS Transit Gateway Attachment data source provides information about an existing transit gateway attachment.
 
 ## Example Usage
@@ -48,5 +50,3 @@ data "hcp_aws_transit_gateway_attachment" "test" {
 Optional:
 
 - **default** (String)
-
-

--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -7,6 +7,8 @@ description: |-
 
 # Resource `hcp_aws_transit_gateway_attachment`
 
+-> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+
 The AWS Transit Gateway Attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.
 
 ## Example Usage

--- a/templates/data-sources/aws_transit_gateway_attachment.md.tmpl
+++ b/templates/data-sources/aws_transit_gateway_attachment.md.tmpl
@@ -1,0 +1,18 @@
+---
+page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} `{{.Type}}`
+
+-> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{ tffile "examples/data-sources/hcp_aws_transit_gateway_attachment/data-source.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}

--- a/templates/resources/aws_transit_gateway_attachment.md.tmpl
+++ b/templates/resources/aws_transit_gateway_attachment.md.tmpl
@@ -7,6 +7,8 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
+-> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+
 {{ .Description | trimspace }}
 
 ## Example Usage


### PR DESCRIPTION
This adds a banner to the docs for transit gateway attachment resources, since they are still in private beta and behind a feature flag. When the next version of the provider is published, these pages will be visible to all users, so this banner will help prevent confusion.