### PR TITLE
HCPE-978: Vault cluster data source, import, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,10 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = hcp_aws_network_peering.example.provider_peering_id
   auto_accept               = true
 }
+
+// Create a Vault cluster within the HVN.
+resource "hcp_vault_cluster" "example" {
+  cluster_id = "vault-cluster"
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+}
 ```

--- a/docs/data-sources/vault_cluster.md
+++ b/docs/data-sources/vault_cluster.md
@@ -1,0 +1,54 @@
+---
+page_title: "hcp_vault_cluster Data Source - terraform-provider-hcp"
+subcategory: ""
+description: |-
+  The cluster data source provides information about an existing HCP Vault cluster.
+---
+
+# Data Source `hcp_vault_cluster`
+
+The cluster data source provides information about an existing HCP Vault cluster.
+
+## Example Usage
+
+```terraform
+data "hcp_vault_cluster" "example" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Schema
+
+### Required
+
+- **cluster_id** (String) The ID of the HCP Vault cluster.
+
+### Optional
+
+- **id** (String) The ID of this resource.
+- **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+
+### Read-only
+
+- **cloud_provider** (String) The provider where the HCP Vault cluster is located.
+- **created_at** (String) The time that the Vault cluster was created.
+- **hvn_id** (String) The ID of the HVN this HCP Vault cluster is associated to.
+- **min_vault_version** (String) The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
+- **namespace** (String) The name of the customer namespace this HCP Vault cluster is located in.
+- **organization_id** (String) The ID of the organization this HCP Vault cluster is located in.
+- **project_id** (String) The ID of the project this HCP Vault cluster is located in.
+- **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
+- **region** (String) The region where the HCP Vault cluster is located.
+- **tier** (String) The tier that the HCP Vault cluster will be provisioned as.  Only 'development' is available at this time.
+- **vault_private_endpoint_url** (String) The private URL for the Vault cluster.
+- **vault_public_endpoint_url** (String) The public URL for the Vault cluster. This will be empty if `public_endpoint` is `false`.
+- **vault_version** (String) The Vault version of the cluster.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- **default** (String)
+
+

--- a/docs/guides/vault-admin-token.md
+++ b/docs/guides/vault-admin-token.md
@@ -8,7 +8,8 @@ description: |-
 # Create a new Vault cluster and an admin token
 
 Once you have an HVN, HCP Vault enables you to quickly deploy a Vault Enterprise cluster in AWS across a variety of environments while offloading the operations burden to the SRE experts at HashiCorp.
-The cluster's admin token grants its bearer administrator access to the Vault cluster. It expires after 6 hours.
+The cluster's admin token grants its bearer administrator access to the Vault cluster. This admin token is valid for six hours. On subsequent reads after creation, 
+the resource will check if the admin token is close to expiration or expired and automatically refresh as needed.
 
 ```terraform
 resource "hcp_vault_cluster" "example_vault_cluster" {

--- a/docs/guides/vault-admin-token.md
+++ b/docs/guides/vault-admin-token.md
@@ -1,0 +1,22 @@
+---
+subcategory: ""
+page_title: "Create a Vault cluster and admin token - HCP Provider"
+description: |-
+    An example of creating a Vault cluster and admin token.
+---
+
+# Create a new Vault cluster and an admin token
+
+Once you have an HVN, HCP Vault enables you to quickly deploy a Vault Enterprise cluster in AWS across a variety of environments while offloading the operations burden to the SRE experts at HashiCorp.
+The cluster's admin token grants its bearer administrator access to the Vault cluster. It expires after 6 hours.
+
+```terraform
+resource "hcp_vault_cluster" "example_vault_cluster" {
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+  cluster_id = "hcp-tf-example-vault-cluster"
+}
+
+data "hcp_vault_cluster_admin_token" "example_vault_admin_token" {
+  cluster_id = hcp_vault_cluster.example_vault_cluster.cluster_id
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,12 @@ resource "hcp_consul_cluster" "example_secondary" {
   tier         = "development"
   primary_link = hcp_consul_cluster.example.self_link
 }
+
+// Create a Vault cluster in the same region and cloud provider as the HVN
+resource "hcp_vault_cluster" "example" {
+  cluster_id = "hcp-tf-example-vault-cluster"
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+}
 ```
 
 ## Schema

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -9,7 +9,21 @@ description: |-
 
 The Vault cluster resource allows you to manage an HCP Vault cluster.
 
+## Example Usage
 
+```terraform
+resource "hcp_hvn" "example" {
+  hvn_id         = "hvn"
+  cloud_provider = "aws"
+  region         = "us-west-2"
+  cidr_block     = "172.25.16.0/20"
+}
+
+resource "hcp_vault_cluster" "example" {
+  cluster_id = "vault-cluster"
+  hvn_id     = hcp_hvn.example.hvn_id
+}
+```
 
 ## Schema
 
@@ -47,4 +61,11 @@ Optional:
 - **default** (String)
 - **delete** (String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# The import ID is {cluster_id}
+terraform import hcp_vault_cluster.example vault-cluster
+```

--- a/examples/data-sources/hcp_vault_cluster/data-source.tf
+++ b/examples/data-sources/hcp_vault_cluster/data-source.tf
@@ -1,0 +1,3 @@
+data "hcp_vault_cluster" "example" {
+  cluster_id = var.cluster_id
+}

--- a/examples/guides/vault_cluster_admin_token/main.tf
+++ b/examples/guides/vault_cluster_admin_token/main.tf
@@ -1,0 +1,8 @@
+resource "hcp_vault_cluster" "example_vault_cluster" {
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+  cluster_id = "hcp-tf-example-vault-cluster"
+}
+
+data "hcp_vault_cluster_admin_token" "example_vault_admin_token" {
+  cluster_id = hcp_vault_cluster.example_vault_cluster.cluster_id
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -61,3 +61,9 @@ resource "hcp_consul_cluster" "example_secondary" {
   tier         = "development"
   primary_link = hcp_consul_cluster.example.self_link
 }
+
+// Create a Vault cluster in the same region and cloud provider as the HVN
+resource "hcp_vault_cluster" "example" {
+  cluster_id = "hcp-tf-example-vault-cluster"
+  hvn_id     = hcp_hvn.example_hvn.hvn_id
+}

--- a/examples/resources/hcp_vault_cluster/import.sh
+++ b/examples/resources/hcp_vault_cluster/import.sh
@@ -1,0 +1,2 @@
+# The import ID is {cluster_id}
+terraform import hcp_vault_cluster.example vault-cluster

--- a/examples/resources/hcp_vault_cluster/resource.tf
+++ b/examples/resources/hcp_vault_cluster/resource.tf
@@ -1,0 +1,11 @@
+resource "hcp_hvn" "example" {
+  hvn_id         = "hvn"
+  cloud_provider = "aws"
+  region         = "us-west-2"
+  cidr_block     = "172.25.16.0/20"
+}
+
+resource "hcp_vault_cluster" "example" {
+  cluster_id = "vault-cluster"
+  hvn_id     = hcp_hvn.example.hvn_id
+}

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -1,0 +1,130 @@
+package provider
+
+import (
+	"context"
+	"log"
+
+	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+)
+
+func dataSourceVaultCluster() *schema.Resource {
+	return &schema.Resource{
+		Description: "The cluster data source provides information about an existing HCP Vault cluster.",
+		ReadContext: dataSourceVaultClusterRead,
+		Timeouts: &schema.ResourceTimeout{
+			Default: &defaultClusterTimeoutDuration,
+		},
+		Schema: map[string]*schema.Schema{
+			// Required inputs
+			"cluster_id": {
+				Description:      "The ID of the HCP Vault cluster.",
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateSlugID,
+			},
+			// computed outputs
+			"hvn_id": {
+				Description: "The ID of the HVN this HCP Vault cluster is associated to.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"public_endpoint": {
+				Description: "Denotes that the cluster has a public endpoint. Defaults to false.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+			"min_vault_version": {
+				Description: "The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"tier": {
+				Description: "The tier that the HCP Vault cluster will be provisioned as.  Only 'development' is available at this time.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"organization_id": {
+				Description: "The ID of the organization this HCP Vault cluster is located in.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"project_id": {
+				Description: "The ID of the project this HCP Vault cluster is located in.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"cloud_provider": {
+				Description: "The provider where the HCP Vault cluster is located.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"region": {
+				Description: "The region where the HCP Vault cluster is located.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"namespace": {
+				Description: "The name of the customer namespace this HCP Vault cluster is located in.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vault_version": {
+				Description: "The Vault version of the cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vault_public_endpoint_url": {
+				Description: "The public URL for the Vault cluster. This will be empty if `public_endpoint` is `false`.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vault_private_endpoint_url": {
+				Description: "The private URL for the Vault cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"created_at": {
+				Description: "The time that the Vault cluster was created.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceVaultClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterID := d.Get("cluster_id").(string)
+	client := meta.(*clients.Client)
+
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		OrganizationID: client.Config.OrganizationID,
+		ProjectID:      client.Config.ProjectID,
+	}
+
+	log.Printf("[INFO] Reading Vault cluster (%s) [project_id=%s, organization_id=%s]", clusterID, loc.ProjectID, loc.OrganizationID)
+
+	cluster, err := clients.GetVaultClusterByID(ctx, client, loc, clusterID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// build the id for this Vault cluster
+	link := newLink(loc, VaultClusterResourceType, clusterID)
+	url, err := linkURL(link)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(url)
+
+	// Cluster found, update resource data.
+	if err := setVaultClusterResourceData(d, cluster); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,6 +25,7 @@ func New() func() *schema.Provider {
 				"hcp_consul_cluster":                 dataSourceConsulCluster(),
 				"hcp_consul_versions":                dataSourceConsulVersions(),
 				"hcp_hvn":                            dataSourceHvn(),
+				"hcp_vault_cluster":                  dataSourceVaultCluster(),
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"hcp_aws_network_peering":            resourceAwsNetworkPeering(),

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -37,6 +37,9 @@ func resourceVaultCluster() *schema.Resource {
 			Delete:  &deleteVaultClusterTimeout,
 			Default: &defaultVaultClusterTimeout,
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAwsNetworkPeeringImport,
+		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs
 			"cluster_id": {
@@ -348,4 +351,23 @@ func setVaultClusterResourceData(d *schema.ResourceData, cluster *vaultmodels.Ha
 	}
 
 	return nil
+}
+
+func resourceVaultClusterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*clients.Client)
+
+	clusterID := d.Id()
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		ProjectID: client.Config.ProjectID,
+	}
+
+	link := newLink(loc, VaultClusterResourceType, clusterID)
+	url, err := linkURL(link)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(url)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -38,7 +38,7 @@ func resourceVaultCluster() *schema.Resource {
 			Default: &defaultVaultClusterTimeout,
 		},
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceAwsNetworkPeeringImport,
+			StateContext: resourceVaultClusterImport,
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -52,6 +52,20 @@ func TestAccVaultCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 				),
 			},
+			// This step simulates an import of the resource.
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+
+					return rs.Primary.Attributes["cluster_id"], nil
+				},
+				ImportStateVerify: true,
+			},
 			// This step is a subsequent terraform apply that verifies that no state is modified.
 			{
 				Config: testConfig(testAccVaultClusterConfig),

--- a/templates/guides/vault-admin-token.md.tmpl
+++ b/templates/guides/vault-admin-token.md.tmpl
@@ -1,0 +1,13 @@
+---
+subcategory: ""
+page_title: "Create a Vault cluster and admin token - HCP Provider"
+description: |-
+    An example of creating a Vault cluster and admin token.
+---
+
+# Create a new Vault cluster and an admin token
+
+Once you have an HVN, HCP Vault enables you to quickly deploy a Vault Enterprise cluster in AWS across a variety of environments while offloading the operations burden to the SRE experts at HashiCorp.
+The cluster's admin token grants its bearer administrator access to the Vault cluster. It expires after 6 hours.
+
+{{ tffile "examples/guides/vault_cluster_admin_token/main.tf" }}

--- a/templates/guides/vault-admin-token.md.tmpl
+++ b/templates/guides/vault-admin-token.md.tmpl
@@ -8,6 +8,7 @@ description: |-
 # Create a new Vault cluster and an admin token
 
 Once you have an HVN, HCP Vault enables you to quickly deploy a Vault Enterprise cluster in AWS across a variety of environments while offloading the operations burden to the SRE experts at HashiCorp.
-The cluster's admin token grants its bearer administrator access to the Vault cluster. It expires after 6 hours.
+The cluster's admin token grants its bearer administrator access to the Vault cluster. This admin token is valid for six hours. On subsequent reads after creation, 
+the resource will check if the admin token is close to expiration or expired and automatically refresh as needed.
 
 {{ tffile "examples/guides/vault_cluster_admin_token/main.tf" }}


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR adds the Vault cluster data source, import, and updates documentation with examples and a new guide! 📓 ✨ 

**Data Source:**
```
data "hcp_vault_cluster" "example" {
  cluster_id = "vault-cluster"
}
```

**Import:**
```
terraform import hcp_vault_cluster.example vault-cluster
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccVaultCluster'
--- PASS: TestAccVaultCluster (702.59s)
PASS
```
