### PR TITLE
add note about configuring Consul provider

### DIFF
--- a/docs/guides/consul-root-token.md
+++ b/docs/guides/consul-root-token.md
@@ -31,3 +31,12 @@ resource "hcp_consul_cluster_root_token" "example" {
   cluster_id = hcp_consul_cluster.example.cluster_id
 }
 ```
+
+The secret ID of this root token can be used to configure the Consul provider.
+
+```
+provider "consul" {
+  address    = "example.consul.io:80"
+  token      = hcp_consul_cluster_root_token.example.root_token_secret_id
+}
+```

--- a/templates/guides/consul-root-token.md.tmpl
+++ b/templates/guides/consul-root-token.md.tmpl
@@ -12,3 +12,12 @@ or is managed outside of Terraform. It is important to note that when creating a
 the existing root token will be invalidated.
 
 {{ tffile "examples/guides/consul_cluster_root_token/main.tf" }}
+
+The secret ID of this root token can be used to configure the Consul provider.
+
+```
+provider "consul" {
+  address    = "example.consul.io:80"
+  token      = hcp_consul_cluster_root_token.example.root_token_secret_id
+}
+```


### PR DESCRIPTION
### :hammer_and_wrench: Description

This adds some additional guidance around the Consul root token resource and how it can be used with the Consul provider.

### 🔗 Related Issues

https://github.com/hashicorp/terraform-provider-hcp/issues/131