### PR TITLE
Prep v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.13.0 (Unreleased)
+
+FEATURES
+
+* **New data source** `packer_image_iteration` [GH-169]
+
 ## 0.12.0 (August 04, 2021)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.12.0"
+      version = "~> 0.13.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.12.0"
+      version = "~> 0.13.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Prep for v0.13.0 release, featuring HCP Packer's first data source in private beta!

### :building_construction: Acceptance tests

Output from acceptance testing:

⚠️ Ran into some environment issues while running these, so VaultCluster and TGWAttachment tests were verified separately.
```
$ make testacc
--- PASS: TestAcc_dataSourcePacker (8.93s)
--- PASS: TestAccHvnPeering (212.71s)
--- PASS: TestAccConsulCluster (503.15s)
--- PASS: TestAccConsulSnapshot (516.13s)
--- PASS: TestAccHvnPeeringConnection (102.53s)
--- PASS: TestAccHvnRoute (201.92s)
--- PASS: TestAccHvn (73.03s)

--- PASS: TestAccVaultCluster (702.39s)

--- PASS: TestAccTGWAttachment (482.69s)
```
