### PR TITLE
HCPE-1034: vault resource scaffolding

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,6 +33,7 @@ func New() func() *schema.Provider {
 				"hcp_consul_cluster_root_token":      resourceConsulClusterRootToken(),
 				"hcp_consul_snapshot":                resourceConsulSnapshot(),
 				"hcp_hvn":                            resourceHvn(),
+				"hcp_vault_cluster":                  resourceVaultCluster(),
 			},
 			Schema: map[string]*schema.Schema{
 				"client_id": {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,6 +34,7 @@ func New() func() *schema.Provider {
 				"hcp_consul_snapshot":                resourceConsulSnapshot(),
 				"hcp_hvn":                            resourceHvn(),
 				"hcp_vault_cluster":                  resourceVaultCluster(),
+				"hcp_vault_cluster_admin_token":      resourceVaultClusterAdminToken(),
 			},
 			Schema: map[string]*schema.Schema{
 				"client_id": {

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -50,7 +50,6 @@ func resourceVaultCluster() *schema.Resource {
 				ForceNew:         true,
 				ValidateDiagFunc: validateSlugID,
 			},
-			// TODO: this is required for consul, but is this complete for vault yet? we can also mark computed output until it's ready.
 			"tier": {
 				Description: "The tier that the HCP Vault cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.",
 				Type:        schema.TypeString,
@@ -129,6 +128,11 @@ func resourceVaultCluster() *schema.Resource {
 			},
 			"vault_private_endpoint_url": {
 				Description: "The private URL for the Vault UI.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"created_at": {
+				Description: "The time that the Vault cluster was created.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -48,17 +47,6 @@ func resourceVaultCluster() *schema.Resource {
 				ForceNew:         true,
 				ValidateDiagFunc: validateSlugID,
 			},
-			"tier": {
-				Description: "The tier that the HCP Vault cluster will be provisioned as.  Only 'development' and 'standard' are available at this time.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				// TODO: generalize consul enum validator
-				// ValidateDiagFunc: validateStringInSlice(vaultClusterResourceTiers, true),
-				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return strings.ToLower(old) == strings.ToLower(new)
-				},
-			},
 			// optional fields
 			"public_endpoint": {
 				Description: "Denotes that the cluster has a public endpoint for the Vault UI. Defaults to false.",
@@ -77,6 +65,12 @@ func resourceVaultCluster() *schema.Resource {
 				// },
 			},
 			// computed outputs
+			// TODO: once more tiers are supported and can be changed by users, make this a required input.
+			"tier": {
+				Description: "The tier that the HCP Vault cluster will be provisioned as.  Only 'development' is available at this time.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"organization_id": {
 				Description: "The ID of the organization this HCP Vault cluster is located in.",
 				Type:        schema.TypeString,

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -1,9 +1,53 @@
 package provider
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// defaultClusterTimeout is the amount of time that can elapse
+// before a cluster read operation should timeout.
+var defaultVaultClusterTimeout = time.Minute * 5
+
+// createUpdateTimeout is the amount of time that can elapse
+// before a cluster create or update operation should timeout.
+var createUpdateVaultClusterTimeout = time.Minute * 35
+
+// deleteTimeout is the amount of time that can elapse
+// before a cluster delete operation should timeout.
+var deleteVaultClusterTimeout = time.Minute * 25
 
 func resourceVaultCluster() *schema.Resource {
 	return &schema.Resource{
-		Description: "The Vault cluster resource allows you to manage an HCP Vault cluster.",
+		Description:   "The Vault cluster resource allows you to manage an HCP Vault cluster.",
+		CreateContext: resourceVaultClusterCreate,
+		ReadContext:   resourceVaultClusterRead,
+		UpdateContext: resourceVaultClusterUpdate,
+		DeleteContext: resourceVaultClusterDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create:  &createUpdateVaultClusterTimeout,
+			Update:  &createUpdateVaultClusterTimeout,
+			Delete:  &deleteVaultClusterTimeout,
+			Default: &defaultVaultClusterTimeout,
+		},
 	}
+}
+
+func resourceVaultClusterCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVaultClusterRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVaultClusterUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVaultClusterDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
 }

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -73,17 +73,14 @@ func resourceVaultCluster() *schema.Resource {
 				Description: "The name of the customer namespace.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				// TODO Confirm:
-				// ForceNew:    true,
+				ForceNew:    true,
 			},
 			"max_lease_ttl": {
 				Description: "The max lease time-to-live (TTL) for this Vault cluster.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				// TODO Confirm:
-				// ForceNew:    true,
+				ForceNew:    true,
 			},
-			// TODO: min_vault_version for consistency with Consul?
 			"initial_vault_version": {
 				Description:      "The initial Vault version to use when creating the cluster. Once the cluster is created, this value is no longer used. If not specified, it is defaulted to the version that is currently recommended by HCP.",
 				Type:             schema.TypeString,

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -13,9 +13,9 @@ import (
 // before a cluster read operation should timeout.
 var defaultVaultClusterTimeout = time.Minute * 5
 
-// createUpdateTimeout is the amount of time that can elapse
-// before a cluster create or update operation should timeout.
-var createUpdateVaultClusterTimeout = time.Minute * 35
+// createTimeout is the amount of time that can elapse
+// before a cluster create operation should timeout.
+var createVaultClusterTimeout = time.Minute * 35
 
 // deleteTimeout is the amount of time that can elapse
 // before a cluster delete operation should timeout.
@@ -26,11 +26,9 @@ func resourceVaultCluster() *schema.Resource {
 		Description:   "The Vault cluster resource allows you to manage an HCP Vault cluster.",
 		CreateContext: resourceVaultClusterCreate,
 		ReadContext:   resourceVaultClusterRead,
-		UpdateContext: resourceVaultClusterUpdate,
 		DeleteContext: resourceVaultClusterDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create:  &createUpdateVaultClusterTimeout,
-			Update:  &createUpdateVaultClusterTimeout,
+			Create:  &createVaultClusterTimeout,
 			Delete:  &deleteVaultClusterTimeout,
 			Default: &defaultVaultClusterTimeout,
 		},
@@ -142,10 +140,6 @@ func resourceVaultClusterCreate(ctx context.Context, data *schema.ResourceData, 
 }
 
 func resourceVaultClusterRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil
-}
-
-func resourceVaultClusterUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }
 

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -55,8 +55,8 @@ func resourceVaultCluster() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
-			"initial_vault_version": {
-				Description:      "The initial Vault version to use when creating the cluster. Once the cluster is created, this value is no longer used. If not specified, it is defaulted to the version that is currently recommended by HCP.",
+			"min_vault_version": {
+				Description:      "The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validateSemVer,

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -67,18 +67,6 @@ func resourceVaultCluster() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
-			"namespace": {
-				Description: "The name of the customer namespace.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-			},
-			"max_lease_ttl": {
-				Description: "The max lease time-to-live (TTL) for this Vault cluster.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-			},
 			"initial_vault_version": {
 				Description:      "The initial Vault version to use when creating the cluster. Once the cluster is created, this value is no longer used. If not specified, it is defaulted to the version that is currently recommended by HCP.",
 				Type:             schema.TypeString,
@@ -108,6 +96,11 @@ func resourceVaultCluster() *schema.Resource {
 			},
 			"region": {
 				Description: "The region where the HCP Vault cluster is located.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"namespace": {
+				Description: "The name of the customer namespace this HCP Vault cluster is located in.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -1,0 +1,9 @@
+package provider
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func resourceVaultCluster() *schema.Resource {
+	return &schema.Resource{
+		Description: "The Vault cluster resource allows you to manage an HCP Vault cluster.",
+	}
+}

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -60,9 +60,7 @@ func resourceVaultCluster() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validateSemVer,
-				// DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-				// TODO generalize consul.NormalizeVersion()
-				// },
+				ForceNew:         true,
 			},
 			// computed outputs
 			// TODO: once more tiers are supported and can be changed by users, make this a required input.

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -17,8 +17,6 @@ func resourceVaultClusterAdminToken() *schema.Resource {
 		Description:   "The Vault cluster admin token resource provides a token with administrator privileges on an HCP Vault cluster.",
 		CreateContext: resourceVaultClusterAdminTokenCreate,
 		Timeouts: &schema.ResourceTimeout{
-			// TODO: in the API this is a GetAdminToken, but it's called Generate in the UI?
-			// Should this be a Create or Get?
 			Create: &defaultVaultAdminTokenTimeout,
 		},
 		Schema: map[string]*schema.Schema{
@@ -31,7 +29,7 @@ func resourceVaultClusterAdminToken() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			// computed outputs
-			"admin_token": {
+			"token": {
 				Description: "The admin token of this HCP Vault cluster.",
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -17,9 +17,11 @@ func resourceVaultClusterAdminToken() *schema.Resource {
 		Description:   "The Vault cluster admin token resource provides a token with administrator privileges on an HCP Vault cluster.",
 		CreateContext: resourceVaultClusterAdminTokenCreate,
 		ReadContext:   resourceVaultClusterAdminTokenRead,
+		DeleteContext: resourceVaultClusterAdminTokenDelete,
 		Timeouts: &schema.ResourceTimeout{
 			Create: &defaultVaultAdminTokenTimeout,
 			Read:   &defaultVaultAdminTokenTimeout,
+			Delete: &defaultVaultAdminTokenTimeout,
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs
@@ -47,5 +49,11 @@ func resourceVaultClusterAdminTokenCreate(ctx context.Context, data *schema.Reso
 // resourceVaultClusterAdminTokenRead will act as a no-op as the admin token is not persisted in
 // any way that it can be fetched and read
 func resourceVaultClusterAdminTokenRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+// resourceVaultClusterAdminTokenDelete will act as a no-op as the admin token is not persisted in
+// any way that it can be deleted.
+func resourceVaultClusterAdminTokenDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -16,8 +16,10 @@ func resourceVaultClusterAdminToken() *schema.Resource {
 	return &schema.Resource{
 		Description:   "The Vault cluster admin token resource provides a token with administrator privileges on an HCP Vault cluster.",
 		CreateContext: resourceVaultClusterAdminTokenCreate,
+		ReadContext:   resourceVaultClusterAdminTokenRead,
 		Timeouts: &schema.ResourceTimeout{
 			Create: &defaultVaultAdminTokenTimeout,
+			Read:   &defaultVaultAdminTokenTimeout,
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs
@@ -39,5 +41,11 @@ func resourceVaultClusterAdminToken() *schema.Resource {
 }
 
 func resourceVaultClusterAdminTokenCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+// resourceVaultClusterAdminTokenRead will act as a no-op as the admin token is not persisted in
+// any way that it can be fetched and read
+func resourceVaultClusterAdminTokenRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// defaultVaultAdminTokenTimeout is the amount of time that can elapse
+// before an admin token create operation should timeout.
+var defaultVaultAdminTokenTimeout = time.Minute * 5
+
+func resourceVaultClusterAdminToken() *schema.Resource {
+	return &schema.Resource{
+		Description:   "The Vault cluster admin token resource provides a token with administrator privileges on an HCP Vault cluster.",
+		CreateContext: resourceVaultClusterAdminTokenCreate,
+		Timeouts: &schema.ResourceTimeout{
+			// TODO: in the API this is a GetAdminToken, but it's called Generate in the UI?
+			// Should this be a Create or Get?
+			Create: &defaultVaultAdminTokenTimeout,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required inputs
+			"cluster_id": {
+				Description:      "The ID of the HCP Vault cluster.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateSlugID,
+			},
+			// computed outputs
+			"admin_token": {
+				Description: "The admin token of this HCP Vault cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceVaultClusterAdminTokenCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR adds the schema for the new Vault cluster resource. It takes some inspiration from the Consul cluster resource.

Sample HCL:
```
resource "hcp_vault_cluster" "example" {
  # required
  cluster_id = "testing"
  hvn_id = "test-hvn"
  
  # optional
  public_endpoint = true
  initial_vault_version = "1.7.0"
}
```

Sample `terraform plan` output:
```
# hcp_vault_cluster.example will be created
+ resource "hcp_vault_cluster" "example" {
    + cloud_provider               = (known after apply)
    + cluster_id                   = "testing"
    + created_at                   = (known after apply)
    + hvn_id                       = "test-hvn"
    + id                           = (known after apply)
    + namespace                    = "admin"
    + organization_id              = (known after apply)
    + project_id                   = (known after apply)
    + region                       = (known after apply)
    + tier                         = "development"
    + vault_version                = (known after apply)
    + vault_private_endpoint_url   = (known after apply)
    + vault_public_endpoint_url    = (known after apply)
}
```

Sample HCL:
```
resource "hcp_vault_cluster_admin_token" "example" {
  cluster_id = "testing"
}
```

Sample `terraform plan` output:
```
# hcp_vault_cluster_admin_token.example will be created
+ resource "hcp_vault_cluster_admin_token" "example" {
    + cluster_id                   = "testing"
    + token                        = (known after apply)
}
```