### PR TITLE
HCPE-980: Vault cluster resource

### DIFF
--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -1,0 +1,50 @@
+---
+page_title: "hcp_vault_cluster Resource - terraform-provider-hcp"
+subcategory: ""
+description: |-
+  The Vault cluster resource allows you to manage an HCP Vault cluster.
+---
+
+# Resource `hcp_vault_cluster`
+
+The Vault cluster resource allows you to manage an HCP Vault cluster.
+
+
+
+## Schema
+
+### Required
+
+- **cluster_id** (String) The ID of the HCP Vault cluster.
+- **hvn_id** (String) The ID of the HVN this HCP Vault cluster is associated to.
+
+### Optional
+
+- **id** (String) The ID of this resource.
+- **min_vault_version** (String) The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
+- **project_id** (String) The ID of the project this HCP Vault cluster is located in.
+- **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Vault UI. Defaults to false.
+- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+### Read-only
+
+- **cloud_provider** (String) The provider where the HCP Vault cluster is located.
+- **created_at** (String) The time that the Vault cluster was created.
+- **namespace** (String) The name of the customer namespace this HCP Vault cluster is located in.
+- **organization_id** (String) The ID of the organization this HCP Vault cluster is located in.
+- **region** (String) The region where the HCP Vault cluster is located.
+- **tier** (String) The tier that the HCP Vault cluster will be provisioned as.  Only 'development' is available at this time.
+- **vault_private_endpoint_url** (String) The private URL for the Vault UI.
+- **vault_public_endpoint_url** (String) The public URL for the Vault UI. This will be empty if `public_endpoint` is `false`.
+- **vault_version** (String) The Vault version of the cluster.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- **create** (String)
+- **default** (String)
+- **delete** (String)
+
+

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -22,8 +22,7 @@ The Vault cluster resource allows you to manage an HCP Vault cluster.
 
 - **id** (String) The ID of this resource.
 - **min_vault_version** (String) The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
-- **project_id** (String) The ID of the project this HCP Vault cluster is located in.
-- **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Vault UI. Defaults to false.
+- **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only
@@ -32,10 +31,11 @@ The Vault cluster resource allows you to manage an HCP Vault cluster.
 - **created_at** (String) The time that the Vault cluster was created.
 - **namespace** (String) The name of the customer namespace this HCP Vault cluster is located in.
 - **organization_id** (String) The ID of the organization this HCP Vault cluster is located in.
+- **project_id** (String) The ID of the project this HCP Vault cluster is located in.
 - **region** (String) The region where the HCP Vault cluster is located.
 - **tier** (String) The tier that the HCP Vault cluster will be provisioned as.  Only 'development' is available at this time.
-- **vault_private_endpoint_url** (String) The private URL for the Vault UI.
-- **vault_public_endpoint_url** (String) The public URL for the Vault UI. This will be empty if `public_endpoint` is `false`.
+- **vault_private_endpoint_url** (String) The private URL for the Vault cluster.
+- **vault_public_endpoint_url** (String) The public URL for the Vault cluster. This will be empty if `public_endpoint` is `false`.
 - **vault_version** (String) The Vault version of the cluster.
 
 <a id="nestedblock--timeouts"></a>

--- a/internal/consul/version.go
+++ b/internal/consul/version.go
@@ -34,11 +34,6 @@ func IsValidVersion(version string, versions []*consulmodels.HashicorpCloudConsu
 	return false
 }
 
-// NormalizeVersion ensures the version starts with a 'v'
-func NormalizeVersion(version string) string {
-	return "v" + strings.TrimPrefix(version, "v")
-}
-
 // VersionsToString converts a slice of version pointers to a string of their comma delimited values.
 func VersionsToString(versions []*consulmodels.HashicorpCloudConsul20200826Version) string {
 	var recommendedVersion string

--- a/internal/consul/version_test.go
+++ b/internal/consul/version_test.go
@@ -117,31 +117,6 @@ func Test_IsValidVersion(t *testing.T) {
 	}
 }
 
-func Test_NormalizeVersion(t *testing.T) {
-	tcs := map[string]struct {
-		expected string
-		input    string
-	}{
-		"with a prefixed v": {
-			input:    "v1.9.0",
-			expected: "v1.9.0",
-		},
-		"without a prefixed v": {
-			input:    "1.9.0",
-			expected: "v1.9.0",
-		},
-	}
-
-	for n, tc := range tcs {
-		t.Run(n, func(t *testing.T) {
-			r := require.New(t)
-
-			result := NormalizeVersion(tc.input)
-			r.Equal(tc.expected, result)
-		})
-	}
-}
-
 func Test_VersionsToString(t *testing.T) {
 	tcs := map[string]struct {
 		expected string

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -1,0 +1,10 @@
+package input
+
+import (
+	"strings"
+)
+
+// NormalizeVersion ensures the version starts with a 'v'
+func NormalizeVersion(version string) string {
+	return "v" + strings.TrimPrefix(version, "v")
+}

--- a/internal/input/input_test.go
+++ b/internal/input/input_test.go
@@ -1,0 +1,32 @@
+package input
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NormalizeVersion(t *testing.T) {
+	tcs := map[string]struct {
+		expected string
+		input    string
+	}{
+		"with a prefixed v": {
+			input:    "v1.9.0",
+			expected: "v1.9.0",
+		},
+		"without a prefixed v": {
+			input:    "1.9.0",
+			expected: "v1.9.0",
+		},
+	}
+
+	for n, tc := range tcs {
+		t.Run(n, func(t *testing.T) {
+			r := require.New(t)
+
+			result := NormalizeVersion(tc.input)
+			r.Equal(tc.expected, result)
+		})
+	}
+}

--- a/internal/provider/link.go
+++ b/internal/provider/link.go
@@ -32,6 +32,9 @@ const (
 	// ConsulClusterAgentKubernetesSecretDataSourceType is the data source
 	// type of a Consul cluster agent Kubernetes secret
 	ConsulClusterAgentKubernetesSecretDataSourceType = ConsulClusterResourceType + ".agent-kubernetes-secret"
+
+	// VaultClusterResourceType is the resource type of a Consul cluster
+	VaultClusterResourceType = "hashicorp.vault.cluster"
 )
 
 // newLink constructs a new Link from the passed arguments. ID should be the

--- a/internal/provider/link.go
+++ b/internal/provider/link.go
@@ -33,7 +33,7 @@ const (
 	// type of a Consul cluster agent Kubernetes secret
 	ConsulClusterAgentKubernetesSecretDataSourceType = ConsulClusterResourceType + ".agent-kubernetes-secret"
 
-	// VaultClusterResourceType is the resource type of a Consul cluster
+	// VaultClusterResourceType is the resource type of a Vault cluster
 	VaultClusterResourceType = "hashicorp.vault.cluster"
 )
 

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/consul"
+	"github.com/hashicorp/terraform-provider-hcp/internal/input"
 )
 
 const consulTierDevelopment = "development"
@@ -111,7 +112,7 @@ func resourceConsulCluster() *schema.Resource {
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					// Suppress diff is normalized versions match OR min_consul_version is removed from the resource
 					// since min_consul_version is required in order to upgrade the cluster to a new Consul version.
-					return consul.NormalizeVersion(old) == consul.NormalizeVersion(new) || new == ""
+					return input.NormalizeVersion(old) == input.NormalizeVersion(new) || new == ""
 				},
 			},
 			"datacenter": {
@@ -264,7 +265,7 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	consulVersion := consul.RecommendedVersion(availableConsulVersions)
 	v, ok := d.GetOk("min_consul_version")
 	if ok {
-		consulVersion = consul.NormalizeVersion(v.(string))
+		consulVersion = input.NormalizeVersion(v.(string))
 	}
 
 	// check if version is valid and available
@@ -572,7 +573,7 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	if !ok {
 		return diag.Errorf("min_consul_version is required in order to upgrade the cluster")
 	}
-	newConsulVersion := consul.NormalizeVersion(v.(string))
+	newConsulVersion := input.NormalizeVersion(v.(string))
 
 	// Check that there are any valid upgrade versions
 	if upgradeVersions == nil {

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -55,7 +55,7 @@ func resourceVaultCluster() *schema.Resource {
 			},
 			// optional fields
 			"public_endpoint": {
-				Description: "Denotes that the cluster has a public endpoint for the Vault UI. Defaults to false.",
+				Description: "Denotes that the cluster has a public endpoint. Defaults to false.",
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
@@ -83,8 +83,6 @@ func resourceVaultCluster() *schema.Resource {
 			"project_id": {
 				Description: "The ID of the project this HCP Vault cluster is located in.",
 				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
 				Computed:    true,
 			},
 			"cloud_provider": {
@@ -108,12 +106,12 @@ func resourceVaultCluster() *schema.Resource {
 				Computed:    true,
 			},
 			"vault_public_endpoint_url": {
-				Description: "The public URL for the Vault UI. This will be empty if `public_endpoint` is `false`.",
+				Description: "The public URL for the Vault cluster. This will be empty if `public_endpoint` is `false`.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"vault_private_endpoint_url": {
-				Description: "The private URL for the Vault UI.",
+				Description: "The private URL for the Vault cluster.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -159,8 +157,8 @@ func resourceVaultClusterCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("a Vault cluster with cluster_id=%q in project_id=%q already exists - to be managed via Terraform this resource needs to be imported into the State.  Please see the resource documentation for hcp_vault_cluster for more information.", clusterID, loc.ProjectID)
 	}
 
-	// TODO: Recommended version is hard-coded for now, but eventually should be fetched from an API.
-	vaultVersion := "1.7.0"
+	// If no min_vault_version is set, an empty version is passed and the backend will set a default version.
+	var vaultVersion string
 	v, ok := d.GetOk("min_vault_version")
 	if ok {
 		vaultVersion = input.NormalizeVersion(v.(string))

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -160,8 +160,8 @@ func resourceVaultClusterCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	// TODO: Recommended version is hard-coded for now, but eventually should be fetched from an API.
-	vaultVersion := "1.0.7"
-	v, ok := d.GetOk("initial_vault_version")
+	vaultVersion := "1.7.0"
+	v, ok := d.GetOk("min_vault_version")
 	if ok {
 		vaultVersion = input.NormalizeVersion(v.(string))
 	}
@@ -171,14 +171,11 @@ func resourceVaultClusterCreate(ctx context.Context, d *schema.ResourceData, met
 	// TODO: Tier is hard-coded for now, but eventually will be required input on the resource.
 	tier := vaultmodels.HashicorpCloudVault20201125TierDEV
 
-	namespace := "admin"
-
 	log.Printf("[INFO] Creating Vault cluster (%s)", clusterID)
 
 	vaultCuster := &vaultmodels.HashicorpCloudVault20201125InputCluster{
 		Config: &vaultmodels.HashicorpCloudVault20201125InputClusterConfig{
 			VaultConfig: &vaultmodels.HashicorpCloudVault20201125VaultConfig{
-				Namespace:      namespace,
 				InitialVersion: vaultVersion,
 			},
 			Tier: tier,
@@ -266,7 +263,7 @@ func resourceVaultClusterRead(ctx context.Context, d *schema.ResourceData, meta 
 func resourceVaultClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
-	link, err := buildLinkFromURL(d.Id(), ConsulClusterResourceType, client.Config.OrganizationID)
+	link, err := buildLinkFromURL(d.Id(), VaultClusterResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -20,14 +20,14 @@ resource "hcp_hvn" "test" {
 	
 resource "hcp_vault_cluster" "test" {
 	cluster_id            = "test-vault-cluster"
-	hvn_id                = "test-hvn"
-	initial_vault_version = "1.7.0"
+	hvn_id                = hcp_hvn.test.hvn_id
+	min_vault_version     = "v1.7.0"
 }
 `)
 )
 
 func TestAccVaultCluster(t *testing.T) {
-	resourceName := "hcp_vault_cluster.test-vault"
+	resourceName := "hcp_vault_cluster.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -40,14 +40,14 @@ func TestAccVaultCluster(t *testing.T) {
 					testAccCheckVaultClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-vault-cluster"),
 					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
-					resource.TestCheckResourceAttr(resourceName, "tier", "development"),
+					resource.TestCheckResourceAttr(resourceName, "tier", "DEV"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "namespace", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "vault_version", "v1.7.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "vault_version"),
 					resource.TestCheckNoResourceAttr(resourceName, "vault_public_endpoint_url"),
 					resource.TestCheckResourceAttrSet(resourceName, "vault_private_endpoint_url"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -60,7 +60,7 @@ func TestAccVaultCluster(t *testing.T) {
 					testAccCheckVaultClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-vault-cluster"),
 					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
-					resource.TestCheckResourceAttr(resourceName, "tier", "development"),
+					resource.TestCheckResourceAttr(resourceName, "tier", "DEV"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+)
+
+var (
+	testAccVaultClusterConfig = fmt.Sprintf(`
+resource "hcp_hvn" "test" {
+	hvn_id         = "test-hvn"
+	cloud_provider = "aws"
+	region         = "us-west-2"
+}
+	
+resource "hcp_vault_cluster" "test" {
+	cluster_id            = "test-vault-cluster"
+	hvn_id                = "test-hvn"
+	initial_vault_version = "1.7.0"
+}
+`)
+)
+
+func TestAccVaultCluster(t *testing.T) {
+	resourceName := "hcp_vault_cluster.test-vault"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckVaultClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(testAccVaultClusterConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVaultClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-vault-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "tier", "development"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "admin"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vault_version"),
+					resource.TestCheckNoResourceAttr(resourceName, "vault_public_endpoint_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "vault_private_endpoint_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+			// This step is a subsequent terraform apply that verifies that no state is modified.
+			{
+				Config: testConfig(testAccVaultClusterConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVaultClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-vault-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "tier", "development"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),
+					resource.TestCheckResourceAttr(resourceName, "namespace", "admin"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vault_version"),
+					resource.TestCheckNoResourceAttr(resourceName, "vault_public_endpoint_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "vault_private_endpoint_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVaultClusterExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		client := testAccProvider.Meta().(*clients.Client)
+
+		link, err := buildLinkFromURL(id, VaultClusterResourceType, client.Config.OrganizationID)
+		if err != nil {
+			return fmt.Errorf("unable to build link for %q: %v", id, err)
+		}
+
+		clusterID := link.ID
+		loc := link.Location
+
+		if _, err := clients.GetVaultClusterByID(context.Background(), client, loc, clusterID); err != nil {
+			return fmt.Errorf("unable to read Vault cluster %q: %v", id, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckVaultClusterDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*clients.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "hcp_vault_cluster":
+			id := rs.Primary.ID
+
+			link, err := buildLinkFromURL(id, VaultClusterResourceType, client.Config.OrganizationID)
+			if err != nil {
+				return fmt.Errorf("unable to build link for %q: %v", id, err)
+			}
+
+			clusterID := link.ID
+			loc := link.Location
+
+			_, err = clients.GetVaultClusterByID(context.Background(), client, loc, clusterID)
+			if err == nil || !clients.IsResponseCodeNotFound(err) {
+				return fmt.Errorf("didn't get a 404 when reading destroyed Vault cluster %q: %v", id, err)
+			}
+
+		default:
+			continue
+		}
+	}
+	return nil
+}

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -21,7 +21,6 @@ resource "hcp_hvn" "test" {
 resource "hcp_vault_cluster" "test" {
 	cluster_id            = "test-vault-cluster"
 	hvn_id                = hcp_hvn.test.hvn_id
-	min_vault_version     = "v1.7.0"
 }
 `)
 )
@@ -45,7 +44,7 @@ func TestAccVaultCluster(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "namespace", "admin"),
-					resource.TestCheckResourceAttr(resourceName, "vault_version", "v1.7.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "vault_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vault_public_endpoint_url"),


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR adds the Vault cluster resource.

Sample HCL:
```
resource "hcp_hvn" "example" {
  hvn_id          = "test-hvn"
  cloud_provider  = "aws"
  region          = "us-west-2"
}

resource "hcp_vault_cluster" "example" {
  cluster_id         = "test-vault-cluster"
  hvn_id             = hcp_hvn.example.hvn_id
  min_vault_version  = "v1.7.0"
}
```

Sample `terraform plan` output:
```
# hcp_vault_cluster.example will be created
+ resource "hcp_vault_cluster" "example" {
    + cloud_provider               = (known after apply)
    + cluster_id                   = "test-vault-cluster"
    + created_at                   = (known after apply)
    + hvn_id                       = "test-hvn"
    + id                           = (known after apply)
    + namespace                    = "admin"
    + organization_id              = (known after apply)
    + project_id                   = (known after apply)
    + region                       = (known after apply)
    + tier                         = "DEV"
    + vault_version                = (known after apply)
    + vault_private_endpoint_url   = (known after apply)
    + vault_public_endpoint_url    = (known after apply)
}
```

### :building_construction: Acceptance tests

- [x] No feature flags.
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccVaultCluster'
--- PASS: TestAccVaultCluster (757.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	757.756s

```
