### PR TITLE
HCPE-1032: Add Consul cluster snapshot acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.env*
 
 website/vendor
 

--- a/internal/provider/resource_consul_snapshot_test.go
+++ b/internal/provider/resource_consul_snapshot_test.go
@@ -1,0 +1,127 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+)
+
+var testAccConsulSnapshotConfig = `
+resource "hcp_hvn" "test" {
+	hvn_id         = "test-hvn"
+	cloud_provider = "aws"
+	region         = "us-west-2"
+}
+
+resource "hcp_consul_cluster" "test" {
+	cluster_id = "test-consul-cluster"
+	hvn_id     = hcp_hvn.test.hvn_id
+	tier       = "development"
+}
+
+resource "hcp_consul_snapshot" "test" {
+	cluster_id    = hcp_consul_cluster.test.cluster_id
+	snapshot_name = "test"
+}`
+
+func TestAccConsulSnapshot(t *testing.T) {
+	resourceName := "hcp_consul_snapshot.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckConsulSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig(testAccConsulSnapshotConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConsulSnapshotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_name", "test"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "snapshot_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "size"),
+					resource.TestCheckResourceAttrSet(resourceName, "consul_version"),
+					resource.TestCheckNoResourceAttr(resourceName, "restored_at"), // Not a restored snapshot
+				),
+			},
+			{
+				Config: testConfig(testAccConsulSnapshotConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConsulSnapshotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_name", "test"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "snapshot_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "size"),
+					resource.TestCheckResourceAttrSet(resourceName, "consul_version"),
+					resource.TestCheckNoResourceAttr(resourceName, "restored_at"), // Not a restored snapshot
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckConsulSnapshotExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		client := testAccProvider.Meta().(*clients.Client)
+
+		link, err := buildLinkFromURL(id, ConsulSnapshotResourceType, client.Config.OrganizationID)
+		if err != nil {
+			return fmt.Errorf("unable to build link for %q: %v", id, err)
+		}
+
+		snapshotID := link.ID
+		loc := link.Location
+
+		if _, err := clients.GetSnapshotByID(context.Background(), client, loc, snapshotID); err != nil {
+			return fmt.Errorf("unable to read Consul snapshot %q: %v", id, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckConsulSnapshotDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*clients.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "hcp_consul_snapshot":
+			id := rs.Primary.ID
+
+			link, err := buildLinkFromURL(id, ConsulSnapshotResourceType, client.Config.OrganizationID)
+			if err != nil {
+				return fmt.Errorf("unable to build link for %q: %v", id, err)
+			}
+
+			snapshotID := link.ID
+			loc := link.Location
+
+			_, err = clients.GetSnapshotByID(context.Background(), client, loc, snapshotID)
+			if err == nil || !clients.IsResponseCodeNotFound(err) {
+				return fmt.Errorf("didn't get a 404 when reading destroyed Consul snapshot %q: %v", id, err)
+			}
+		default:
+			continue
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

Adds acceptance tests for Consul cluster snapshots

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality? **No**
- [x] Have you added an acceptance test for the functionality being added? **No new features, just new tests 😄**
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccConsulSnapshot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccConsulSnapshot -timeout 120m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccConsulSnapshot
--- PASS: TestAccConsulSnapshot (567.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	572.920s
```
