### PR TITLE
HCS-1805-hotfix: Set "computed=true" option for the vm size

### DIFF
--- a/docs/data-sources/consul_cluster.md
+++ b/docs/data-sources/consul_cluster.md
@@ -49,7 +49,7 @@ data "hcp_consul_cluster" "example" {
 - **region** (String) The region where the HCP Consul cluster is located.
 - **scale** (Number) The the number of Consul server nodes in the cluster.
 - **self_link** (String) A unique URL identifying the HCP Consul cluster.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`. For more details - https://cloud.hashicorp.com/pricing/consul
 - **tier** (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development` and `standard` are available at this time.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -42,7 +42,7 @@ resource "hcp_consul_cluster" "example" {
 - **min_consul_version** (String) The minimum Consul version of the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
 - **primary_link** (String) The `self_link` of the HCP Consul cluster which is the primary in the federation setup with this HCP Consul cluster. If not specified, it is a standalone cluster.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint for the Consul UI. Defaults to false.
-- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.
+- **size** (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`. For more details - https://cloud.hashicorp.com/pricing/consul
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-only

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -118,7 +118,7 @@ func dataSourceConsulCluster() *schema.Resource {
 				Computed:    true,
 			},
 			"size": {
-				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.",
+				Description: "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`. For more details - https://cloud.hashicorp.com/pricing/consul",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -119,11 +119,11 @@ func resourceConsulCluster() *schema.Resource {
 				ForceNew:    true,
 			},
 			"size": {
-				// TODO: Add a link to the HCP Consul size details when it is available here - https://cloud.hashicorp.com/pricing/consul#FAQ
-				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`.",
+				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`. For more details - https://cloud.hashicorp.com/pricing/consul",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
+				Computed:         true,
 				ValidateDiagFunc: validateConsulClusterSize,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					return strings.ToLower(old) == strings.ToLower(new)


### PR DESCRIPTION
- `size` is an optional field on Consul cluster create. If customers have not specified it in the config, without the "computed=true" option it forces recreation of the cluster.
- Also updated the size desc to include the link with more details. 

