### PR TITLE
Set PlatformType to HCP explicitly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
-	github.com/hashicorp/hcp-sdk-go v0.12.0
+	github.com/hashicorp/hcp-sdk-go v0.13.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1
 	github.com/posener/complete v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2Opti
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcp-sdk-go v0.12.0 h1:hcQRKISUEySPCdAHtXOOnRWis6YYx6TVlQxyKYt4w+w=
 github.com/hashicorp/hcp-sdk-go v0.12.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.13.0 h1:zWlJoLkGUp8bJgR++1m38FroBNSNfOxTk72hN0CTFyc=
+github.com/hashicorp/hcp-sdk-go v0.13.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.14.0 h1:UQoUcxKTZZXhyyK68Cwn4mApT4mnFPmEXPiqaHL9r+w=

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
-github.com/hashicorp/hcp-sdk-go v0.12.0 h1:hcQRKISUEySPCdAHtXOOnRWis6YYx6TVlQxyKYt4w+w=
-github.com/hashicorp/hcp-sdk-go v0.12.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/hcp-sdk-go v0.13.0 h1:zWlJoLkGUp8bJgR++1m38FroBNSNfOxTk72hN0CTFyc=
 github.com/hashicorp/hcp-sdk-go v0.13.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/clients/consul_cluster.go
+++ b/internal/clients/consul_cluster.go
@@ -4,8 +4,14 @@ import (
 	"context"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client/consul_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
+
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+)
+
+var (
+	platformType = string(models.HashicorpCloudConsul20210204PlatformTypeHCP)
 )
 
 // GetConsulClusterByID gets an Consul cluster by its ID
@@ -99,6 +105,7 @@ func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmo
 	p.Context = ctx
 	p.LocationProjectID = loc.ProjectID
 	p.LocationOrganizationID = loc.OrganizationID
+	p.PlatformType = &platformType
 
 	resp, err := client.Consul.ListVersions(p, nil)
 
@@ -113,6 +120,7 @@ func GetAvailableHCPConsulVersionsForLocation(ctx context.Context, loc *sharedmo
 func GetAvailableHCPConsulVersions(ctx context.Context, client *Client) ([]*consulmodels.HashicorpCloudConsul20210204Version, error) {
 	p := consul_service.NewListVersions2Params()
 	p.Context = ctx
+	p.PlatformType = &platformType
 
 	resp, err := client.Consul.ListVersions2(p, nil)
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Setting PlatformType explicitly to HCP for the ListVersions call. 

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* NONE
```

### :building_construction: Acceptance tests

- [n/a] Are there any feature flags that are required to use this functionality?
- [n/a] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TESTARGS='-run=TestAccConsulCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccConsulCluster -timeout 120m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]

=== RUN   TestAccConsulCluster
--- PASS: TestAccConsulCluster (1045.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	1046.059s
```
