### PR TITLE
add team ownership to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,16 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
 *       @hashicorp/cloud-experiences-go
+
+# all Consul resources and clients are owned by the cloud-consul team
+*consul* @hashicorp/cloud-consul @hashicorp/cloud-experiences-go
+/internal/consul/ @hashicorp/cloud-consul @hashicorp/cloud-experiences-go
+
+# all Vault resources and clients are owned by the vault-cloud team
+*vault* @hashicorp/vault-cloud @hashicorp/cloud-experiences-go
+
+# all Networking resources and clients are owned by the cloud-control-plane team
+*hvn* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+*aws* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+*tgw* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+*peering* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go


### PR DESCRIPTION
### :hammer_and_wrench: Description

Updates the CODEOWNERS file to include backend team reviewers on their relevant files. I've tested the file syntax out by messing with `.gitignore` locally, so I'm fairly confident they'll target the right files. But fine-tuning may be needed. 🤓 