### PR TITLE
added self_link to hvn, peering and tgw attachment

### DIFF
--- a/docs/data-sources/aws_network_peering.md
+++ b/docs/data-sources/aws_network_peering.md
@@ -43,6 +43,7 @@ data "hcp_aws_network_peering" "test" {
 - **peer_vpc_region** (String) The region of the peer VPC in AWS.
 - **project_id** (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - **provider_peering_id** (String) The peering connection ID used by AWS.
+- **self_link** (String) A unique URL identifying the network peering.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/data-sources/aws_transit_gateway_attachment.md
+++ b/docs/data-sources/aws_transit_gateway_attachment.md
@@ -42,6 +42,7 @@ data "hcp_aws_transit_gateway_attachment" "test" {
 - **organization_id** (String) The ID of the HCP organization where the transit gateway attachment is located. Always matches the HVN's organization.
 - **project_id** (String) The ID of the HCP project where the transit gateway attachment is located. Always matches the HVN's project.
 - **provider_transit_gateway_attachment_id** (String) The transit gateway attachment ID used by AWS.
+- **self_link** (String) A unique URL identifying the transit gateway attachment.
 - **state** (String) The state of the transit gateway attachment.
 - **transit_gateway_id** (String) The ID of the user-owned transit gateway in AWS.
 

--- a/docs/data-sources/hvn.md
+++ b/docs/data-sources/hvn.md
@@ -39,6 +39,7 @@ data "hcp_hvn" "example" {
 - **project_id** (String) The ID of the HCP project where the HVN is located.
 - **provider_account_id** (String) The provider account ID where the HVN is located.
 - **region** (String) The region where the HVN is located.
+- **self_link** (String) A unique URL identifying the HVN.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/aws_network_peering.md
+++ b/docs/resources/aws_network_peering.md
@@ -70,6 +70,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 - **organization_id** (String) The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.
 - **project_id** (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - **provider_peering_id** (String) The peering connection ID used by AWS.
+- **self_link** (String) A unique URL identifying the network peering.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -93,6 +93,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
 - **organization_id** (String) The ID of the HCP organization where the transit gateway attachment is located. Always matches the HVN's organization.
 - **project_id** (String) The ID of the HCP project where the transit gateway attachment is located. Always matches the HVN's project.
 - **provider_transit_gateway_attachment_id** (String) The transit gateway attachment ID used by AWS.
+- **self_link** (String) A unique URL identifying the transit gateway attachment.
 - **state** (String) The state of the transit gateway attachment.
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -42,6 +42,7 @@ resource "hcp_hvn" "example" {
 - **organization_id** (String) The ID of the HCP organization where the HVN is located.
 - **project_id** (String) The ID of the HCP project where the HVN is located.
 - **provider_account_id** (String) The provider account ID where the HVN is located.
+- **self_link** (String) A unique URL identifying the HVN.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -77,6 +77,11 @@ func dataSourceAwsNetworkPeering() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"self_link": {
+				Description: "A unique URL identifying the network peering.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_aws_transit_gateway_attachment.go
+++ b/internal/provider/data_source_aws_transit_gateway_attachment.go
@@ -83,6 +83,11 @@ func dataSourceAwsTransitGatewayAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"self_link": {
+				Description: "A unique URL identifying the transit gateway attachment.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/internal/provider/data_source_hvn.go
+++ b/internal/provider/data_source_hvn.go
@@ -62,6 +62,11 @@ func dataSourceHvn() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"self_link": {
+				Description: "A unique URL identifying the HVN.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -108,6 +108,11 @@ func resourceAwsNetworkPeering() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"self_link": {
+				Description: "A unique URL identifying the network peering.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -327,6 +332,15 @@ func setPeeringResourceData(d *schema.ResourceData, peering *networkmodels.Hashi
 		return err
 	}
 	if err := d.Set("expires_at", peering.ExpiresAt.String()); err != nil {
+		return err
+	}
+
+	link := newLink(peering.Hvn.Location, PeeringResourceType, peering.ID)
+	selfLink, err := linkURL(link)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("self_link", selfLink); err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -107,6 +107,11 @@ func resourceAwsTransitGatewayAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"self_link": {
+				Description: "A unique URL identifying the transit gateway attachment.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -324,6 +329,15 @@ func setTransitGatewayAttachmentResourceData(d *schema.ResourceData, tgwAtt *net
 		return err
 	}
 	if err := d.Set("expires_at", tgwAtt.ExpiresAt.String()); err != nil {
+		return err
+	}
+
+	link := newLink(tgwAtt.Location, TgwAttachmentResourceType, tgwAtt.ID)
+	selfLink, err := linkURL(link)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("self_link", selfLink); err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -99,6 +99,11 @@ func resourceHvn() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"self_link": {
+				Description: "A unique URL identifying the HVN.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -273,6 +278,15 @@ func setHvnResourceData(d *schema.ResourceData, hvn *networkmodels.HashicorpClou
 		return err
 	}
 	if err := d.Set("provider_account_id", hvn.ProviderNetworkData.AwsNetworkData.AccountID); err != nil {
+		return err
+	}
+
+	link := newLink(hvn.Location, HvnResourceType, hvn.ID)
+	selfLink, err := linkURL(link)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("self_link", selfLink); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### :hammer_and_wrench: Description

Added `self_link` attribute to hvn, peering and tgw attachment resources and datasources.

