### PR TITLE
Set ForceNew to false for public_endpoint

### DIFF
--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -62,7 +62,7 @@ func resourceVaultCluster() *schema.Resource {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"min_vault_version": {
 				Description:      "The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.",


### PR DESCRIPTION
I don't believe changing public_endpoint requires a recreation of the cluster. At least it doesn't in the UI
