### PR TITLE
Test creation on Consul cluster root token

### DIFF
--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -26,10 +26,15 @@ resource "hcp_consul_cluster" "test" {
 data "hcp_consul_cluster" "test" {
 	cluster_id = hcp_consul_cluster.test.cluster_id
 }
+
+resource "hcp_consul_cluster_root_token" "test" {
+	cluster_id = hcp_consul_cluster.test.cluster_id
+}
 `
 
-// This includes tests against both the resource and the corresponding datasource
-// to shorten testing time.
+// This includes tests against both the resource, the corresponding datasource,
+// and creation of the Consul cluster root token resource in order to shorten
+// testing time.
 func TestAccConsulCluster(t *testing.T) {
 	resourceName := "hcp_consul_cluster.test"
 	dataSourceName := "data.hcp_consul_cluster.test"

--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -38,6 +38,7 @@ resource "hcp_consul_cluster_root_token" "test" {
 func TestAccConsulCluster(t *testing.T) {
 	resourceName := "hcp_consul_cluster.test"
 	dataSourceName := "data.hcp_consul_cluster.test"
+	rootTokenResourceName := "hcp_consul_cluster_root_token.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t, false) },
@@ -145,6 +146,16 @@ func TestAccConsulCluster(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "size", dataSourceName, "size"),
 					resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
 					resource.TestCheckResourceAttrPair(resourceName, "primary_link", dataSourceName, "primary_link"),
+				),
+			},
+			// Tests root token
+			{
+				Config: testConfig(testAccConsulClusterConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rootTokenResourceName, "cluster_id", "test-consul-cluster"),
+					resource.TestCheckResourceAttrSet(rootTokenResourceName, "accessor_id"),
+					resource.TestCheckResourceAttrSet(rootTokenResourceName, "secret_id"),
+					resource.TestCheckResourceAttrSet(rootTokenResourceName, "kubernetes_secret"),
 				),
 			},
 		},


### PR DESCRIPTION
### :hammer_and_wrench: Description

Because the root token has a no-op for reading the resource, we only
create the token to ensure that it does not error upon creation.
<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality? **no**
- [ ] Have you added an acceptance test for the functionality being added? **no new functionality**
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccConsulCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccConsulCluster -timeout 120m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.190s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.150s [no tests to run]
=== RUN   TestAccConsulCluster
--- PASS: TestAccConsulCluster (585.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	586.387s
```
