### PR TITLE
Bump hcp-go-sdk to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-openapi/runtime v0.19.20
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
-	github.com/hashicorp/hcp-sdk-go v0.2.0
+	github.com/hashicorp/hcp-sdk-go v0.5.0
 	github.com/hashicorp/terraform-plugin-docs v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
-github.com/hashicorp/hcp-sdk-go v0.2.0 h1:kY+1WSAE1NiWz+DwqzzgJDz6AUETVOhex6itGlJ4Rpw=
-github.com/hashicorp/hcp-sdk-go v0.2.0/go.mod h1:vpV5eSGZVmfCFcksi4AH8d/QSybuyLSH5UQcwmnRUQk=
+github.com/hashicorp/hcp-sdk-go v0.5.0 h1:g9sFOcRdCH5OMbsg7uO8TR+WjeSGVDgtnfWB2ilkMRQ=
+github.com/hashicorp/hcp-sdk-go v0.5.0/go.mod h1:vpV5eSGZVmfCFcksi4AH8d/QSybuyLSH5UQcwmnRUQk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.9.0/go.mod h1:tOT8j1J8rP05bZBGWXfMyU3HkLi1LWyqL3Bzsc3CJjo=

--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -12,13 +12,13 @@ import (
 func GetConsulClusterByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	consulClusterID string) (*consulmodels.HashicorpCloudConsul20200826Cluster, error) {
 
-	getParams := consul_service.NewConsulServiceGetParams()
+	getParams := consul_service.NewGetParams()
 	getParams.Context = ctx
 	getParams.ID = consulClusterID
 	getParams.LocationOrganizationID = loc.OrganizationID
 	getParams.LocationProjectID = loc.ProjectID
 
-	getResp, err := client.Consul.ConsulServiceGet(getParams, nil)
+	getResp, err := client.Consul.Get(getParams, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -33,13 +33,13 @@ func GetConsulClusterByID(ctx context.Context, client *Client, loc *sharedmodels
 func GetConsulClientConfigFiles(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	consulClusterID string) (*consulmodels.HashicorpCloudConsul20200826GetClientConfigResponse, error) {
 
-	p := consul_service.NewConsulServiceGetClientConfigParams()
+	p := consul_service.NewGetClientConfigParams()
 	p.Context = ctx
 	p.ID = consulClusterID
 	p.LocationOrganizationID = loc.OrganizationID
 	p.LocationProjectID = loc.ProjectID
 
-	resp, err := client.Consul.ConsulServiceGetClientConfig(p, nil)
+	resp, err := client.Consul.GetClientConfig(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func GetConsulClientConfigFiles(ctx context.Context, client *Client, loc *shared
 func CreateCustomerRootACLToken(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	consulClusterID string) (*consulmodels.HashicorpCloudConsul20200826CreateCustomerMasterACLTokenResponse, error) {
 
-	p := consul_service.NewConsulServiceCreateCustomerMasterACLTokenParams()
+	p := consul_service.NewCreateCustomerMasterACLTokenParams()
 	p.Context = ctx
 	p.ID = consulClusterID
 	p.Body = &consulmodels.HashicorpCloudConsul20200826CreateCustomerMasterACLTokenRequest{
@@ -64,7 +64,7 @@ func CreateCustomerRootACLToken(ctx context.Context, client *Client, loc *shared
 	p.LocationOrganizationID = loc.OrganizationID
 	p.LocationProjectID = loc.ProjectID
 
-	resp, err := client.Consul.ConsulServiceCreateCustomerMasterACLToken(p, nil)
+	resp, err := client.Consul.CreateCustomerMasterACLToken(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +77,14 @@ func CreateCustomerRootACLToken(ctx context.Context, client *Client, loc *shared
 func CreateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	consulCluster *consulmodels.HashicorpCloudConsul20200826Cluster) (*consulmodels.HashicorpCloudConsul20200826CreateResponse, error) {
 
-	p := consul_service.NewConsulServiceCreateParams()
+	p := consul_service.NewCreateParams()
 	p.Context = ctx
 	p.Body = &consulmodels.HashicorpCloudConsul20200826CreateRequest{Cluster: consulCluster}
 
 	p.ClusterLocationOrganizationID = loc.OrganizationID
 	p.ClusterLocationProjectID = loc.ProjectID
 
-	resp, err := client.Consul.ConsulServiceCreate(p, nil)
+	resp, err := client.Consul.Create(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +95,12 @@ func CreateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 // GetAvailableHCPConsulVersionsForLocation gets the list of available Consul versions that HCP supports for
 // the provided location.
 func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmodels.HashicorpCloudLocationLocation, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
-	p := consul_service.NewConsulServiceListVersionsParams()
+	p := consul_service.NewListVersionsParams()
 	p.Context = ctx
 	p.LocationProjectID = loc.ProjectID
 	p.LocationOrganizationID = loc.OrganizationID
 
-	resp, err := client.Consul.ConsulServiceListVersions(p, nil)
+	resp, err := client.Consul.ListVersions(p, nil)
 
 	if err != nil {
 		return nil, err
@@ -111,10 +111,10 @@ func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmo
 
 // GetAvailableHCPConsulVersions gets the list of available Consul versions that HCP supports.
 func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
-	p := consul_service.NewConsulServiceListVersions2Params()
+	p := consul_service.NewListVersions2Params()
 	p.Context = ctx
 
-	resp, err := client.Consul.ConsulServiceListVersions2(p, nil)
+	resp, err := client.Consul.ListVersions2(p, nil)
 
 	if err != nil {
 		return nil, err
@@ -128,13 +128,13 @@ func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*cons
 func DeleteConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	clusterID string) (*consulmodels.HashicorpCloudConsul20200826DeleteResponse, error) {
 
-	p := consul_service.NewConsulServiceDeleteParams()
+	p := consul_service.NewDeleteParams()
 	p.Context = ctx
 	p.ID = clusterID
 	p.LocationOrganizationID = loc.OrganizationID
 	p.LocationProjectID = loc.ProjectID
 
-	deleteResp, err := client.Consul.ConsulServiceDelete(p, nil)
+	deleteResp, err := client.Consul.Delete(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,13 +147,13 @@ func DeleteConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	clusterID string) ([]*consulmodels.HashicorpCloudConsul20200826Version, error) {
 
-	p := consul_service.NewConsulServiceListUpgradeVersionsParams()
+	p := consul_service.NewListUpgradeVersionsParams()
 	p.Context = ctx
 	p.ID = clusterID
 	p.LocationOrganizationID = loc.OrganizationID
 	p.LocationProjectID = loc.ProjectID
 
-	resp, err := client.Consul.ConsulServiceListUpgradeVersions(p, nil)
+	resp, err := client.Consul.ListUpgradeVersions(p, nil)
 
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func UpdateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 		},
 	}
 
-	updateParams := consul_service.NewConsulServiceUpdateParams()
+	updateParams := consul_service.NewUpdateParams()
 	updateParams.Context = ctx
 	updateParams.ClusterID = cluster.ID
 	updateParams.ClusterLocationProjectID = loc.ProjectID
@@ -188,7 +188,7 @@ func UpdateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.
 	updateParams.Body = &cluster
 
 	// Invoke update cluster endpoint
-	updateResp, err := client.Consul.ConsulServiceUpdate(updateParams, nil)
+	updateResp, err := client.Consul.Update(updateParams, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/clients/consul_snapshot.go
+++ b/internal/clients/consul_snapshot.go
@@ -13,7 +13,7 @@ import (
 func CreateSnapshot(ctx context.Context, client *Client, res *sharedmodels.HashicorpCloudLocationLink,
 	snapshotName string) (*consulmodels.HashicorpCloudConsul20200826CreateSnapshotResponse, error) {
 
-	p := consul_service.NewConsulServiceCreateSnapshotParams()
+	p := consul_service.NewCreateSnapshotParams()
 	p.Context = ctx
 	p.ResourceLocationOrganizationID = res.Location.OrganizationID
 	p.ResourceLocationProjectID = res.Location.ProjectID
@@ -22,7 +22,7 @@ func CreateSnapshot(ctx context.Context, client *Client, res *sharedmodels.Hashi
 		Resource: res,
 	}
 
-	resp, err := client.Consul.ConsulServiceCreateSnapshot(p, nil)
+	resp, err := client.Consul.CreateSnapshot(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -34,13 +34,13 @@ func CreateSnapshot(ctx context.Context, client *Client, res *sharedmodels.Hashi
 func GetSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	snapshotID string) (*consulmodels.HashicorpCloudConsul20200826GetSnapshotResponse, error) {
 
-	p := consul_service.NewConsulServiceGetSnapshotParams()
+	p := consul_service.NewGetSnapshotParams()
 	p.Context = ctx
 	p.LocationOrganizationID = loc.OrganizationID
 	p.LocationProjectID = loc.ProjectID
 	p.SnapshotID = snapshotID
 
-	resp, err := client.Consul.ConsulServiceGetSnapshot(p, nil)
+	resp, err := client.Consul.GetSnapshot(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -52,13 +52,13 @@ func GetSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.Hash
 func DeleteSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	snapshotID string) (*consulmodels.HashicorpCloudConsul20200826DeleteSnapshotResponse, error) {
 
-	p := consul_service.NewConsulServiceDeleteSnapshotParams()
+	p := consul_service.NewDeleteSnapshotParams()
 	p.Context = ctx
 	p.LocationOrganizationID = loc.OrganizationID
 	p.LocationProjectID = loc.ProjectID
 	p.SnapshotID = snapshotID
 
-	resp, err := client.Consul.ConsulServiceDeleteSnapshot(p, nil)
+	resp, err := client.Consul.DeleteSnapshot(p, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func DeleteSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.H
 func RenameSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	snapshotID string, snapshotName string) (*consulmodels.HashicorpCloudConsul20200826UpdateSnapshotResponse, error) {
 
-	p := consul_service.NewConsulServiceUpdateSnapshotParams()
+	p := consul_service.NewUpdateSnapshotParams()
 	p.Context = ctx
 	p.SnapshotLocationOrganizationID = loc.OrganizationID
 	p.SnapshotLocationProjectID = loc.ProjectID
@@ -80,7 +80,7 @@ func RenameSnapshotByID(ctx context.Context, client *Client, loc *sharedmodels.H
 		Name: snapshotName,
 	}
 
-	resp, err := client.Consul.ConsulServiceUpdateSnapshot(p, nil)
+	resp, err := client.Consul.UpdateSnapshot(p, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR bumps the dependency [hcp-sdk-go](https://github.com/hashicorp/hcp-sdk-go) to v0.5.0, capturing this [list of changes](https://github.com/hashicorp/hcp-sdk-go/compare/v0.2.0...v0.5.0). Highlights include - complete API errors can now be surfaced, a new version of the Consul API, and the addition of the Vault API!