### PR TITLE
added dedicated timeout for hvn route delete

### DIFF
--- a/docs/resources/hvn_route.md
+++ b/docs/resources/hvn_route.md
@@ -80,6 +80,7 @@ Optional:
 
 - **create** (String)
 - **default** (String)
+- **delete** (String)
 
 ## Import
 

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -18,6 +18,7 @@ import (
 
 var hvnRouteDefaultTimeout = time.Minute * 1
 var hvnRouteCreateTimeout = time.Minute * 35
+var hvnRouteDeleteTimeout = time.Minute * 25
 
 func resourceHvnRoute() *schema.Resource {
 	return &schema.Resource{
@@ -29,6 +30,7 @@ func resourceHvnRoute() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Default: &hvnRouteDefaultTimeout,
 			Create:  &hvnRouteCreateTimeout,
+			Delete:  &hvnRouteDeleteTimeout,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceHVNRouteImport,


### PR DESCRIPTION
Added timeout for HVN route delete, otherwise on destroy it was failing with error like:
```
Error: unable to delete HVN route (tgw-route-1): context canceled waiting for delete HVN route operation (72667030-7343-4592-9a88-93d9f7cf0473) to complete
```