### PR TITLE
HCS-2061: Add size upgrade field for consul cluster update

### DIFF
--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -165,27 +165,14 @@ func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedm
 // UpdateConsulCluster will make a call to the Consul service to initiate the update Consul
 // cluster workflow.
 func UpdateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	clusterID, newConsulVersion string) (*consulmodels.HashicorpCloudConsul20210204UpdateResponse, error) {
-
-	cluster := consulmodels.HashicorpCloudConsul20210204Cluster{
-		ConsulVersion: newConsulVersion,
-		ID:            clusterID,
-		Location: &sharedmodels.HashicorpCloudLocationLocation{
-			ProjectID:      loc.ProjectID,
-			OrganizationID: loc.OrganizationID,
-			Region: &sharedmodels.HashicorpCloudLocationRegion{
-				Region:   loc.Region.Region,
-				Provider: loc.Region.Provider,
-			},
-		},
-	}
+	newCluster *consulmodels.HashicorpCloudConsul20210204Cluster) (*consulmodels.HashicorpCloudConsul20210204UpdateResponse, error) {
 
 	updateParams := consul_service.NewUpdateParams()
 	updateParams.Context = ctx
-	updateParams.ClusterID = cluster.ID
+	updateParams.ClusterID = newCluster.ID
 	updateParams.ClusterLocationProjectID = loc.ProjectID
 	updateParams.ClusterLocationOrganizationID = loc.OrganizationID
-	updateParams.Body = &cluster
+	updateParams.Body = newCluster
 
 	// Invoke update cluster endpoint
 	updateResp, err := client.Consul.Update(updateParams, nil)

--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -164,14 +164,14 @@ func ListConsulUpgradeVersions(ctx context.Context, client *Client, loc *sharedm
 
 // UpdateConsulCluster will make a call to the Consul service to initiate the update Consul
 // cluster workflow.
-func UpdateConsulCluster(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
+func UpdateConsulCluster(ctx context.Context, client *Client,
 	newCluster *consulmodels.HashicorpCloudConsul20210204Cluster) (*consulmodels.HashicorpCloudConsul20210204UpdateResponse, error) {
 
 	updateParams := consul_service.NewUpdateParams()
 	updateParams.Context = ctx
 	updateParams.ClusterID = newCluster.ID
-	updateParams.ClusterLocationProjectID = loc.ProjectID
-	updateParams.ClusterLocationOrganizationID = loc.OrganizationID
+	updateParams.ClusterLocationProjectID = newCluster.Location.ProjectID
+	updateParams.ClusterLocationOrganizationID = newCluster.Location.OrganizationID
 	updateParams.Body = newCluster
 
 	// Invoke update cluster endpoint

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -131,7 +131,6 @@ func resourceConsulCluster() *schema.Resource {
 				Description:      "The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`. For more details - https://cloud.hashicorp.com/pricing/consul",
 				Type:             schema.TypeString,
 				Optional:         true,
-				ForceNew:         true,
 				Computed:         true,
 				ValidateDiagFunc: validateConsulClusterSize,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
@@ -583,30 +582,59 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("unable to fetch Consul cluster (%s): %v", clusterID, err)
 	}
 
-	// Fetch available upgrade versions
-	upgradeVersions, err := clients.ListConsulUpgradeVersions(ctx, client, cluster.Location, clusterID)
-	if err != nil {
-		return diag.Errorf("unable to list Consul upgrade versions (%s): %v", clusterID, err)
+	// Confirm update fields have been changed
+	sizeChanged := d.HasChange("size")
+	version, versionOk := d.GetOk("min_consul_version")
+
+	if !sizeChanged && !versionOk {
+		return diag.Errorf("at least one of: [min_consul_version, size] is required in order to upgrade the cluster")
 	}
 
-	v, ok := d.GetOk("min_consul_version")
-	if !ok {
-		return diag.Errorf("min_consul_version is required in order to upgrade the cluster")
+	targetCluster := consulmodels.HashicorpCloudConsul20210204Cluster{
+		ID: clusterID,
+		Location: &sharedmodels.HashicorpCloudLocationLocation{
+			ProjectID:      loc.ProjectID,
+			OrganizationID: loc.OrganizationID,
+			Region: &sharedmodels.HashicorpCloudLocationRegion{
+				Region:   loc.Region.Region,
+				Provider: loc.Region.Provider,
+			},
+		},
 	}
-	newConsulVersion := input.NormalizeVersion(v.(string))
 
-	// Check that there are any valid upgrade versions
-	if upgradeVersions == nil {
-		return diag.Errorf("no upgrade versions of Consul are available for this cluster; you may already be on the latest Consul version supported by HCP")
+	if versionOk {
+		// Fetch available upgrade versions
+		upgradeVersions, err := clients.ListConsulUpgradeVersions(ctx, client, cluster.Location, clusterID)
+		if err != nil {
+			return diag.Errorf("unable to list Consul upgrade versions (%s): %v", clusterID, err)
+		}
+
+		newConsulVersion := input.NormalizeVersion(version.(string))
+
+		// Check that there are any valid upgrade versions
+		if upgradeVersions == nil {
+			return diag.Errorf("no upgrade versions of Consul are available for this cluster; you may already be on the latest Consul version supported by HCP")
+		}
+
+		// Validate that the upgrade version is valid
+		if !consul.IsValidVersion(newConsulVersion, upgradeVersions) {
+			return diag.Errorf("specified Consul version (%s) is unavailable; must be one of: [%s]", newConsulVersion, consul.VersionsToString(upgradeVersions))
+		}
+
+		targetCluster.ConsulVersion = newConsulVersion
 	}
 
-	// Validate that the upgrade version is valid
-	if !consul.IsValidVersion(newConsulVersion, upgradeVersions) {
-		return diag.Errorf("specified Consul version (%s) is unavailable; must be one of: [%s]", newConsulVersion, consul.VersionsToString(upgradeVersions))
+	if sizeChanged {
+		newSize := d.Get("size").(string)
+		targetCluster.Config = &consulmodels.HashicorpCloudConsul20210204ClusterConfig{
+			CapacityConfig: &consulmodels.HashicorpCloudConsul20210204CapacityConfig{
+				Size: consulmodels.HashicorpCloudConsul20210204CapacityConfigSize(newSize),
+			},
+		}
 	}
 
 	// Invoke update cluster endpoint
-	updateResp, err := clients.UpdateConsulCluster(ctx, client, cluster.Location, clusterID, newConsulVersion)
+	updateResp, err := clients.UpdateConsulCluster(ctx, client, cluster.Location, &targetCluster)
 	if err != nil {
 		return diag.Errorf("error updating Consul cluster (%s): %v", clusterID, err)
 	}

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -587,7 +587,7 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	versionChanged := d.HasChange("min_consul_version")
 
 	if !sizeChanged && !versionChanged {
-		return diag.Errorf("at least one of: [min_consul_version, size] is required in order to upgrade the cluster")
+		return diag.Errorf("at least one of: [min_consul_version, size] is required in order to update the cluster")
 	}
 
 	targetCluster := consulmodels.HashicorpCloudConsul20210204Cluster{
@@ -644,13 +644,19 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("unable to update Consul cluster (%s): %v", clusterID, err)
 	}
 
+	// Get updated Consul cluster
+	updatedCluster, err := clients.GetConsulClusterByID(ctx, client, loc, clusterID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve Consul cluster (%s): %v", clusterID, err)
+	}
+
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, cluster.Location, clusterID)
 	if err != nil {
 		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
 	}
 
-	if err := setConsulClusterResourceData(d, cluster, clientConfigFiles); err != nil {
+	if err := setConsulClusterResourceData(d, updatedCluster, clientConfigFiles); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Changes
- remove `ForceNew` on consul cluster size field - we want to update the resource instead of destroy and recreate
- modify `resourceConsulClusterUpdate` to handle size change 
- note: the logic to validate size upgrade paths is already in consul service so it is not needed here

### Testing
- tested size upgrade using terraform with consul cluster in integration (currently behind launchdarkly flag)

### Acceptance Criteria:
- HCP TF provider should call the consul-service update cluster API on a change in the value for size , instead of re-creating the cluster. 
- The PR should be approved from a consul-service engineer and a TCE team engineer
- PR will not be merged until monitoring is added