### PR TITLE
Make peer_vpc_cidr_block(peering resource) and destination_cidrs(TGW attachment resource) optional 

### DIFF
--- a/docs/resources/aws_network_peering.md
+++ b/docs/resources/aws_network_peering.md
@@ -53,13 +53,13 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 
 - **hvn_id** (String) The ID of the HashiCorp Virtual Network (HVN).
 - **peer_account_id** (String) The account ID of the peer VPC in AWS.
-- **peer_vpc_cidr_block** (String) The CIDR range of the peer VPC in AWS.
 - **peer_vpc_id** (String) The ID of the peer VPC in AWS.
 - **peer_vpc_region** (String) The region of the peer VPC in AWS.
 
 ### Optional
 
 - **id** (String) The ID of this resource.
+- **peer_vpc_cidr_block** (String) The CIDR range of the peer VPC in AWS.
 - **peering_id** (String) The ID of the network peering.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -75,7 +75,6 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
 
 ### Required
 
-- **destination_cidrs** (List of String) The list of associated CIDR ranges. Traffic from these CIDRs will be allowed for all resources in the HVN. Traffic to these CIDRs will be routed into this transit gateway attachment.
 - **hvn_id** (String) The ID of the HashiCorp Virtual Network (HVN).
 - **resource_share_arn** (String, Sensitive) The Amazon Resource Name (ARN) of the Resource Share that is needed to grant HCP access to the transit gateway in AWS. The Resource Share should be associated with the HCP AWS account principal (see [aws_ram_principal_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association)) and the transit gateway resource (see [aws_ram_resource_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_resource_association))
 - **transit_gateway_attachment_id** (String) The user-settable name of the transit gateway attachment in HCP.
@@ -83,6 +82,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
 
 ### Optional
 
+- **destination_cidrs** (List of String) The list of associated CIDR ranges. Traffic from these CIDRs will be allowed for all resources in the HVN. Traffic to these CIDRs will be routed into this transit gateway attachment.
 - **id** (String) The ID of this resource.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -66,14 +66,14 @@ func resourceAwsNetworkPeering() *schema.Resource {
 					return strings.ToLower(old) == strings.ToLower(new)
 				},
 			},
+			// Optional inputs
 			"peer_vpc_cidr_block": {
 				Description:  "The CIDR range of the peer VPC in AWS.",
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IsCIDR,
 			},
-			// Optional inputs
 			"peering_id": {
 				Description:      "The ID of the network peering.",
 				Type:             schema.TypeString,

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -65,6 +65,7 @@ func resourceAwsTransitGatewayAttachment() *schema.Resource {
 				Sensitive:   true,
 				ForceNew:    true,
 			},
+			// Optional inputs
 			"destination_cidrs": {
 				Description: "The list of associated CIDR ranges. Traffic from these CIDRs will be allowed for all resources in the HVN. Traffic to these CIDRs will be routed into this transit gateway attachment.",
 				Type:        schema.TypeList,
@@ -72,8 +73,7 @@ func resourceAwsTransitGatewayAttachment() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.IsCIDR,
 				},
-				Required: true,
-				MinItems: 1,
+				Optional: true,
 				ForceNew: true,
 			},
 			// Computed outputs


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/HCCP-91

peer_vpc_cidr_block(peering resource) and destination_cidrs(TGW attachment resource) are optional instead of mandatory.

Prepartory PR for HCCP-91 HVN route resource. 