### PR TITLE
remove v0.4.0 warning and replace with upcoming migration in index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+IMPROVEMENTS:
+* docs: updates banner on index page to warn of upcoming breaking changes (#134)
+* resource/hcp_consul_cluster_snapshot_test: add Consul cluster snapshot acceptance test (#126)
+
 ## 0.6.0 (May 10, 2021)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-~> **Known Issue:** There is a known issue with v0.4.0 of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Consul cluster, which could result in data loss. 
-See the Release Notes on Github for more detail. Please upgrade to the patch v0.4.1 or beyond to avoid this issue.
+~> **Upcoming Migration:** The upcoming release of HVN Routes will include breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This PR](https://github.com/hashicorp/terraform-provider-hcp/pull/128) contains a migration guide.
+Please pin to the current version to avoid disruption until you are ready to migrate.
 
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -9,8 +9,8 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-~> **Known Issue:** There is a known issue with v0.4.0 of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Consul cluster, which could result in data loss. 
-See the Release Notes on Github for more detail. Please upgrade to the patch v0.4.1 or beyond to avoid this issue.
+~> **Upcoming Migration:** The upcoming release of HVN Routes will include breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This PR](https://github.com/hashicorp/terraform-provider-hcp/pull/128) contains a migration guide.
+Please pin to the current version to avoid disruption until you are ready to migrate.
 
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
 


### PR DESCRIPTION
### :hammer_and_wrench: Description
This PR removes the v0.4.0 warning from the registry index page. The warning will stay in the changelog forever.

In its place, I've added a warning about the upcoming breaking changes in our networking resources. 

I'll be releasing publishing these changes to the registry as a patch, v0.6.1. Since there are no feature changes in this tiny release, I did not update the version used in our examples.