### PR TITLE
Fix terraform updates for min_consul_version after revert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.20.1
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
 	github.com/hashicorp/hcp-sdk-go v0.10.0
 	github.com/hashicorp/terraform-exec v0.13.3 // indirect

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -94,7 +94,7 @@ func resourceConsulCluster() *schema.Resource {
 				ValidateDiagFunc: validateSemVer,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					// Suppress diff for non specified value
-					if new == "" {
+					if new == "" || old == "" {
 						return true
 					}
 

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -103,7 +103,7 @@ func resourceConsulCluster() *schema.Resource {
 					log.Printf("[DEBUG] Actual Consul Version %v", old)
 					log.Printf("[DEBUG] Current TF Version %v", new)
 					// suppres diff if the specified min_consul_version is <= to the actual consul version
-					return currentTFVersion.LessThanOrEqual(actualConsulVersion) || new == ""
+					return currentTFVersion.LessThanOrEqual(actualConsulVersion)
 				},
 			},
 			"datacenter": {

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -95,7 +95,7 @@ func resourceConsulCluster() *schema.Resource {
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					// Suppress diff for non specified value
 					if new == "" {
-						return false
+						return true
 					}
 
 					actualConsulVersion := version.Must(version.NewVersion(old))

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-version"
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -92,9 +93,17 @@ func resourceConsulCluster() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validateSemVer,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					// Suppress diff is normalized versions match OR min_consul_version is removed from the resource
-					// since min_consul_version is required in order to upgrade the cluster to a new Consul version.
-					return input.NormalizeVersion(old) == input.NormalizeVersion(new) || new == ""
+					// Suppress diff for non specified value
+					if new == "" {
+						return false
+					}
+
+					actualConsulVersion := version.Must(version.NewVersion(old))
+					currentTFVersion := version.Must(version.NewVersion(new))
+					log.Printf("[DEBUG] Actual Consul Version %v", old)
+					log.Printf("[DEBUG] Current TF Version %v", new)
+					// suppres diff if the specified min_consul_version is <= to the actual consul version
+					return currentTFVersion.LessThanOrEqual(actualConsulVersion) || new == ""
 				},
 			},
 			"datacenter": {
@@ -458,6 +467,10 @@ func setConsulClusterResourceData(d *schema.ResourceData, cluster *consulmodels.
 	}
 
 	if err := d.Set("consul_version", cluster.ConsulVersion); err != nil {
+		return err
+	}
+
+	if err := d.Set("min_consul_version", cluster.ConsulVersion); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If an update fails subsequent terraform runs consider the state correct. This is because the current cluster version is not validated against the min_consul_version.

### :hammer_and_wrench: Description

Added  min_consul_version to read and set it to the consul_version. We can suppress the diff when the cluster version is greater than or equal to the what is set in the terraform by the user.

### :building_construction: Acceptance tests

- ~~[ ] Are there any feature flags that are required to use this functionality?~~
- ~~[ ] Have you added an acceptance test for the functionality being added?~~
- [X] Have you run the acceptance tests on this branch?
-  Ran manual tests extensively in cases where user setup would cause update errors. Validated that it works correctly.
