### PR TITLE
Prep 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
+## 0.14.0 (Unreleased)
+
+FEATURES:
+
+* resource/hcp_consul_cluster: Add size upgrade field for consul cluster update [GH-168]
+
+IMPROVEMENTS:
+* provider: Add HCP status check to run before TF commands [GH-184]
+* provider: Bump `google.golang.org/grpc` dependency [GH-185]
+* provider: Bump `github.com/go-openapi/runtime` dependency [GH-183]
+
 ## 0.13.0 (August 06, 2021)
 
-FEATURES
+FEATURES:
 
 * **New data source** `packer_image_iteration` ([#169](https://github.com/hashicorp/terraform-provider-hcp/issues/169)) in **private beta**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.13.0"
+      version = "~> 0.14.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.13.0"
+      version = "~> 0.14.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Prep for v0.14.0 release, featuring the ability to update Consul cluster size! 🎆 

### :building_construction: Acceptance tests

Output from acceptance testing:

TGW and HVN Peering Connections were tested against a separate environment.
```
$ make testacc 

--- PASS: TestAccConsulCluster (581.00s)
--- PASS: TestAccConsulSnapshot (553.94s)
--- PASS: TestAcc_dataSourcePacker (13.10s)
--- PASS: TestAccHvn (75.74s)
--- PASS: TestAccHvnPeering (218.14s)
--- PASS: TestAccHvnRoute (209.62s)
--- PASS: TestAccVaultCluster (690.41s)

--- PASS: TestAccTGWAttachment (476.26s)
--- PASS: TestAccHvnPeeringConnection (119.57s)
```
