### PR TITLE
Update resources to be in line with current patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ resource "aws_vpc" "peer" {
   cidr_block = "10.220.0.0/16"
 }
 
-// Create an HCP Network peering to peer your HVN with your AWS VPC.
+// Create an HCP network peering to peer your HVN with your AWS VPC.
 resource "hcp_aws_network_peering" "example" {
   peering_id          = "peer-id"
   hvn_id              = hcp_hvn.example.hvn_id

--- a/docs/data-sources/aws_network_peering.md
+++ b/docs/data-sources/aws_network_peering.md
@@ -2,12 +2,12 @@
 page_title: "hcp_aws_network_peering Data Source - terraform-provider-hcp"
 subcategory: ""
 description: |-
-  The AWS Network peering data source provides information about an existing Network peering between an HVN and a peer AWS VPC.
+  The AWS network peering data source provides information about an existing network peering between an HVN and a peer AWS VPC.
 ---
 
 # Data Source `hcp_aws_network_peering`
 
-The AWS Network peering data source provides information about an existing Network peering between an HVN and a peer AWS VPC.
+The AWS network peering data source provides information about an existing network peering between an HVN and a peer AWS VPC.
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ data "hcp_aws_network_peering" "test" {
 ### Required
 
 - **hvn_id** (String) The ID of the HashiCorp Virtual Network (HVN).
-- **peering_id** (String) The ID of the Network peering.
+- **peering_id** (String) The ID of the network peering.
 
 ### Optional
 
@@ -32,14 +32,14 @@ data "hcp_aws_network_peering" "test" {
 
 ### Read-only
 
-- **created_at** (String) The time that the Network peering was created.
-- **expires_at** (String) The time after which the Network peering will be considered expired if it hasn't transitioned into 'Accepted' or 'Active' state.
-- **organization_id** (String) The ID of the HCP organization where the Network peering is located. Always matches the HVN's organization.
+- **created_at** (String) The time that the network peering was created.
+- **expires_at** (String) The time after which the network peering will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.
+- **organization_id** (String) The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.
 - **peer_account_id** (String) The account ID of the peer VPC in AWS.
 - **peer_vpc_cidr_block** (String) The CIDR range of the peer VPC in AWS.
 - **peer_vpc_id** (String) The ID of the peer VPC in AWS.
 - **peer_vpc_region** (String) The region of the peer VPC in AWS.
-- **project_id** (String) The ID of the HCP project where the Network peering is located. Always matches the HVN's project.
+- **project_id** (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - **provider_peering_id** (String) The peering connection ID used by AWS.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/data-sources/aws_transit_gateway_attachment.md
+++ b/docs/data-sources/aws_transit_gateway_attachment.md
@@ -2,14 +2,14 @@
 page_title: "hcp_aws_transit_gateway_attachment Data Source - terraform-provider-hcp"
 subcategory: ""
 description: |-
-  The AWS Transit Gateway Attachment data source provides information about an existing transit gateway attachment.
+  The AWS transit gateway attachment data source provides information about an existing transit gateway attachment.
 ---
 
 # Data Source `hcp_aws_transit_gateway_attachment`
 
 -> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
 
-The AWS Transit Gateway Attachment data source provides information about an existing transit gateway attachment.
+The AWS transit gateway attachment data source provides information about an existing transit gateway attachment.
 
 ## Example Usage
 

--- a/docs/guides/peering.md
+++ b/docs/guides/peering.md
@@ -8,8 +8,8 @@ description: |-
 # Peer an AWS VPC to a HashiCorp Virtual Network (HVN)
 
 In order to connect AWS workloads to an HCP Consul cluster, you must peer the VPC in which the workloads reside to the HVN in which the HCP cluster resides.
-This is accomplished by using the `hcp_aws_network_peering` resource to create a Network peering between the HVN's VPC and your own VPC.
-The [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) resource is useful for accepting the Network peering that is initiated from the `hcp_aws_network_peering`.
+This is accomplished by using the `hcp_aws_network_peering` resource to create a network peering between the HVN's VPC and your own VPC.
+The [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) resource is useful for accepting the network peering that is initiated from the `hcp_aws_network_peering`.
 
 -> **Note:** The CIDR blocks of the HVN and the peer VPC cannot overlap.
 
@@ -39,7 +39,7 @@ resource "aws_vpc" "peer" {
   cidr_block = "10.220.0.0/16"
 }
 
-// Create an HCP Network peering to peer your HVN with your AWS VPC.
+// Create an HCP network peering to peer your HVN with your AWS VPC.
 resource "hcp_aws_network_peering" "example" {
   peering_id          = var.peer_id
   hvn_id              = hcp_hvn.example.hvn_id

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -11,7 +11,7 @@ Everything in HashiCorp Cloud Platform (HCP) starts with the HashiCorp Virtual N
 
 HVNs enable you to deploy HashiCorp Cloud products without having to manage the networking details. They give you a simple setup for creating a network on AWS, in the region of your choice, and with the option to specify a CIDR range.
 
-Creating a Network peering from your HVN will allow you to connect and launch AWS resources to your HCP account.
+Creating a network peering from your HVN will allow you to connect and launch AWS resources to your HCP account.
 Peer your Amazon VPC with your HVN to enable resource access. After creating, you will need to accept the peering request and set up your VPC’s security groups and routing table on your AWS account. The Amazon VPC can be managed with the [AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs).
 
 Once you have an HVN, HCP Consul enables you to quickly deploy Consul servers in AWS across a variety of environments while offloading the operations burden to the SRE experts at HashiCorp.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ resource "aws_vpc_peering_connection_accepter" "main" {
   auto_accept               = true
 }
 
-// Create a Network peering between the HVN and the AWS VPC
+// Create a network peering between the HVN and the AWS VPC
 resource "hcp_aws_network_peering" "example_peering" {
   hvn_id              = hcp_hvn.example_hvn.hvn_id
   peer_vpc_id         = aws_vpc.main.id

--- a/docs/resources/aws_network_peering.md
+++ b/docs/resources/aws_network_peering.md
@@ -2,12 +2,12 @@
 page_title: "hcp_aws_network_peering Resource - terraform-provider-hcp"
 subcategory: ""
 description: |-
-  The AWS Network peering resource allows you to manage a Network peering between an HVN and a peer AWS VPC.
+  The AWS network peering resource allows you to manage a network peering between an HVN and a peer AWS VPC.
 ---
 
 # Resource `hcp_aws_network_peering`
 
-The AWS Network peering resource allows you to manage a Network peering between an HVN and a peer AWS VPC.
+The AWS network peering resource allows you to manage a network peering between an HVN and a peer AWS VPC.
 
 ## Example Usage
 
@@ -58,15 +58,15 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 ### Optional
 
 - **id** (String) The ID of this resource.
-- **peering_id** (String) The ID of the Network peering.
+- **peering_id** (String) The ID of the network peering.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
 
-- **created_at** (String) The time that the Network peering was created.
-- **expires_at** (String) The time after which the Network peering will be considered expired if it hasn't transitioned into 'Accepted' or 'Active' state.
-- **organization_id** (String) The ID of the HCP organization where the Network peering is located. Always matches the HVN's organization.
-- **project_id** (String) The ID of the HCP project where the Network peering is located. Always matches the HVN's project.
+- **created_at** (String) The time that the network peering was created.
+- **expires_at** (String) The time after which the network peering will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.
+- **organization_id** (String) The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.
+- **project_id** (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - **provider_peering_id** (String) The peering connection ID used by AWS.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -2,14 +2,14 @@
 page_title: "hcp_aws_transit_gateway_attachment Resource - terraform-provider-hcp"
 subcategory: ""
 description: |-
-  The AWS Transit Gateway Attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.
+  The AWS transit gateway attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.
 ---
 
 # Resource `hcp_aws_transit_gateway_attachment`
 
 -> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
 
-The AWS Transit Gateway Attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.
+The AWS transit gateway attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.
 
 ## Example Usage
 

--- a/examples/data-sources/hcp_aws_network_peering/variables.tf
+++ b/examples/data-sources/hcp_aws_network_peering/variables.tf
@@ -4,6 +4,6 @@ variable "hvn_id" {
 }
 
 variable "peering_id" {
-  description = "The ID of the Network peering."
+  description = "The ID of the network peering."
   type        = string
 }

--- a/examples/guides/peering/main.tf
+++ b/examples/guides/peering/main.tf
@@ -21,7 +21,7 @@ resource "aws_vpc" "peer" {
   cidr_block = "10.220.0.0/16"
 }
 
-// Create an HCP Network peering to peer your HVN with your AWS VPC.
+// Create an HCP network peering to peer your HVN with your AWS VPC.
 resource "hcp_aws_network_peering" "example" {
   peering_id          = var.peer_id
   hvn_id              = hcp_hvn.example.hvn_id

--- a/examples/guides/peering/variables.tf
+++ b/examples/guides/peering/variables.tf
@@ -14,6 +14,6 @@ variable "region" {
 }
 
 variable "peer_id" {
-  description = "The ID to use for the HCP Network peering."
+  description = "The ID to use for the HCP network peering."
   type        = string
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -38,7 +38,7 @@ resource "aws_vpc_peering_connection_accepter" "main" {
   auto_accept               = true
 }
 
-// Create a Network peering between the HVN and the AWS VPC
+// Create a network peering between the HVN and the AWS VPC
 resource "hcp_aws_network_peering" "example_peering" {
   hvn_id              = hcp_hvn.example_hvn.hvn_id
   peer_vpc_id         = aws_vpc.main.id

--- a/internal/clients/peering.go
+++ b/internal/clients/peering.go
@@ -14,6 +14,7 @@ import (
 // GetPeeringByID gets a peering by its ID, hvnID, and location
 func GetPeeringByID(ctx context.Context, client *Client, peeringID string, hvnID string, loc *sharedmodels.HashicorpCloudLocationLocation) (*networkmodels.HashicorpCloudNetwork20200907Peering, error) {
 	getPeeringParams := network_service.NewGetPeeringParams()
+	getPeeringParams.Context = ctx
 	getPeeringParams.ID = peeringID
 	getPeeringParams.HvnID = hvnID
 	getPeeringParams.LocationOrganizationID = loc.OrganizationID

--- a/internal/clients/peering.go
+++ b/internal/clients/peering.go
@@ -29,18 +29,18 @@ func GetPeeringByID(ctx context.Context, client *Client, peeringID string, hvnID
 
 // WaitForPeeringToBePendingAcceptance will poll the GET peering endpoint until
 // the state is PENDING_ACCEPTANCE, ctx is canceled, or an error occurs. This
-// is required because AWS can return a newly created Network peering before
+// is required because AWS can return a newly created network peering before
 // it is ready to be accepted.
 // See https://hashicorp.atlassian.net/browse/HCP-1658
 func WaitForPeeringToBePendingAcceptance(ctx context.Context, client *Client, peeringID string, hvnID string, loc *sharedmodels.HashicorpCloudLocationLocation) (*networkmodels.HashicorpCloudNetwork20200907Peering, error) {
 	for {
 		peering, err := GetPeeringByID(ctx, client, peeringID, hvnID, loc)
 		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve Network peering (%s): %v", peeringID, err)
+			return nil, fmt.Errorf("unable to retrieve network peering (%s): %v", peeringID, err)
 		}
 		switch peering.State {
 		case networkmodels.HashicorpCloudNetwork20200907PeeringStateCREATING:
-			log.Printf("[INFO] Waiting for Network peering (%s) to be in PENDING_ACCEPTANCE state", peeringID)
+			log.Printf("[INFO] Waiting for network peering (%s) to be in PENDING_ACCEPTANCE state", peeringID)
 		case networkmodels.HashicorpCloudNetwork20200907PeeringStatePENDINGACCEPTANCE:
 			return peering, nil
 		default:
@@ -52,7 +52,7 @@ func WaitForPeeringToBePendingAcceptance(ctx context.Context, client *Client, pe
 		case <-time.After(time.Second * 5):
 			continue
 		case <-ctx.Done():
-			return nil, fmt.Errorf("context canceled waiting to retrieve Network peering (%s)", peeringID)
+			return nil, fmt.Errorf("context canceled waiting to retrieve network peering (%s)", peeringID)
 		}
 	}
 }

--- a/internal/clients/tgw.go
+++ b/internal/clients/tgw.go
@@ -14,6 +14,7 @@ import (
 // GetTGWAttachmentByID gets a TGW attachment by its ID, hvnID, and location
 func GetTGWAttachmentByID(ctx context.Context, client *Client, tgwAttachmentID string, hvnID string, loc *sharedmodels.HashicorpCloudLocationLocation) (*networkmodels.HashicorpCloudNetwork20200907TGWAttachment, error) {
 	getTGWAttachmentParams := network_service.NewGetTGWAttachmentParams()
+	getTGWAttachmentParams.Context = ctx
 	getTGWAttachmentParams.ID = tgwAttachmentID
 	getTGWAttachmentParams.HvnID = hvnID
 	getTGWAttachmentParams.HvnLocationOrganizationID = loc.OrganizationID

--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceAwsNetworkPeering() *schema.Resource {
 	return &schema.Resource{
-		Description: "The AWS Network peering data source provides information about an existing Network peering between an HVN and a peer AWS VPC.",
+		Description: "The AWS network peering data source provides information about an existing network peering between an HVN and a peer AWS VPC.",
 		ReadContext: dataSourceAwsNetworkPeeringRead,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &peeringDefaultTimeout,
@@ -26,19 +26,19 @@ func dataSourceAwsNetworkPeering() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			"peering_id": {
-				Description:      "The ID of the Network peering.",
+				Description:      "The ID of the network peering.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validateSlugID,
 			},
 			// Computed outputs
 			"organization_id": {
-				Description: "The ID of the HCP organization where the Network peering is located. Always matches the HVN's organization.",
+				Description: "The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"project_id": {
-				Description: "The ID of the HCP project where the Network peering is located. Always matches the HVN's project.",
+				Description: "The ID of the HCP project where the network peering is located. Always matches the HVN's project.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -68,12 +68,12 @@ func dataSourceAwsNetworkPeering() *schema.Resource {
 				Computed:    true,
 			},
 			"created_at": {
-				Description: "The time that the Network peering was created.",
+				Description: "The time that the network peering was created.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"expires_at": {
-				Description: "The time after which the Network peering will be considered expired if it hasn't transitioned into 'Accepted' or 'Active' state.",
+				Description: "The time after which the network peering will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -82,7 +82,7 @@ func dataSourceAwsNetworkPeering() *schema.Resource {
 }
 
 // dataSourceAwsNetworkPeeringRead is the func to implement reading of the
-// AWS Network peering between an HVN and a peer AWS VPC.
+// network peering between an HVN and a peer AWS VPC.
 func dataSourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
@@ -93,10 +93,10 @@ func dataSourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData
 	hvnID := d.Get("hvn_id").(string)
 	peeringID := d.Get("peering_id").(string)
 
-	log.Printf("[INFO] Reading Network peering (%s)", peeringID)
+	log.Printf("[INFO] Reading network peering (%s)", peeringID)
 	peering, err := clients.GetPeeringByID(ctx, client, peeringID, hvnID, loc)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Network peering (%s): %v", peeringID, err)
+		return diag.Errorf("unable to retrieve network peering (%s): %v", peeringID, err)
 	}
 
 	// Network peering found, update resource data.

--- a/internal/provider/data_source_aws_transit_gateway_attachment.go
+++ b/internal/provider/data_source_aws_transit_gateway_attachment.go
@@ -13,7 +13,7 @@ import (
 
 func dataSourceAwsTransitGatewayAttachment() *schema.Resource {
 	return &schema.Resource{
-		Description: "The AWS Transit Gateway Attachment data source provides information about an existing transit gateway attachment.",
+		Description: "The AWS transit gateway attachment data source provides information about an existing transit gateway attachment.",
 		ReadContext: dataSourceAwsTransitGatewayAttachmentRead,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &tgwDefaultTimeout,

--- a/internal/provider/link.go
+++ b/internal/provider/link.go
@@ -16,7 +16,7 @@ const (
 	// HvnResourceType is the resource type of an HVN
 	HvnResourceType = "hashicorp.network.hvn"
 
-	// PeeringResourceType is the resource type of a Network peering
+	// PeeringResourceType is the resource type of a network peering
 	PeeringResourceType = "hashicorp.network.peering"
 
 	// TgwAttachmentResourceType is the resource type of a TGW attachment

--- a/internal/provider/link.go
+++ b/internal/provider/link.go
@@ -9,6 +9,15 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 )
 
+// NOTE: The `Link` behavior in this file is based off of the internal cloud-api:
+// https://github.com/hashicorp/cloud-api-internal/blob/master/helper/hashicorp/cloud/location/link.go
+//
+// It is important that the implementation here is consistent with the internal
+// cloud-api because the `Link`s produced by these functions could be sent in
+// API requests. In practice, this primarily means that the resource types must
+// be the same in both places, eg. the HVN type is defined here:
+// https://github.com/hashicorp/cloud-network/blob/master/resource/network.go#L13
+
 const (
 	// ConsulClusterResourceType is the resource type of a Consul cluster
 	ConsulClusterResourceType = "hashicorp.consul.cluster"

--- a/internal/provider/link.go
+++ b/internal/provider/link.go
@@ -94,7 +94,7 @@ func parseLinkURL(urn string, resourceType string) (*sharedmodels.HashicorpCloud
 	pattern := fmt.Sprintf("^/project/[^/]+/%s/[^/]+$", resourceType)
 	match, _ := regexp.MatchString(pattern, urn)
 	if !match {
-		return nil, fmt.Errorf("url is not in the correct format: /project/{project_id}/%s/{id}", resourceType)
+		return nil, fmt.Errorf("url %q is not in the correct format: /project/{project_id}/%s/{id}", urn, resourceType)
 	}
 
 	components := strings.Split(urn, "/")

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -198,7 +198,7 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] Created network peering (%s) between HVN (%s) and peer (%s)", peering.ID, peering.Hvn.ID, peering.Target.AwsTarget.VpcID)
 
-	peering, err = clients.WaitForPeeringToBePendingAcceptance(ctx, client, peering.ID, hvnID, loc)
+	peering, err = clients.WaitForPeeringToBePendingAcceptance(ctx, client, peering.ID, hvnID, loc, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -22,7 +22,7 @@ var peeringDeleteTimeout = time.Minute * 35
 
 func resourceAwsNetworkPeering() *schema.Resource {
 	return &schema.Resource{
-		Description: "The AWS Network peering resource allows you to manage a Network peering between an HVN and a peer AWS VPC.",
+		Description: "The AWS network peering resource allows you to manage a network peering between an HVN and a peer AWS VPC.",
 
 		CreateContext: resourceAwsNetworkPeeringCreate,
 		ReadContext:   resourceAwsNetworkPeeringRead,
@@ -75,7 +75,7 @@ func resourceAwsNetworkPeering() *schema.Resource {
 			},
 			// Optional inputs
 			"peering_id": {
-				Description:      "The ID of the Network peering.",
+				Description:      "The ID of the network peering.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
@@ -84,12 +84,12 @@ func resourceAwsNetworkPeering() *schema.Resource {
 			},
 			// Computed outputs
 			"organization_id": {
-				Description: "The ID of the HCP organization where the Network peering is located. Always matches the HVN's organization.",
+				Description: "The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"project_id": {
-				Description: "The ID of the HCP project where the Network peering is located. Always matches the HVN's project.",
+				Description: "The ID of the HCP project where the network peering is located. Always matches the HVN's project.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -99,12 +99,12 @@ func resourceAwsNetworkPeering() *schema.Resource {
 				Computed:    true,
 			},
 			"created_at": {
-				Description: "The time that the Network peering was created.",
+				Description: "The time that the network peering was created.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"expires_at": {
-				Description: "The time after which the Network peering will be considered expired if it hasn't transitioned into 'Accepted' or 'Active' state.",
+				Description: "The time after which the network peering will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -131,24 +131,24 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 	_, err := clients.GetHvnByID(ctx, client, loc, hvnID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
-			return diag.Errorf("unable to find the HVN (%s) for the Network peering", hvnID)
+			return diag.Errorf("unable to find the HVN (%s) for the network peering", hvnID)
 		}
 
 		return diag.Errorf("unable to check for presence of an existing HVN (%s): %v", hvnID, err)
 	}
-	log.Printf("[INFO] HVN (%s) found, proceeding with create", hvnID)
+	log.Printf("[INFO] HVN (%s) found, proceeding with network peering create", hvnID)
 
 	// Check if peering already exists
 	if peeringID != "" {
 		_, err = clients.GetPeeringByID(ctx, client, peeringID, hvnID, loc)
 		if err != nil {
 			if !clients.IsResponseCodeNotFound(err) {
-				return diag.Errorf("unable to check for presence of an existing Network peering (%s): %v", peeringID, err)
+				return diag.Errorf("unable to check for presence of an existing network peering (%s): %v", peeringID, err)
 			}
 
-			log.Printf("[INFO] Network peering (%s) not found, proceeding with create", peeringID)
+			log.Printf("[INFO] Network peering (%s) not found, proceeding with network peering create", peeringID)
 		} else {
-			return diag.Errorf("a Network peering with peering_id=%s, hvn_id=%s and project_id=%s already exists - to be managed via Terraform this resource needs to be imported into the state. Please see the resource documentation for hcp_aws_network_peering for more information", peeringID, hvnID, loc.ProjectID)
+			return diag.Errorf("a network peering with peering_id=%s, hvn_id=%s and project_id=%s already exists - to be managed via Terraform this resource needs to be imported into the state. Please see the resource documentation for hcp_aws_network_peering for more information", peeringID, hvnID, loc.ProjectID)
 		}
 	}
 
@@ -174,10 +174,10 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 			},
 		},
 	}
-	log.Printf("[INFO] Creating Network peering between HVN (%s) and peer (%s)", hvnID, peerVpcID)
+	log.Printf("[INFO] Creating network peering between HVN (%s) and peer (%s)", hvnID, peerVpcID)
 	peeringResponse, err := client.Network.CreatePeering(peerNetworkParams, nil)
 	if err != nil {
-		return diag.Errorf("unable to create Network peering between HVN (%s) and peer (%s): %v", hvnID, peerVpcID, err)
+		return diag.Errorf("unable to create network peering between HVN (%s) and peer (%s): %v", hvnID, peerVpcID, err)
 	}
 
 	peering := peeringResponse.Payload.Peering
@@ -191,12 +191,12 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 	}
 	d.SetId(url)
 
-	// Wait for Network peering to be created
-	if err := clients.WaitForOperation(ctx, client, "create Network peering", loc, peeringResponse.Payload.Operation.ID); err != nil {
-		return diag.Errorf("unable to create Network peering (%s) between HVN (%s) and peer (%s): %v", peering.ID, peering.Hvn.ID, peering.Target.AwsTarget.VpcID, err)
+	// Wait for network peering to be created
+	if err := clients.WaitForOperation(ctx, client, "create network peering", loc, peeringResponse.Payload.Operation.ID); err != nil {
+		return diag.Errorf("unable to create network peering (%s) between HVN (%s) and peer (%s): %v", peering.ID, peering.Hvn.ID, peering.Target.AwsTarget.VpcID, err)
 	}
 
-	log.Printf("[INFO] Created Network peering (%s) between HVN (%s) and peer (%s)", peering.ID, peering.Hvn.ID, peering.Target.AwsTarget.VpcID)
+	log.Printf("[INFO] Created network peering (%s) between HVN (%s) and peer (%s)", peering.ID, peering.Hvn.ID, peering.Target.AwsTarget.VpcID)
 
 	peering, err = clients.WaitForPeeringToBePendingAcceptance(ctx, client, peering.ID, hvnID, loc)
 	if err != nil {
@@ -224,7 +224,7 @@ func resourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData, 
 	loc := link.Location
 	hvnID := d.Get("hvn_id").(string)
 
-	log.Printf("[INFO] Reading Network peering (%s)", peeringID)
+	log.Printf("[INFO] Reading network peering (%s)", peeringID)
 	peering, err := clients.GetPeeringByID(ctx, client, peeringID, hvnID, loc)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
@@ -233,13 +233,13 @@ func resourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData, 
 			return nil
 		}
 
-		return diag.Errorf("unable to retrieve Network peering (%s): %v", peeringID, err)
+		return diag.Errorf("unable to retrieve network peering (%s): %v", peeringID, err)
 	}
 
-	// The Network peering failed to provision properly so we want to let the user know and
+	// The network peering failed to provision properly so we want to let the user know and
 	// remove it from state
 	if peering.State == networkmodels.HashicorpCloudNetwork20200907PeeringStateFAILED {
-		log.Printf("[WARN] network peering (%s) failed to provision, removing from state", peering.ID)
+		log.Printf("[WARN] Network peering (%s) failed to provision, removing from state", peering.ID)
 		d.SetId("")
 		return nil
 	}
@@ -270,7 +270,7 @@ func resourceAwsNetworkPeeringDelete(ctx context.Context, d *schema.ResourceData
 	deletePeeringParams.HvnID = hvnID
 	deletePeeringParams.LocationOrganizationID = loc.OrganizationID
 	deletePeeringParams.LocationProjectID = loc.ProjectID
-	log.Printf("[INFO] Deleting Network peering (%s)", peeringID)
+	log.Printf("[INFO] Deleting network peering (%s)", peeringID)
 	deletePeeringResponse, err := client.Network.DeletePeering(deletePeeringParams, nil)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
@@ -278,11 +278,11 @@ func resourceAwsNetworkPeeringDelete(ctx context.Context, d *schema.ResourceData
 			return nil
 		}
 
-		return diag.Errorf("unable to delete Network peering (%s): %v", peeringID, err)
+		return diag.Errorf("unable to delete network peering (%s): %v", peeringID, err)
 	}
 
 	// Wait for peering to be deleted
-	if err := clients.WaitForOperation(ctx, client, "delete Network peering", loc, deletePeeringResponse.Payload.Operation.ID); err != nil {
+	if err := clients.WaitForOperation(ctx, client, "delete network peering", loc, deletePeeringResponse.Payload.Operation.ID); err != nil {
 		// If the HVN has already been deleted
 		// TODO: Peerings can be deleted automatically by the network monitor workflow ]
 		// and when deleting the HVN is deleted can cause an already started error.
@@ -290,7 +290,7 @@ func resourceAwsNetworkPeeringDelete(ctx context.Context, d *schema.ResourceData
 		if strings.Contains(err.Error(), "execution already started") {
 			return nil
 		}
-		return diag.Errorf("unable to delete Network peering (%s): %v", peeringID, err)
+		return diag.Errorf("unable to delete network peering (%s): %v", peeringID, err)
 	}
 
 	log.Printf("[INFO] Network peering (%s) deleted, removing from state", peeringID)
@@ -334,7 +334,7 @@ func setPeeringResourceData(d *schema.ResourceData, peering *networkmodels.Hashi
 }
 
 // resourceAwsNetworkPeeringImport implements the logic necessary to import an
-// un-tracked (by Terraform) Network peering resource into Terraform state.
+// un-tracked (by Terraform) network peering resource into Terraform state.
 func resourceAwsNetworkPeeringImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*clients.Client)
 

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -153,6 +153,7 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	peerNetworkParams := network_service.NewCreatePeeringParams()
+	peerNetworkParams.Context = ctx
 	peerNetworkParams.PeeringHvnID = hvnID
 	peerNetworkParams.PeeringHvnLocationOrganizationID = loc.OrganizationID
 	peerNetworkParams.PeeringHvnLocationProjectID = loc.ProjectID
@@ -264,6 +265,7 @@ func resourceAwsNetworkPeeringDelete(ctx context.Context, d *schema.ResourceData
 	hvnID := d.Get("hvn_id").(string)
 
 	deletePeeringParams := network_service.NewDeletePeeringParams()
+	deletePeeringParams.Context = ctx
 	deletePeeringParams.ID = peeringID
 	deletePeeringParams.HvnID = hvnID
 	deletePeeringParams.LocationOrganizationID = loc.OrganizationID

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -159,6 +159,7 @@ func resourceAwsTransitGatewayAttachmentCreate(ctx context.Context, d *schema.Re
 
 	// Create TGW attachment
 	createTGWAttachmentParams := network_service.NewCreateTGWAttachmentParams()
+	createTGWAttachmentParams.Context = ctx
 	createTGWAttachmentParams.HvnID = hvnID
 	createTGWAttachmentParams.HvnLocationOrganizationID = loc.OrganizationID
 	createTGWAttachmentParams.HvnLocationProjectID = loc.ProjectID
@@ -268,6 +269,7 @@ func resourceAwsTransitGatewayAttachmentDelete(ctx context.Context, d *schema.Re
 	hvnID := d.Get("hvn_id").(string)
 
 	deleteTGWAttParams := network_service.NewDeleteTGWAttachmentParams()
+	deleteTGWAttParams.Context = ctx
 	deleteTGWAttParams.ID = tgwAttID
 	deleteTGWAttParams.HvnID = hvnID
 	deleteTGWAttParams.HvnLocationOrganizationID = loc.OrganizationID

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -22,7 +22,7 @@ var tgwDeleteTimeout = time.Minute * 35
 
 func resourceAwsTransitGatewayAttachment() *schema.Resource {
 	return &schema.Resource{
-		Description: "The AWS Transit Gateway Attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.",
+		Description: "The AWS transit gateway attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.",
 
 		CreateContext: resourceAwsTransitGatewayAttachmentCreate,
 		ReadContext:   resourceAwsTransitGatewayAttachmentRead,
@@ -331,8 +331,8 @@ func setTransitGatewayAttachmentResourceData(d *schema.ResourceData, tgwAtt *net
 }
 
 // resourceAwsTransitGatewayAttachmentImport implements the logic necessary to
-// import an un-tracked (by Terraform) Network peering resource into Terraform
-// state.
+// import an un-tracked (by Terraform) transit gateway attachment resource into
+// Terraform state.
 func resourceAwsTransitGatewayAttachmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	client := meta.(*clients.Client)
 

--- a/templates/guides/peering.md.tmpl
+++ b/templates/guides/peering.md.tmpl
@@ -8,8 +8,8 @@ description: |-
 # Peer an AWS VPC to a HashiCorp Virtual Network (HVN)
 
 In order to connect AWS workloads to an HCP Consul cluster, you must peer the VPC in which the workloads reside to the HVN in which the HCP cluster resides.
-This is accomplished by using the `hcp_aws_network_peering` resource to create a Network peering between the HVN's VPC and your own VPC.
-The [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) resource is useful for accepting the Network peering that is initiated from the `hcp_aws_network_peering`.
+This is accomplished by using the `hcp_aws_network_peering` resource to create a network peering between the HVN's VPC and your own VPC.
+The [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) resource is useful for accepting the network peering that is initiated from the `hcp_aws_network_peering`.
 
 -> **Note:** The CIDR blocks of the HVN and the peer VPC cannot overlap.
 

--- a/templates/guides/quick-start.md.tmpl
+++ b/templates/guides/quick-start.md.tmpl
@@ -11,7 +11,7 @@ Everything in HashiCorp Cloud Platform (HCP) starts with the HashiCorp Virtual N
 
 HVNs enable you to deploy HashiCorp Cloud products without having to manage the networking details. They give you a simple setup for creating a network on AWS, in the region of your choice, and with the option to specify a CIDR range.
 
-Creating a Network peering from your HVN will allow you to connect and launch AWS resources to your HCP account.
+Creating a network peering from your HVN will allow you to connect and launch AWS resources to your HCP account.
 Peer your Amazon VPC with your HVN to enable resource access. After creating, you will need to accept the peering request and set up your VPC’s security groups and routing table on your AWS account. The Amazon VPC can be managed with the [AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs).
 
 Once you have an HVN, HCP Consul enables you to quickly deploy Consul servers in AWS across a variety of environments while offloading the operations burden to the SRE experts at HashiCorp.


### PR DESCRIPTION
These changes will probably be easiest to review one commit at a time. The updates largely come from items we ran into while working on the TGW resource, but did not yet backport to the other resources:

- **fix:** Ensure context is being passed for all HCP API calls - https://github.com/hashicorp/terraform-provider-hcp/commit/27be4da53d37f8199e87442c8ad2df0ad739c49f
- **improvement:** Update comments, docs, and messages to use correct capitalization for network peering - https://github.com/hashicorp/terraform-provider-hcp/commit/e8015376a8d2f7215bb631a54150222b909769e9
- **improvement:** Log import ID used when an import fails due to parsing - https://github.com/hashicorp/terraform-provider-hcp/commit/8204243661125969be973ea0f742cef229284465
- **improvement:** Add comment to clarify that Links can be sent in API requests - https://github.com/hashicorp/terraform-provider-hcp/commit/45e03702e98254687755f122604370223e7cbdc0
- **improvement:** Update peering wait function to use helper - https://github.com/hashicorp/terraform-provider-hcp/commit/86ad65206fdce9a6cd94872faf09b6e4407c38c2
