### PR TITLE
Add CheckDestroy step for Packer Data Source Test

### DIFF
--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -164,6 +164,10 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	if channel.Pointer == nil {
+		return diag.Errorf("no iteration information found for the specified channel %s", channelSlug)
+	}
+
 	iteration := channel.Pointer.Iteration
 
 	d.SetId(channel.Pointer.Iteration.ID)


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

This change adds a few new helper functions for deleting resources on the HCP Packer registry under tests.

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality? > Nope !
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```shellsession
$ make testacc TESTARGS='-count=1 -run=TestAcc_dataSourcePacker'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -count=1
-run=TestAcc_dataSourcePacker -timeout 120m
?       github.com/hashicorp/terraform-provider-hcp/internal/clients
[no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul
0.172s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input
0.127s [no tests to run]
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (6.47s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider
6.815s
```
