### PR TITLE
HCPE-1281: add design doc on networking resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ See the [HashiCorp Cloud Platform (HCP) Provider documentation](https://registry
 
 See the [`contributing`](contributing/) directory for more developer documentation.
 
+## Design
+
+See the [`design`](design/) for documents capturing certain key design decisions made for this provider as a platform.
+
 ## Example
 
 Below is a complex example that creates a HashiCorp Virtual Network (HVN), an HCP Consul cluster within that HVN, and peers the HVN to an AWS VPC.

--- a/design/networking-abstractions.md
+++ b/design/networking-abstractions.md
@@ -1,0 +1,89 @@
+# Networking Abstractions
+
+During early development of the HCP provider, the question of how much abstraction is needed for our networking resources came up. Knowing that our networking resources will be used with various cloud providers, what is the right level of abstraction to use when designing their resource interfaces? What terminology should we use?
+
+We narrowed down to two options:
+
+## 1. Multiple resources, each one specific to a cloud provider
+
+```hcl
+resource "hcp_hvn" "example" {
+  hvn_id         = "my-favorite-hvn"
+  cloud_provider = "aws"
+  region         = "us-west-2"
+}
+
+resource "hcp_aws_peering_connection" "example" {
+   hvn_id                = hcp_hvn.example.hvn_id
+   peer_vpc_id           = "my-aws-network"
+   aws_specific_field    = ...
+   ...
+}
+
+resource "hcp_gcp_peering_connection" "example" {
+   hvn_id                = hcp_hvn.example.hvn_id
+   peer_network_id       = "my-google-network"
+   gcp_specific_field    = ...
+   ...
+}
+
+resource "hcp_azure_peering_connection" "example" {
+   hvn_id                        = hcp_hvn.example.hvn_id
+   virtual_network_peering_name  = "my-azure-network"
+   azure_specific_field          = ...
+   ...
+}
+```
+
+## 2. A single resource that accepts a block of cloud provider config
+
+```hcl
+resource "hcp_hvn" "example" {
+  hvn_id          = "my-favorite-hvn"
+  cloud_provider  = "aws"
+  region          = "us-west-2"
+}
+
+resource "hcp_network_peering" "example" {
+  hvn_id               = hcp_hvn.example.hvn_id
+    
+  aws {
+    target_account_id  = "123456789012"
+    peer_vpc_id        = "vpc-0054c413d7fb111a1"
+    vpc_region         = "us-west-2"
+    vpc_cidr_block     = "172.25.8.0/20"
+  }
+}
+
+resource "hcp_network_peering" "example" {
+  hvn_id                  = hcp_hvn.example.hvn_id
+    
+  gcp { 
+    peer_network_id       = "my-google-network"
+    gcp_specific_field    = ...
+    ...
+  }
+}
+  
+resource "hcp_network_peering" "example" {
+  hvn_id                          = hcp_hvn.example.hvn_id
+    
+  azure { 
+    virtual_network_peering_name  = "my-azure-network"
+    azure_specific_field          = ...
+    ... 
+   }
+}
+```
+
+After some user research and discussion with product, the team decided to go with option 1: Multiple resources, each one specific to a cloud provider support by HCP. This decision was made in order to conform with familiar HCL patterns in Terraform today.
+
+It also allows us to tailor each peering resource to its corresponding cloud provider resource. For example, the peering resources in each provider use different words to refer to the network being connected. AWS uses "vpc", Google uses "network", and Azure uses "virtual network". Rather than pick our side in this semantic battle, our networking resources can be designed to match each cloud provider. This reduces the cognitive load of translating between different synonymous terms for users.
+
+Finally, the Terraform Provider SDK does not fully support the block input use case, due to legacy constraints. Separate resources allow us to avoid building a work-around validation system that would be difficult to make obvious through documentation.
+
+Currently, this pattern has been applied to the peering connection and transit gateway attachment resources.
+
+### Exception
+
+There is an exception to this rule: HashiCorp Virtual Networks (HVNs). HVNs and any other networking resource that is designed solely for use within the context of HCP should be represented in the TF provider as a singular cloud provider-agnostic resource that accepts a cloud provider as input.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-~> **Upcoming Migration:** The upcoming release of HVN Routes in v0.7.0 will include breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
+~> **Migration Required:** The release of HVN Routes in v0.7.0 includes breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
 Please pin to the previous version to avoid disruption until you are ready to migrate.
 
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -20,6 +20,9 @@ var peeringDefaultTimeout = time.Minute * 1
 var peeringCreateTimeout = time.Minute * 35
 var peeringDeleteTimeout = time.Minute * 35
 
+// The team decided to create a separate peering resource for each cloud provider supported by HCP, rather than a single peering resource that
+// can be configured with different cloud providers, like the HVN resource. See more about this decision under design/networking-abstractions.md.
+
 func resourceAwsNetworkPeering() *schema.Resource {
 	return &schema.Resource{
 		Description: "The AWS network peering resource allows you to manage a network peering between an HVN and a peer AWS VPC.",

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -20,6 +20,9 @@ var tgwDefaultTimeout = time.Minute * 1
 var tgwCreateTimeout = time.Minute * 35
 var tgwDeleteTimeout = time.Minute * 35
 
+// The team decided to create a separate transit gateway attachment resource for each cloud provider supported by HCP, rather than a single transit gateway attachment resource that
+// can be configured with different cloud providers, like the HVN resource. See more about this decision under design/networking-abstractions.md.
+
 func resourceAwsTransitGatewayAttachment() *schema.Resource {
 	return &schema.Resource{
 		Description: "The AWS transit gateway attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.",

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-~> **Upcoming Migration:** The upcoming release of HVN Routes in v0.7.0 will include breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
+~> **Migration Required:** The release of HVN Routes in v0.7.0 includes breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
 Please pin to the previous version to avoid disruption until you are ready to migrate.
 
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR sets up a new directory called `design`, where we save records of architectural designs made as we implement the HCP provider. The first such design doc is on how we decided to handle abstractions over our networking resources.

Also includes a bonus wording fix in the overview banner.