### PR TITLE
HCPE-798 - Add initial contribution guidelines

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -63,3 +63,7 @@ The following checklists are meant to be used for PRs to give developers and rev
 
 * [New resource](checklist-resource.md)
 * [Adding resource import support](checklist-resource-import.md)
+
+## References
+
+The [reference documentation](references.md) includes more background material on specific functionality. This documentation is intended for Terraform HCP Provider code developers. Typical operators writing and applying Terraform configurations do not need to read or understand this material.

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -56,3 +56,10 @@ To generate or update documentation, run `go generate`.
 ```shell script
 $ go generate
 ```
+
+## Checklists
+
+The following checklists are meant to be used for PRs to give developers and reviewers confidence that the proper changes have been made:
+
+* [New resource](checklist-resource.md)
+* [Adding resource import support](checklist-resource-import.md)

--- a/contributing/checklist-resource-import.md
+++ b/contributing/checklist-resource-import.md
@@ -1,0 +1,11 @@
+# Adding Resource Import Support Checklist
+
+Adding import support for Terraform resources will allow existing infrastructure to be managed within Terraform. This type of enhancement generally requires a small to moderate amount of code changes.
+
+Comprehensive code examples and information about resource import support can be found in the [Extending Terraform documentation](https://www.terraform.io/docs/extend/resources/import.html).
+
+- [ ] __Uses Context-Aware Import Function__: The context-aware `StateContext` function should be used over the deprecated `State` function.
+- [ ] __Does Not Use Project ID In Import Identifier__: There should not be a project ID present in the import identifier. Instead of the user providing a project ID explicitly, the provider uses the authentication scope to determine which project is accessible. This prevents the user from needing to locate and provide their project ID. `client.Config.ProjectID` should be used to retrieve the implied project ID.
+- [ ] __Uses Passthrough If Possible__: If the import identifier can match the `id` of the resource, and this does not violate any other guidelines, the `ImportStatePassthroughContext` passthrough should be used.
+- [ ] __Specifies Minimal Import Identifier__: If more than one value needs to be specified in the import identifier, the minimal number of values should be used, and those values should be colon (`:`) separated.
+- [ ] __Includes Import Documentation__: There should be an import example at `examples/resources/<resource>/import.sh`, which will be used when generating the docs. The docs should then be regenerated using `go generate`, which will update files in the `docs/` directory.

--- a/contributing/checklist-resource.md
+++ b/contributing/checklist-resource.md
@@ -1,0 +1,31 @@
+# New Resource Checklist
+
+Implementing a new resource is a good way to learn more about how Terraform interacts with upstream APIs. There are plenty of examples to draw from in the existing resources, but you still get to implement something completely new.
+
+- [ ] __Minimal LOC__: It can be inefficient for both the reviewer and author to go through long feedback cycles on a big PR with many resources. We therefore encourage you to only submit **1 resource at a time**.
+- [ ] __Documentation__: Each resource gets a page in the [Terraform Registry documentation](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs). For a new resource, you'll want to add an example, field descriptions, and possibly a guide.
+- [ ] __Well-formed Code__: Do your best to follow existing conventions you see in the codebase, and ensure your code is formatted with `go fmt`. The PR reviewers can help out on this front, and may provide comments with suggestions on how to improve the code.
+
+## Schema
+
+- [ ] __Uses Globally Unique ID__: The `id` field needs to be globally unique. Since many of the HCP services use IDs that are only unique within a particular project, you may need to create an `id` for Terraform using the `linkURL()` helper function. This function will produce an `id` of the following format: `/project/<project_id>/<resource_type>/<resource_id>`. If the service uses `ID` for a resource ID that is not globally unique, the resource ID should be specified in the Terraform schema as `<resource_type>_id`.
+- [ ] __Validates Fields Where Possible__: All fields that can be validated client-side should include a `ValidateFunc` or `ValidateDiagFunc`.
+These validations should favor validators provided by this project, or [Terraform `helper/validation` package](https://godoc.org/github.com/hashicorp/terraform/helper/validation) functions.
+- [ ] __Does Not Use Project ID Input__: There should not be an input field for `project_id` in the schema. Instead of the user providing a `project_id` explicitly, the provider uses the authentication scope to determine which project is accessible. This prevents the user from needing to locate and provide their project ID. `client.Config.ProjectID` should be used to retrieve the implied project ID.
+
+## CRUD Operations
+
+- [ ] __Uses Context-Aware CRUD Functions__: The context-aware CRUD functions (eg. `CreateContext`, `ReadContext`, etc.) should be used over their deprecated counterparts (eg. `Create`, `Read`, etc.).
+- [ ] __Uses Context For API Calls__: The `context.Context` that is passed into the CRUD functions should be passed into all API calls, most often by setting the `Context` field of a `*Params` object. This allows the API calls to be cancelled properly by Terraform.
+- [ ] __Handles Existing Resource Prior To Create__: Before calling the API creation function, there should be a check to ensure that the resource does not already exist. If it does exist, the user should see a helpful log message that they may need to import the resource.
+- [ ] __Implements Immediate Resource ID Set During Create__: Immediately after calling the API creation function, the resource ID should be set with [`d.SetId()`](https://godoc.org/github.com/hashicorp/terraform/helper/schema#ResourceData.SetId) before other API operations or returning.
+- [ ] __Refreshes Attributes During Read__: All attributes available in the API should have [`d.Set()`](https://godoc.org/github.com/hashicorp/terraform/helper/schema#ResourceData.Set) called to set their values in the Terraform state during the `Read` function.
+- [ ] __Handles Removed Resource During Read__: If a resource is removed outside of Terraform (e.g. via different tool, API, or web UI), `d.SetId("")` and `return nil` can be used in the resource `Read` function to trigger resource recreation. When this occurs, a warning log message should be printed beforehand.
+- [ ] __Handles Failed State During Read__: If a resource fails during an operation and ends up in a failed state, `d.SetId("")` and `return nil` can be used in the resource `Read` function to trigger resource recreation. When this occurs, a warning log message should be printed beforehand.
+- [ ] __Handles Nonexistent Resource Prior To Delete__: Before calling the API deletion function, there should be a check to ensure that the resource exists. If it does not exist, the user should see a helpful log message that no action was taken.
+
+## Documentation
+
+- [ ] __Includes Descriptions For Resource And Fields__: The resource and all fields in the schema should include a `Description`, which will be used when generating the docs.
+- [ ] __Includes Example__: The resource should include an example in `examples/resources/<resource>/resource.tf`, which will be used when generating the docs.
+- [ ] __Includes Generated Docs__: The docs should be regenerated using `go generate`, which will update files in the `docs/` directory.

--- a/contributing/references.md
+++ b/contributing/references.md
@@ -1,0 +1,46 @@
+# References
+
+This documentation also contains reference material specific to certain functionality.
+
+_Note: This documentation is intended for Terraform HCP Provider code developers. Typical operators writing and applying Terraform configurations do not need to read or understand this material._
+
+## Beta Features
+
+The HCP team will sometimes use a pattern where a feature or set of features are only available to a limited group of beta customers. This allows the team to develop and test these features against a smaller group before releasing them more broadly. Features that are in a beta phase are generally controlled at the service level through feature flags.
+
+In order to support Terraform usage for our beta customers, **the current pattern is to make the Terraform resources publicly available, and use a banner in the resource documentation to indicate that the feature is only available to beta customers.** Other users that attempt to use the feature with Terraform will be presented with an error message from the service indicating that the feature is not enabled.
+
+Here are some steps that can be followed when adding resources that are only available to beta customers:
+1. Ensure there is a feature flag at the service level that will produce a clear error message for a Terraform user without access
+1. Create a template file for the resource documentation to include a banner. For example, `templates/resources/aws_transit_gateway_attachment.md.tmpl` used this content:
+```
+---
+page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} `{{.Type}}`
+
+-> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+
+{{ .Description | trimspace }}
+
+## Example Usage
+
+{{ tffile "examples/resources/hcp_aws_transit_gateway_attachment/resource.tf" }}
+
+{{ .SchemaMarkdown | trimspace }}
+
+## Import
+
+-> **Note:** When importing a transit gateway attachment, you will want to configure a `lifecycle` configuration block with an `ignore_changes` argument including `resource_share_arn`. This is needed because its value is no longer retrievable after creation.
+
+Import is supported using the following syntax:
+
+{{ codefile "shell" "examples/resources/hcp_aws_transit_gateway_attachment/import.sh" }}
+
+```
+1. Merge the resources into `main` like normal, and include them in the next public release of the provider
+1. Once the feature is no longer in a beta phase, remove the banner by deleting the custom template file


### PR DESCRIPTION
This initial set of guidelines aims to capture some of the design decisions and patterns that have already been made, and provide some context around why they were chosen.

The format is largely stolen from [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md), and to a lesser extent, [nomad](https://github.com/hashicorp/nomad/tree/master/contributing) and [terraform-provider-boundary](https://github.com/hashicorp/terraform-provider-boundary/blob/main/.github/CONTRIBUTING.md). Checklists appear to be a standard way of communicating the list of implementation items to consider while making a change while providing some context, and the references concept gives us a place to keep background information around broader concepts.