### PR TITLE
HCS-1805: Add consul cluster vm size

### DIFF
--- a/docs/data-sources/consul_cluster.md
+++ b/docs/data-sources/consul_cluster.md
@@ -49,8 +49,7 @@ data "hcp_consul_cluster" "example" {
 - **region** (String) The region where the HCP Consul cluster is located.
 - **scale** (Number) The the number of Consul server nodes in the cluster.
 - **self_link** (String) A unique URL identifying the HCP Consul cluster.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster
-is provisioned with. Valid options - x_small, small, medium, large.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.
 - **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/data-sources/consul_cluster.md
+++ b/docs/data-sources/consul_cluster.md
@@ -49,6 +49,8 @@ data "hcp_consul_cluster" "example" {
 - **region** (String) The region where the HCP Consul cluster is located.
 - **scale** (Number) The the number of Consul server nodes in the cluster.
 - **self_link** (String) A unique URL identifying the HCP Consul cluster.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster
+is provisioned with. Valid options - x_small, small, medium, large.
 - **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/data-sources/consul_cluster.md
+++ b/docs/data-sources/consul_cluster.md
@@ -49,8 +49,8 @@ data "hcp_consul_cluster" "example" {
 - **region** (String) The region where the HCP Consul cluster is located.
 - **scale** (Number) The the number of Consul server nodes in the cluster.
 - **self_link** (String) A unique URL identifying the HCP Consul cluster.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.
-- **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.
+- **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development` and `standard` are available at this time.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/data-sources/consul_cluster.md
+++ b/docs/data-sources/consul_cluster.md
@@ -49,7 +49,7 @@ data "hcp_consul_cluster" "example" {
 - **region** (String) The region where the HCP Consul cluster is located.
 - **scale** (Number) The the number of Consul server nodes in the cluster.
 - **self_link** (String) A unique URL identifying the HCP Consul cluster.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.
 - **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -42,7 +42,7 @@ resource "hcp_consul_cluster" "example" {
 - **min_consul_version** (String) The minimum Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
 - **primary_link** (String) The `self_link` of the HCP Consul cluster which is the primary in the federation setup with this HCP Consul cluster. If not specified, it is a standalone cluster.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Consul UI. Defaults to false.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -32,7 +32,7 @@ resource "hcp_consul_cluster" "example" {
 
 - **cluster_id** (String) The ID of the HCP Consul cluster.
 - **hvn_id** (String) The ID of the HVN this HCP Consul cluster is associated to.
-- **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.
+- **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development` and `standard` are available at this time.
 
 ### Optional
 
@@ -42,7 +42,7 @@ resource "hcp_consul_cluster" "example" {
 - **min_consul_version** (String) The minimum Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
 - **primary_link** (String) The `self_link` of the HCP Consul cluster which is the primary in the federation setup with this HCP Consul cluster. If not specified, it is a standalone cluster.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Consul UI. Defaults to false.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -42,6 +42,8 @@ resource "hcp_consul_cluster" "example" {
 - **min_consul_version** (String) The minimum Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
 - **primary_link** (String) The `self_link` of the HCP Consul cluster which is the primary in the federation setup with this HCP Consul cluster. If not specified, it is a standalone cluster.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Consul UI. Defaults to false.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster
+is provisioned with. Valid options - x_small, small, medium, large.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -42,8 +42,7 @@ resource "hcp_consul_cluster" "example" {
 - **min_consul_version** (String) The minimum Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
 - **primary_link** (String) The `self_link` of the HCP Consul cluster which is the primary in the federation setup with this HCP Consul cluster. If not specified, it is a standalone cluster.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Consul UI. Defaults to false.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster
-is provisioned with. Valid options - x_small, small, medium, large.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-openapi/runtime v0.19.20
+	github.com/go-openapi/strfmt v0.19.5
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcp-sdk-go v0.5.0

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -1,8 +1,8 @@
 package clients
 
 import (
-	cloud_consul "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/client"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/client/consul_service"
+	cloud_consul "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client/consul_service"
 	cloud_network "github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client/network_service"
 	cloud_operation "github.com/hashicorp/hcp-sdk-go/clients/cloud-operation/preview/2020-05-05/client"

--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -3,14 +3,14 @@ package clients
 import (
 	"context"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/client/consul_service"
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client/consul_service"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 )
 
 // GetConsulClusterByID gets an Consul cluster by its ID
 func GetConsulClusterByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	consulClusterID string) (*consulmodels.HashicorpCloudConsul20200826Cluster, error) {
+	consulClusterID string) (*consulmodels.HashicorpCloudConsul20210204Cluster, error) {
 
 	getParams := consul_service.NewGetParams()
 	getParams.Context = ctx
@@ -31,7 +31,7 @@ func GetConsulClusterByID(ctx context.Context, client *Client, loc *sharedmodels
 // The files will be returned in base64-encoded format and will get passed in
 // that format.
 func GetConsulClientConfigFiles(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	consulClusterID string) (*consulmodels.HashicorpCloudConsul20200826GetClientConfigResponse, error) {
+	consulClusterID string) (*consulmodels.HashicorpCloudConsul20210204GetClientConfigResponse, error) {
 
 	p := consul_service.NewGetClientConfigParams()
 	p.Context = ctx
@@ -52,12 +52,12 @@ func GetConsulClientConfigFiles(ctx context.Context, client *Client, loc *shared
 // Example token: After cluster create, a customer would want a root token
 // (or "bootstrap token") so they can continue to set-up their cluster.
 func CreateCustomerRootACLToken(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	consulClusterID string) (*consulmodels.HashicorpCloudConsul20200826CreateCustomerMasterACLTokenResponse, error) {
+	consulClusterID string) (*consulmodels.HashicorpCloudConsul20210204CreateCustomerMasterACLTokenResponse, error) {
 
 	p := consul_service.NewCreateCustomerMasterACLTokenParams()
 	p.Context = ctx
 	p.ID = consulClusterID
-	p.Body = &consulmodels.HashicorpCloudConsul20200826CreateCustomerMasterACLTokenRequest{
+	p.Body = &consulmodels.HashicorpCloudConsul20210204CreateCustomerMasterACLTokenRequest{
 		ID:       consulClusterID,
 		Location: loc,
 	}
@@ -75,11 +75,11 @@ func CreateCustomerRootACLToken(ctx context.Context, client *Client, loc *shared
 // CreateConsulCluster will make a call to the Consul service to initiate the create Consul
 // cluster workflow.
 func CreateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	consulCluster *consulmodels.HashicorpCloudConsul20200826Cluster) (*consulmodels.HashicorpCloudConsul20200826CreateResponse, error) {
+	consulCluster *consulmodels.HashicorpCloudConsul20210204Cluster) (*consulmodels.HashicorpCloudConsul20210204CreateResponse, error) {
 
 	p := consul_service.NewCreateParams()
 	p.Context = ctx
-	p.Body = &consulmodels.HashicorpCloudConsul20200826CreateRequest{Cluster: consulCluster}
+	p.Body = &consulmodels.HashicorpCloudConsul20210204CreateRequest{Cluster: consulCluster}
 
 	p.ClusterLocationOrganizationID = loc.OrganizationID
 	p.ClusterLocationProjectID = loc.ProjectID
@@ -94,7 +94,7 @@ func CreateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 
 // GetAvailableHCPConsulVersionsForLocation gets the list of available Consul versions that HCP supports for
 // the provided location.
-func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmodels.HashicorpCloudLocationLocation, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
+func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmodels.HashicorpCloudLocationLocation, client *Client) ([]*consulmodels.HashicorpCloudConsul20210204Version, error) {
 	p := consul_service.NewListVersionsParams()
 	p.Context = ctx
 	p.LocationProjectID = loc.ProjectID
@@ -110,7 +110,7 @@ func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmo
 }
 
 // GetAvailableHCPConsulVersions gets the list of available Consul versions that HCP supports.
-func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
+func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*consulmodels.HashicorpCloudConsul20210204Version, error) {
 	p := consul_service.NewListVersions2Params()
 	p.Context = ctx
 
@@ -126,7 +126,7 @@ func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*cons
 // DeleteConsulCluster will make a call to the Consul service to initiate the delete Consul
 // cluster workflow.
 func DeleteConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	clusterID string) (*consulmodels.HashicorpCloudConsul20200826DeleteResponse, error) {
+	clusterID string) (*consulmodels.HashicorpCloudConsul20210204DeleteResponse, error) {
 
 	p := consul_service.NewDeleteParams()
 	p.Context = ctx
@@ -145,7 +145,7 @@ func DeleteConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 // ListConsulUpgradeVersions gets the list of available Consul versions that the supplied cluster
 // can upgrade to.
 func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	clusterID string) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
+	clusterID string) ([]*consulmodels.HashicorpCloudConsul20210204Version, error) {
 
 	p := consul_service.NewListUpgradeVersionsParams()
 	p.Context = ctx
@@ -165,9 +165,9 @@ func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedm
 // UpdateConsulCluster will make a call to the Consul service to initiate the update Consul
 // cluster workflow.
 func UpdateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	clusterID, newConsulVersion string) (*consulmodels.HashicorpCloudConsul20200826UpdateResponse, error) {
+	clusterID, newConsulVersion string) (*consulmodels.HashicorpCloudConsul20210204UpdateResponse, error) {
 
-	cluster := consulmodels.HashicorpCloudConsul20200826Cluster{
+	cluster := consulmodels.HashicorpCloudConsul20210204Cluster{
 		ConsulVersion: newConsulVersion,
 		ID:            clusterID,
 		Location: &sharedmodels.HashicorpCloudLocationLocation{

--- a/internal/clients/consul_snapshot.go
+++ b/internal/clients/consul_snapshot.go
@@ -3,21 +3,21 @@ package clients
 import (
 	"context"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/client/consul_service"
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client/consul_service"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 )
 
 // CreateSnapshot  will make a call to the Consul service to initiate the create Consul
 // snapshot workflow.
 func CreateSnapshot(ctx context.Context, client *Client, res *sharedmodels.HashicorpCloudLocationLink,
-	snapshotName string) (*consulmodels.HashicorpCloudConsul20200826CreateSnapshotResponse, error) {
+	snapshotName string) (*consulmodels.HashicorpCloudConsul20210204CreateSnapshotResponse, error) {
 
 	p := consul_service.NewCreateSnapshotParams()
 	p.Context = ctx
 	p.ResourceLocationOrganizationID = res.Location.OrganizationID
 	p.ResourceLocationProjectID = res.Location.ProjectID
-	p.Body = &consulmodels.HashicorpCloudConsul20200826CreateSnapshotRequest{
+	p.Body = &consulmodels.HashicorpCloudConsul20210204CreateSnapshotRequest{
 		Name:     snapshotName,
 		Resource: res,
 	}
@@ -32,7 +32,7 @@ func CreateSnapshot(ctx context.Context, client *Client, res *sharedmodels.Hashi
 
 // GetSnapshotByID gets a Consul snapshot by its ID
 func GetSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	snapshotID string) (*consulmodels.HashicorpCloudConsul20200826GetSnapshotResponse, error) {
+	snapshotID string) (*consulmodels.HashicorpCloudConsul20210204GetSnapshotResponse, error) {
 
 	p := consul_service.NewGetSnapshotParams()
 	p.Context = ctx
@@ -50,7 +50,7 @@ func GetSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.Hash
 
 // DeleteSnapshotByID deletes a Consul snapshot by its ID
 func DeleteSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	snapshotID string) (*consulmodels.HashicorpCloudConsul20200826DeleteSnapshotResponse, error) {
+	snapshotID string) (*consulmodels.HashicorpCloudConsul20210204DeleteSnapshotResponse, error) {
 
 	p := consul_service.NewDeleteSnapshotParams()
 	p.Context = ctx
@@ -68,7 +68,7 @@ func DeleteSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.H
 
 // RenameSnapshotByID renames a Consul snapshot by its ID
 func RenameSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	snapshotID string, snapshotName string) (*consulmodels.HashicorpCloudConsul20200826UpdateSnapshotResponse, error) {
+	snapshotID string, snapshotName string) (*consulmodels.HashicorpCloudConsul20210204UpdateSnapshotResponse, error) {
 
 	p := consul_service.NewUpdateSnapshotParams()
 	p.Context = ctx
@@ -76,7 +76,7 @@ func RenameSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.H
 	p.SnapshotLocationProjectID = loc.ProjectID
 	p.SnapshotID = snapshotID
 
-	p.Body = &consulmodels.HashicorpCloudConsul20200826Snapshot{
+	p.Body = &consulmodels.HashicorpCloudConsul20210204Snapshot{
 		Name: snapshotName,
 	}
 

--- a/internal/consul/version.go
+++ b/internal/consul/version.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 )
 
 // RecommendedVersion returns the recommended version of Consul
-func RecommendedVersion(versions []*consulmodels.HashicorpCloudConsul20200826Version) string {
+func RecommendedVersion(versions []*consulmodels.HashicorpCloudConsul20210204Version) string {
 	var defaultVersion string
 
 	for _, v := range versions {
@@ -24,7 +24,7 @@ func RecommendedVersion(versions []*consulmodels.HashicorpCloudConsul20200826Ver
 
 // IsValidVersion determines that a given version string is contained within the slice of
 // available Consul versions.
-func IsValidVersion(version string, versions []*consulmodels.HashicorpCloudConsul20200826Version) bool {
+func IsValidVersion(version string, versions []*consulmodels.HashicorpCloudConsul20210204Version) bool {
 	for _, v := range versions {
 		if version == v.Version {
 			return true
@@ -40,7 +40,7 @@ func NormalizeVersion(version string) string {
 }
 
 // VersionsToString converts a slice of version pointers to a string of their comma delimited values.
-func VersionsToString(versions []*consulmodels.HashicorpCloudConsul20200826Version) string {
+func VersionsToString(versions []*consulmodels.HashicorpCloudConsul20210204Version) string {
 	var recommendedVersion string
 	var otherVersions []string
 
@@ -49,7 +49,7 @@ func VersionsToString(versions []*consulmodels.HashicorpCloudConsul20200826Versi
 			continue
 		}
 
-		if v.Status == consulmodels.HashicorpCloudConsul20200826VersionStatusRECOMMENDED {
+		if v.Status == consulmodels.HashicorpCloudConsul20210204VersionStatusRECOMMENDED {
 			recommendedVersion = v.Version
 		} else {
 			otherVersions = append(otherVersions, v.Version)

--- a/internal/consul/version_test.go
+++ b/internal/consul/version_test.go
@@ -3,17 +3,17 @@ package consul
 import (
 	"testing"
 
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_RecommendedVersion(t *testing.T) {
 	tcs := map[string]struct {
 		expected string
-		input    []*consulmodels.HashicorpCloudConsul20200826Version
+		input    []*consulmodels.HashicorpCloudConsul20210204Version
 	}{
 		"with a recommended version": {
-			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+			input: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.9.0",
 					Status:  "RECOMMENDED",
@@ -30,7 +30,7 @@ func Test_RecommendedVersion(t *testing.T) {
 			expected: "v1.9.0",
 		},
 		"without a recommended version": {
-			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+			input: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.9.0",
 					Status:  "AVAILABLE",
@@ -62,11 +62,11 @@ func Test_IsValidVersion(t *testing.T) {
 	tcs := map[string]struct {
 		expected      bool
 		version       string
-		validVersions []*consulmodels.HashicorpCloudConsul20200826Version
+		validVersions []*consulmodels.HashicorpCloudConsul20210204Version
 	}{
 		"with a valid version": {
 			version: "v1.9.0",
-			validVersions: []*consulmodels.HashicorpCloudConsul20200826Version{
+			validVersions: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.9.0",
 					Status:  "RECOMMENDED",
@@ -84,7 +84,7 @@ func Test_IsValidVersion(t *testing.T) {
 		},
 		"with an invalid version": {
 			version: "v1.8.0",
-			validVersions: []*consulmodels.HashicorpCloudConsul20200826Version{
+			validVersions: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.9.0",
 					Status:  "RECOMMENDED",
@@ -145,10 +145,10 @@ func Test_NormalizeVersion(t *testing.T) {
 func Test_VersionsToString(t *testing.T) {
 	tcs := map[string]struct {
 		expected string
-		input    []*consulmodels.HashicorpCloudConsul20200826Version
+		input    []*consulmodels.HashicorpCloudConsul20210204Version
 	}{
 		"with a recommended version": {
-			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+			input: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.9.0",
 					Status:  "RECOMMENDED",
@@ -165,7 +165,7 @@ func Test_VersionsToString(t *testing.T) {
 			expected: "v1.9.0 (recommended), v1.8.6, v1.8.4",
 		},
 		"without a recommended version": {
-			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+			input: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.8.6",
 					Status:  "AVAILABLE",
@@ -178,7 +178,7 @@ func Test_VersionsToString(t *testing.T) {
 			expected: "v1.8.6, v1.8.4",
 		},
 		"no other versions but recommended": {
-			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+			input: []*consulmodels.HashicorpCloudConsul20210204Version{
 				{
 					Version: "v1.9.0",
 					Status:  "RECOMMENDED",
@@ -191,7 +191,7 @@ func Test_VersionsToString(t *testing.T) {
 			expected: "",
 		},
 		"nil values": {
-			input: []*consulmodels.HashicorpCloudConsul20200826Version{
+			input: []*consulmodels.HashicorpCloudConsul20210204Version{
 				nil,
 				{
 					Version: "v1.9.0",

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -118,7 +118,7 @@ func dataSourceConsulCluster() *schema.Resource {
 				Computed:    true,
 			},
 			"size": {
-				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.",
+				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -113,12 +113,12 @@ func dataSourceConsulCluster() *schema.Resource {
 				Computed:    true,
 			},
 			"tier": {
-				Description: "The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.",
+				Description: "The tier that the HCP Consul cluster will be provisioned as.  Only `development` and `standard` are available at this time.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"size": {
-				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.",
+				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -117,6 +117,11 @@ func dataSourceConsulCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"size": {
+				Description: "The t-shirt size representation of each server VM that this Consul cluster\nis provisioned with. Valid options - x_small, small, medium, large.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"self_link": {
 				Description: "A unique URL identifying the HCP Consul cluster.",
 				Type:        schema.TypeString,

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -118,7 +118,7 @@ func dataSourceConsulCluster() *schema.Resource {
 				Computed:    true,
 			},
 			"size": {
-				Description: "The t-shirt size representation of each server VM that this Consul cluster\nis provisioned with. Valid options - x_small, small, medium, large.",
+				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_consul_versions.go
+++ b/internal/provider/data_source_consul_versions.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -67,12 +67,12 @@ func dataSourceConsulVersionsRead(ctx context.Context, d *schema.ResourceData, m
 
 	for _, v := range availableConsulVersions {
 		switch v.Status {
-		case consulmodels.HashicorpCloudConsul20200826VersionStatusRECOMMENDED:
+		case consulmodels.HashicorpCloudConsul20210204VersionStatusRECOMMENDED:
 			recommendedVersion = v.Version
 			availableVersions = append(availableVersions, v.Version)
-		case consulmodels.HashicorpCloudConsul20200826VersionStatusAVAILABLE:
+		case consulmodels.HashicorpCloudConsul20210204VersionStatusAVAILABLE:
 			availableVersions = append(availableVersions, v.Version)
-		case consulmodels.HashicorpCloudConsul20200826VersionStatusPREVIEW:
+		case consulmodels.HashicorpCloudConsul20210204VersionStatusPREVIEW:
 			previewVersions = append(previewVersions, v.Version)
 		}
 	}

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -415,11 +415,11 @@ func setConsulClusterResourceData(d *schema.ResourceData, cluster *consulmodels.
 		return err
 	}
 
-	if err := d.Set("tier", strings.ToLower(string(cluster.Config.Tier))); err != nil {
+	if err := d.Set("tier", cluster.Config.Tier); err != nil {
 		return err
 	}
 
-	if err := d.Set("size", strings.ToLower(string(cluster.Config.CapacityConfig.Size))); err != nil {
+	if err := d.Set("size", cluster.Config.CapacityConfig.Size); err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -68,7 +68,7 @@ func resourceConsulCluster() *schema.Resource {
 			},
 			"tier": {
 				// TODO: link to HCP Consul feature tier page when it is available
-				Description:      "The tier that the HCP Consul cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.",
+				Description:      "The tier that the HCP Consul cluster will be provisioned as.  Only `development` and `standard` are available at this time.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
@@ -119,7 +119,7 @@ func resourceConsulCluster() *schema.Resource {
 			},
 			"size": {
 				// TODO: Add a link to the HCP Consul size details when it is available.
-				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.",
+				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -118,7 +118,7 @@ func resourceConsulCluster() *schema.Resource {
 				ForceNew:    true,
 			},
 			"size": {
-				Description:      "The t-shirt size representation of each server VM that this Consul cluster\nis provisioned with. Valid options - x_small, small, medium, large.",
+				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -6,18 +6,14 @@ import (
 	"strings"
 	"time"
 
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/consul"
 )
-
-const consulTierDevelopment = "development"
-const consulTierStandard = "standard"
 
 // defaultClusterTimeoutDuration is the amount of time that can elapse
 // before a cluster read operation should timeout.
@@ -35,20 +31,6 @@ var deleteTimeoutDuration = time.Minute * 25
 // where a HCP Consul cluster can be provisioned.
 var consulCusterResourceCloudProviders = []string{
 	"aws",
-}
-
-// consulClusterResourceTiers is the list of tiers
-// that an HCP Consul cluster can be provisioned as.
-var consulClusterResourceTiers = []string{
-	consulTierDevelopment,
-	consulTierStandard,
-}
-
-// tierToNumServers maps the set of tiers
-// to the number of servers to be provisioned for that cluster.
-var consulTierToNumServers = map[string]int32{
-	consulTierDevelopment: int32(1),
-	consulTierStandard:    int32(3),
 }
 
 // resourceConsulCluster represents an HCP Consul cluster.
@@ -90,7 +72,7 @@ func resourceConsulCluster() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validateStringInSlice(consulClusterResourceTiers, true),
+				ValidateDiagFunc: validateConsulClusterTier,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					return strings.ToLower(old) == strings.ToLower(new)
 				},
@@ -134,6 +116,16 @@ func resourceConsulCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+			},
+			"size": {
+				Description:      "The t-shirt size representation of each server VM that this Consul cluster\nis provisioned with. Valid options - x_small, small, medium, large.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateConsulClusterSize,
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					return strings.ToLower(old) == strings.ToLower(new)
+				},
 			},
 			// computed outputs
 			"organization_id": {
@@ -302,23 +294,21 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	connectEnabled := d.Get("connect_enabled").(bool)
 	publicEndpoint := d.Get("public_endpoint").(bool)
 
-	tier := strings.ToLower(d.Get("tier").(string))
-	numServers := consulTierToNumServers[tier]
-
 	log.Printf("[INFO] Creating Consul cluster (%s)", clusterID)
 
-	consulCuster := &consulmodels.HashicorpCloudConsul20200826Cluster{
-		Config: &consulmodels.HashicorpCloudConsul20200826ClusterConfig{
-			CapacityConfig: &consulmodels.HashicorpCloudConsul20200826CapacityConfig{
-				NumServers: numServers,
+	consulCuster := &consulmodels.HashicorpCloudConsul20210204Cluster{
+		Config: &consulmodels.HashicorpCloudConsul20210204ClusterConfig{
+			Tier: consulmodels.HashicorpCloudConsul20210204ClusterConfigTier(strings.ToUpper(d.Get("tier").(string))),
+			CapacityConfig: &consulmodels.HashicorpCloudConsul20210204CapacityConfig{
+				Size: consulmodels.HashicorpCloudConsul20210204CapacityConfigSize(strings.ToUpper(d.Get("size").(string))),
 			},
-			ConsulConfig: &consulmodels.HashicorpCloudConsul20200826ConsulConfig{
+			ConsulConfig: &consulmodels.HashicorpCloudConsul20210204ConsulConfig{
 				ConnectEnabled: connectEnabled,
 				Datacenter:     datacenter,
 				Primary:        primary,
 			},
 			MaintenanceConfig: nil,
-			NetworkConfig: &consulmodels.HashicorpCloudConsul20200826NetworkConfig{
+			NetworkConfig: &consulmodels.HashicorpCloudConsul20210204NetworkConfig{
 				Network: newLink(loc, "hvn", hvnID),
 				Private: !publicEndpoint,
 			},
@@ -385,8 +375,8 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 // setConsulClusterResourceData sets the KV pairs of the Consul cluster resource schema.
 // We do not set consul_root_token_accessor_id and consul_root_token_secret_id here since
 // the original root token is only available during cluster creation.
-func setConsulClusterResourceData(d *schema.ResourceData, cluster *consulmodels.HashicorpCloudConsul20200826Cluster,
-	clientConfigFiles *consulmodels.HashicorpCloudConsul20200826GetClientConfigResponse) error {
+func setConsulClusterResourceData(d *schema.ResourceData, cluster *consulmodels.HashicorpCloudConsul20210204Cluster,
+	clientConfigFiles *consulmodels.HashicorpCloudConsul20210204GetClientConfigResponse) error {
 
 	if err := d.Set("cluster_id", cluster.ID); err != nil {
 		return err
@@ -421,18 +411,16 @@ func setConsulClusterResourceData(d *schema.ResourceData, cluster *consulmodels.
 		return err
 	}
 
-	if err := d.Set("scale", cluster.Config.CapacityConfig.NumServers); err != nil {
+	if err := d.Set("scale", cluster.Config.CapacityConfig.Scale); err != nil {
 		return err
 	}
 
-	// TODO: Update this logic when tier becomes a first class value on the cluster
-	for t, numServers := range consulTierToNumServers {
-		if numServers == cluster.Config.CapacityConfig.NumServers {
-			if err := d.Set("tier", t); err != nil {
-				return err
-			}
-			break
-		}
+	if err := d.Set("tier", strings.ToLower(string(cluster.Config.Tier))); err != nil {
+		return err
+	}
+
+	if err := d.Set("size", strings.ToLower(string(cluster.Config.CapacityConfig.Size))); err != nil {
+		return err
 	}
 
 	if err := d.Set("consul_snapshot_interval", "24h"); err != nil {
@@ -518,7 +506,7 @@ func resourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, meta
 
 	// The Consul cluster failed to provision properly so we want to let the user know and
 	// remove it from state
-	if cluster.State == consulmodels.HashicorpCloudConsul20200826ClusterStateFAILED {
+	if cluster.State == consulmodels.HashicorpCloudConsul20210204ClusterStateFAILED {
 		log.Printf("[WARN] Consul cluster (%s) failed to provision, removing from state", clusterID)
 		d.SetId("")
 		return nil

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -118,7 +118,7 @@ func resourceConsulCluster() *schema.Resource {
 				ForceNew:    true,
 			},
 			"size": {
-				// TODO: Add a link to the HCP Consul size details when it is available.
+				// TODO: Add a link to the HCP Consul size details when it is available here - https://cloud.hashicorp.com/pricing/consul#FAQ
 				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.",
 				Type:             schema.TypeString,
 				Optional:         true,

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -118,7 +118,8 @@ func resourceConsulCluster() *schema.Resource {
 				ForceNew:    true,
 			},
 			"size": {
-				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid options - x_small, small, medium, large.",
+				// TODO: Add a link to the HCP Consul size details when it is available.
+				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - x_small. Valid options for other tiers - small, medium, large.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,

--- a/internal/provider/resource_consul_snapshot.go
+++ b/internal/provider/resource_consul_snapshot.go
@@ -8,7 +8,7 @@ import (
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 
-	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/models"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -169,7 +169,7 @@ func resourceConsulSnapshotRead(ctx context.Context, d *schema.ResourceData, met
 
 	// The Consul snapshot failed to provision properly so we want to let the user know and
 	// remove it from state
-	if snapshotResp.Snapshot.State == consulmodels.HashicorpCloudConsul20200826SnapshotSnapshotStateCREATINGFAILED {
+	if snapshotResp.Snapshot.State == consulmodels.HashicorpCloudConsul20210204SnapshotSnapshotStateCREATINGFAILED {
 		log.Printf("[WARN] Consul snapshot (%s) failed to provision, removing from state", snapshotResp.Snapshot.ID)
 		d.SetId("")
 		return nil
@@ -250,7 +250,7 @@ func resourceConsulSnapshotDelete(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func setConsulSnapshotResourceData(d *schema.ResourceData, snapshot *consulmodels.HashicorpCloudConsul20200826Snapshot) error {
+func setConsulSnapshotResourceData(d *schema.ResourceData, snapshot *consulmodels.HashicorpCloudConsul20210204Snapshot) error {
 
 	if err := d.Set("organization_id", snapshot.Location.OrganizationID); err != nil {
 		return err

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -112,9 +112,11 @@ func validateDatacenter(v interface{}, path cty.Path) diag.Diagnostics {
 func validateConsulClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 
+	// TODO: Update the validation once SDK provides a way to get all valid values for the enum.
 	err := consulmodels.HashicorpCloudConsul20210204ClusterConfigTier(strings.ToUpper(v.(string))).Validate(strfmt.Default)
 	if err != nil {
-		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		enumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		expectedEnumList := strings.Replace(enumList, "UNSET ", "", 1)
 		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList)
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,
@@ -130,9 +132,11 @@ func validateConsulClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
 func validateConsulClusterSize(v interface{}, path cty.Path) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 
+	// TODO: Update the validation once SDK provides a way to get all valid values for the enum.
 	err := consulmodels.HashicorpCloudConsul20210204CapacityConfigSize(strings.ToUpper(v.(string))).Validate(strfmt.Default)
 	if err != nil {
-		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		enumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		expectedEnumList := strings.Replace(enumList, "UNSET ", "", 1)
 		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList)
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -119,7 +119,7 @@ func validateConsulClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,
 			Summary:       msg,
-			Detail:        msg + " (value can be case-insensitive).",
+			Detail:        msg + " (value is case-insensitive).",
 			AttributePath: path,
 		})
 	}

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -137,7 +137,7 @@ func validateConsulClusterSize(v interface{}, path cty.Path) diag.Diagnostics {
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,
 			Summary:       msg,
-			Detail:        msg + " (value can be case-insensitive).",
+			Detail:        msg + " (value is case-insensitive).",
 			AttributePath: path,
 		})
 	}

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -5,7 +5,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-cty/cty"
+	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -100,6 +102,42 @@ func validateDatacenter(v interface{}, path cty.Path) diag.Diagnostics {
 			Severity:      diag.Error,
 			Summary:       msg,
 			Detail:        msg,
+			AttributePath: path,
+		})
+	}
+
+	return diagnostics
+}
+
+func validateConsulClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	err := consulmodels.HashicorpCloudConsul20210204ClusterConfigTier(strings.ToUpper(v.(string))).Validate(strfmt.Default)
+	if err != nil {
+		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindStringSubmatch(err.Error())
+		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList[0])
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       msg,
+			Detail:        msg + " (value can be case-insensitive).",
+			AttributePath: path,
+		})
+	}
+
+	return diagnostics
+}
+
+func validateConsulClusterSize(v interface{}, path cty.Path) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	err := consulmodels.HashicorpCloudConsul20210204CapacityConfigSize(strings.ToUpper(v.(string))).Validate(strfmt.Default)
+	if err != nil {
+		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindStringSubmatch(err.Error())
+		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList[0])
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       msg,
+			Detail:        msg + " (value can be case-insensitive).",
 			AttributePath: path,
 		})
 	}

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -114,8 +114,8 @@ func validateConsulClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
 
 	err := consulmodels.HashicorpCloudConsul20210204ClusterConfigTier(strings.ToUpper(v.(string))).Validate(strfmt.Default)
 	if err != nil {
-		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindStringSubmatch(err.Error())
-		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList[0])
+		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList)
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,
 			Summary:       msg,
@@ -132,8 +132,8 @@ func validateConsulClusterSize(v interface{}, path cty.Path) diag.Diagnostics {
 
 	err := consulmodels.HashicorpCloudConsul20210204CapacityConfigSize(strings.ToUpper(v.(string))).Validate(strfmt.Default)
 	if err != nil {
-		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindStringSubmatch(err.Error())
-		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList[0])
+		expectedEnumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		msg := fmt.Sprintf("expected %v to be one of %v", v, expectedEnumList)
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,
 			Summary:       msg,

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -261,3 +261,83 @@ func Test_validateDatacenter(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateConsulClusterTier(t *testing.T) {
+	tcs := map[string]struct {
+		input    string
+		expected diag.Diagnostics
+	}{
+		"valid tier lowercase": {
+			input:    "development",
+			expected: nil,
+		},
+		"valid tier uppercase": {
+			input:    "STANDARD",
+			expected: nil,
+		},
+		"valid tier mixedcase": {
+			input:    "DEVelopment",
+			expected: nil,
+		},
+		"invalid tier": {
+			input: "dev",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "expected dev to be one of [UNSET DEVELOPMENT STANDARD]",
+					Detail:        "expected dev to be one of [UNSET DEVELOPMENT STANDARD] (value can be case-insensitive).",
+					AttributePath: nil,
+				},
+			},
+		},
+	}
+	for n, tc := range tcs {
+		t.Run(n, func(t *testing.T) {
+			r := require.New(t)
+			result := validateConsulClusterTier(tc.input, nil)
+			r.Equal(tc.expected, result)
+		})
+	}
+}
+
+func Test_validateConsulClusterSize(t *testing.T) {
+	tcs := map[string]struct {
+		input    string
+		expected diag.Diagnostics
+	}{
+		"valid size": {
+			input:    "x_small",
+			expected: nil,
+		},
+		"valid size lowercase": {
+			input:    "small",
+			expected: nil,
+		},
+		"valid size uppercase": {
+			input:    "MEDIUM",
+			expected: nil,
+		},
+		"valid size mixedcase": {
+			input:    "LARge",
+			expected: nil,
+		},
+		"invalid tier": {
+			input: "med",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE]",
+					Detail:        "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE] (value can be case-insensitive).",
+					AttributePath: nil,
+				},
+			},
+		},
+	}
+	for n, tc := range tcs {
+		t.Run(n, func(t *testing.T) {
+			r := require.New(t)
+			result := validateConsulClusterSize(tc.input, nil)
+			r.Equal(tc.expected, result)
+		})
+	}
+}

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -285,7 +285,7 @@ func Test_validateConsulClusterTier(t *testing.T) {
 				diag.Diagnostic{
 					Severity:      diag.Error,
 					Summary:       "expected dev to be one of [UNSET DEVELOPMENT STANDARD]",
-					Detail:        "expected dev to be one of [UNSET DEVELOPMENT STANDARD] (value can be case-insensitive).",
+					Detail:        "expected dev to be one of [UNSET DEVELOPMENT STANDARD] (value is case-insensitive).",
 					AttributePath: nil,
 				},
 			},
@@ -327,7 +327,7 @@ func Test_validateConsulClusterSize(t *testing.T) {
 				diag.Diagnostic{
 					Severity:      diag.Error,
 					Summary:       "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE]",
-					Detail:        "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE] (value can be case-insensitive).",
+					Detail:        "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE] (value is case-insensitive).",
 					AttributePath: nil,
 				},
 			},

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -284,8 +284,8 @@ func Test_validateConsulClusterTier(t *testing.T) {
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,
-					Summary:       "expected dev to be one of [UNSET DEVELOPMENT STANDARD]",
-					Detail:        "expected dev to be one of [UNSET DEVELOPMENT STANDARD] (value is case-insensitive).",
+					Summary:       "expected dev to be one of [DEVELOPMENT STANDARD]",
+					Detail:        "expected dev to be one of [DEVELOPMENT STANDARD] (value is case-insensitive).",
 					AttributePath: nil,
 				},
 			},
@@ -326,8 +326,8 @@ func Test_validateConsulClusterSize(t *testing.T) {
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,
-					Summary:       "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE]",
-					Detail:        "expected med to be one of [UNSET X_SMALL SMALL MEDIUM LARGE] (value is case-insensitive).",
+					Summary:       "expected med to be one of [X_SMALL SMALL MEDIUM LARGE]",
+					Detail:        "expected med to be one of [X_SMALL SMALL MEDIUM LARGE] (value is case-insensitive).",
 					AttributePath: nil,
 				},
 			},


### PR DESCRIPTION
- Adds a size attribute to the consul cluster properties. This can be provided during creation to specify t-shirt size of each server.
- Updates the hcp-go-sdk version.
- Cleans up some tier related validation in favor of leveraging sdk provided validation.