### PR TITLE
[HCS-1831] Remove extraneous protocol from fqdn string if present

### DIFF
--- a/internal/provider/data_source_consul_agent_helm_config.go
+++ b/internal/provider/data_source_consul_agent_helm_config.go
@@ -190,6 +190,19 @@ func generateHelmConfig(name, datacenter, fqdn string, retryJoin []string, expos
 	// replace any escaped double-quotes with single quotes
 	rj = strings.Replace(rj, "\"", "'", -1)
 
+	// trim off any leading `https://` protocol if present.
+	// this protocol will be prepended as expected when
+	// the helm config string is generated.
+	//
+	// this string is trimmed here to handle both the cases
+	// of when the provided fqdn string has the leading
+	// protocol and does not.
+	//
+	// trimming the leading protocol here will guarantee a
+	// valid URL is generated when prepended in the
+	// helmConfigTemplate.
+	fqdn = strings.TrimPrefix(fqdn, "https://")
+
 	return fmt.Sprintf(helmConfigTemplate,
 		datacenter,
 		lower, lower, lower,


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md
-->

### :hammer_and_wrench: Description

This PR updates the logic for generating the `k8sAuthMethodHost` within the `hcp_consul_agent_helm_config` data source.

As it stands now we always prepend an `https://` protocol to the `kubernetes_endpoint` string provided. This updated logic will strip a leading `https://` from the `kubernetes_endpoint` string and will leverage the existing logic to prepend the protocol again as needed.  This will allow for handling of both cases of this string having a leading `https://` and not.


### :building_construction: Local testing
With the following `main.tf`

```
<PROVIDER set-up>

data "hcp_consul_agent_helm_config" "test" {
  cluster_id = "consul-cluster"
  kubernetes_endpoint = "https://catter.com"
}
```

resulted with the following in `terraform.state` file:
```
...
k8sAuthMethodHost: https://catter.com:443
...
```

The above output is seen with the following `main.tf` as well:

```
<PROVIDER set-up>

data "hcp_consul_agent_helm_config" "test" {
  cluster_id = "consul-cluster"
  kubernetes_endpoint = "catter.com"
}
```