### PR TITLE
Update changelog for 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 Please remove any functions that adjust the output from the `vault_private_endpoint_url`, `vault_public_endpoint_url`, `consul_private_endpoint_url`, and `consul_public_endpoint_url` when upgrading to this version. ⚠️
 
 IMPROVEMENTS:
-* resource/vault_cluster: `tier` is now an optional input (#144)
+* resource/vault_cluster: `tier` is now an optional input, with the options `dev`, `standard_small`, `standard_medium`, and `standard_large` (#144)
+* resource/consul_cluster: `plus` is now available as a `tier` option (#148)
 * tests: expands acceptance test coverage to data sources and dependent resources (#135, #142, #150)
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ⚠️ Note: This version fixes a bug where the Consul and Vault clusters' `*_endpoint_url` outputs did not return complete URLs. This may result in issues for existing clusters whose endpoint urls are already adjusted by a workaround. ⚠️
 
+IMPROVEMENTS:
+* resource/vault_cluster: `tier` is now an optional input (#144)
+* tests: expands acceptance test coverage to data sources and dependent resources (#135, #142, #150)
+
 FIXES:
 * resource/consul_cluster: returns complete endpoint URLs (#145)
 * resource/vault_cluster: returns complete endpoint URLs (#145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 0.8.0 (Unreleased)
 
 ⚠️ Note: This version fixes a bug where the Consul and Vault clusters' `*_endpoint_url` outputs did not return complete URLs. This may result in a breaking change for existing clusters whose endpoint URLs are already adjusted to be a full URL with string helpers. 
-Please remove any functions that adjust the output from the `vault_private_endpoint_url`, `vault_public_endpoint_url`, `consul_private_endpoint_url`, and `consul_public_endpoint_url` when upgrading to this version. ⚠️
+Please remove any functions that adjust the output of the `vault_private_endpoint_url`, `vault_public_endpoint_url`, `consul_private_endpoint_url`, and `consul_public_endpoint_url` when upgrading to this version. ⚠️
 
 IMPROVEMENTS:
-* resource/vault_cluster: `tier` is now an optional input, with the options `dev`, `standard_small`, `standard_medium`, and `standard_large` (#144)
+* resource/vault_cluster: `tier` is now an optional input, with the options `dev`, `standard_small`, `standard_medium`, and `standard_large` (#144) (our first open-source contribution - thanks @waxb!)
 * resource/consul_cluster: `plus` is now available as a `tier` option (#148)
 * tests: expands acceptance test coverage to data sources and dependent resources (#135, #142, #150)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## 0.8.0 (Unreleased)
 
-⚠️ Note: This version fixes a bug where the Consul and Vault clusters' `*_endpoint_url` outputs did not return complete URLs. This may result in issues for existing clusters whose endpoint urls are already adjusted by a workaround. ⚠️
+⚠️ Note: This version fixes a bug where the Consul and Vault clusters' `*_endpoint_url` outputs did not return complete URLs. This may result in a breaking change for existing clusters whose endpoint URLs are already adjusted to be a full URL with string helpers. 
+Please remove any functions that adjust the output from the `vault_private_endpoint_url`, `vault_public_endpoint_url`, `consul_private_endpoint_url`, and `consul_public_endpoint_url` when upgrading to this version. ⚠️
 
 IMPROVEMENTS:
 * resource/vault_cluster: `tier` is now an optional input (#144)
 * tests: expands acceptance test coverage to data sources and dependent resources (#135, #142, #150)
 
-FIXES:
+BREAKING CHANGES:
 * resource/consul_cluster: returns complete endpoint URLs (#145)
 * resource/vault_cluster: returns complete endpoint URLs (#145)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ⚠️ Note: This version fixes a bug where the Consul and Vault clusters' `*_endpoint_url` outputs did not return complete URLs. This may result in a breaking change for existing clusters whose endpoint URLs are already adjusted to be a full URL with string helpers. 
 Please remove any functions that adjust the output of the `vault_private_endpoint_url`, `vault_public_endpoint_url`, `consul_private_endpoint_url`, and `consul_public_endpoint_url` when upgrading to this version. ⚠️
 
+For example, your Vault provider configuration might need to change:
+
+```
+# before
+provider "vault" {
+  address = join("", ["https://", hcp_vault_cluster.example.vault_public_endpoint_url, ":8200"])
+}
+
+# after
+provider "vault" {
+  address = hcp_vault_cluster.example.vault_public_endpoint_url
+}
+```
+
 IMPROVEMENTS:
 * resource/vault_cluster: `tier` is now an optional input, with the options `dev`, `standard_small`, `standard_medium`, and `standard_large` (#144) (our first open-source contribution - thanks @waxb!)
 * resource/consul_cluster: `plus` is now available as a `tier` option (#148)

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.7.0"
+      version = "~> 0.8.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.7.0"
+      version = "~> 0.8.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

In preparation for release of 0.8.0!

Output from acceptance testing:

```
$ make testacc

--- PASS: TestAccHvnPeering (224.95s)
--- PASS: TestAccTGWAttachment (514.70s)
--- PASS: TestAccConsulCluster (543.60s)
--- PASS: TestAccConsulSnapshot (611.61s)
--- PASS: TestAccHvnRoute (220.75s)
--- PASS: TestAccHvn (74.41s)
--- PASS: TestAccVaultCluster (653.02s)

ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	2843.669s
```
