### PR TITLE
change bucket to bucket_name to remain consistent with Packer

### DIFF
--- a/docs/data-sources/packer_image_iteration.md
+++ b/docs/data-sources/packer_image_iteration.md
@@ -15,7 +15,7 @@ The Packer Image data source iteration gets the most recent iteration (or build)
 
 ```terraform
 data "hcp_packer_image_iteration" "alpine" {
-  bucket  = "alpine"
+  bucket_name  = "alpine"
   channel = "production"
 }
 ```
@@ -24,7 +24,7 @@ data "hcp_packer_image_iteration" "alpine" {
 
 ### Required
 
-- **bucket** (String) The slug of the HCP Packer Registry image bucket to pull from.
+- **bucket_name** (String) The slug of the HCP Packer Registry image bucket to pull from.
 - **channel** (String) The channel that points to the version of the image you want.
 
 ### Optional

--- a/examples/data-sources/hcp_packer_image_iteration/data-source.tf
+++ b/examples/data-sources/hcp_packer_image_iteration/data-source.tf
@@ -1,4 +1,4 @@
 data "hcp_packer_image_iteration" "alpine" {
-  bucket  = "alpine"
+  bucket_name  = "alpine"
   channel = "production"
 }

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -23,7 +23,7 @@ func dataSourcePackerImageIteration() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs
-			"bucket": {
+			"bucket_name": {
 				Description:      "The slug of the HCP Packer Registry image bucket to pull from.",
 				Type:             schema.TypeString,
 				Required:         true,
@@ -144,7 +144,7 @@ func dataSourcePackerImageIteration() *schema.Resource {
 }
 
 func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	bucketName := d.Get("bucket").(string)
+	bucketName := d.Get("bucket_name").(string)
 	channelSlug := d.Get("channel").(string)
 	client := meta.(*clients.Client)
 

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -23,7 +23,7 @@ const (
 var (
 	testAccPackerAlpineProductionImage = fmt.Sprintf(`
 	data "hcp_packer_image_iteration" "alpine" {
-		bucket  = %q
+		bucket_name  = %q
 		channel = %q
 	}`, bucket, channel)
 )

--- a/templates/data-sources/packer_image_iteration.md.tmpl
+++ b/templates/data-sources/packer_image_iteration.md.tmpl
@@ -19,7 +19,7 @@ description: |-
 
 ### Required
 
-- **bucket** (String) The slug of the HCP Packer Registry image bucket to pull from.
+- **bucket_name** (String) The slug of the HCP Packer Registry image bucket to pull from.
 - **channel** (String) The channel that points to the version of the image you want.
 
 ### Optional


### PR DESCRIPTION
Following https://github.com/hashicorp/packer/pull/11219, I'm renaming this field to stay consistent.