### PR TITLE
Prep 0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.12.0 (Unreleased)
+
+FEATURES:
+
+* resource/hcp_vault_cluster: Add `starter_small` cluster tier [GH-178]
+
+IMPROVEMENTS:
+
+* provider: Bump `terraform-plugin-sdk/v2` dependency [GH-157]
+* provider: Bump `go-openapi/runtime` dependency [GH-140]
+* provider: Bump `google/uuid` dependency [GH-164]
+* docs: Update Consul docs to include hcp_hvn_peering_connection [GH-176]
+
 ## 0.11.0 (July 30, 2021)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.11.0"
+      version = "~> 0.12.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.11.0"
+      version = "~> 0.12.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Updates the CHANGELOG and example provider version in preparation for releasing v0.12.0.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc

PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	3257.108s
```
