### PR TITLE
Make cluster_id understand id as well

### DIFF
--- a/docs/guides/consul-root-token.md
+++ b/docs/guides/consul-root-token.md
@@ -28,7 +28,7 @@ resource "hcp_consul_cluster" "example" {
 
 // Create a new ACL root token
 resource "hcp_consul_cluster_root_token" "example" {
-  cluster_id = hcp_consul_cluster.example.cluster_id
+  cluster_id = hcp_consul_cluster.example.id
 }
 ```
 

--- a/examples/guides/consul_cluster_root_token/main.tf
+++ b/examples/guides/consul_cluster_root_token/main.tf
@@ -14,5 +14,5 @@ resource "hcp_consul_cluster" "example" {
 
 // Create a new ACL root token
 resource "hcp_consul_cluster_root_token" "example" {
-  cluster_id = hcp_consul_cluster.example.cluster_id
+  cluster_id = hcp_consul_cluster.example.id
 }

--- a/internal/provider/resource_consul_cluster_root_token.go
+++ b/internal/provider/resource_consul_cluster_root_token.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -47,7 +48,7 @@ func resourceConsulClusterRootToken() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validateSlugID,
+				ValidateDiagFunc: validateSlugIDOrID,
 			},
 			// Computed outputs
 			"accessor_id": {
@@ -76,6 +77,9 @@ func resourceConsulClusterRootTokenCreate(ctx context.Context, d *schema.Resourc
 	client := meta.(*clients.Client)
 
 	clusterID := d.Get("cluster_id").(string)
+	if matchesID(clusterID) {
+		clusterID = filepath.Base(clusterID)
+	}
 
 	// fetch organizationID by project ID
 	organizationID := client.Config.OrganizationID
@@ -140,6 +144,9 @@ func resourceConsulClusterRootTokenRead(ctx context.Context, d *schema.ResourceD
 	client := meta.(*clients.Client)
 
 	clusterID := d.Get("cluster_id").(string)
+	if matchesID(clusterID) {
+		clusterID = filepath.Base(clusterID)
+	}
 	organizationID := client.Config.OrganizationID
 	projectID := client.Config.ProjectID
 
@@ -178,6 +185,9 @@ func resourceConsulClusterRootTokenDelete(ctx context.Context, d *schema.Resourc
 	client := meta.(*clients.Client)
 
 	clusterID := d.Get("cluster_id").(string)
+	if matchesID(clusterID) {
+		clusterID = filepath.Base(clusterID)
+	}
 	organizationID := client.Config.OrganizationID
 	projectID := client.Config.ProjectID
 

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -74,12 +74,39 @@ func validateSemVer(v interface{}, path cty.Path) diag.Diagnostics {
 	return diagnostics
 }
 
+// matchesID matches /project/11eabb9f-d2ee-9c80-9483-0242ac110013/hashicorp.consul.cluster/example
+func matchesID(id string) bool {
+	return regexp.MustCompile(`/project/\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/hashicorp\.consul\.cluster/.*`).MatchString(id)
+}
+
+func matchesSlugID(slugID string) bool {
+	return regexp.MustCompile(`^[-\da-zA-Z]{3,36}$`).MatchString(slugID)
+}
+
+// validateSlugIDOrID validates that the string value matches the HCP requirements for
+// an id or slug id.
+func validateSlugIDOrID(v interface{}, path cty.Path) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	if !matchesID(v.(string)) && !matchesSlugID(v.(string)) {
+		msg := "must be between 3 and 36 characters in length and contains only letters, numbers or hyphens OR must match /project/uuid/hashicorp.consul.cluster/id format"
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       msg,
+			Detail:        msg,
+			AttributePath: path,
+		})
+	}
+
+	return diagnostics
+}
+
 // validateSlugID validates that the string value matches the HCP requirements for
 // a user-settable slug.
 func validateSlugID(v interface{}, path cty.Path) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 
-	if !regexp.MustCompile(`^[-\da-zA-Z]{3,36}$`).MatchString(v.(string)) {
+	if !matchesSlugID(v.(string)) {
 		msg := "must be between 3 and 36 characters in length and contains only letters, numbers or hyphens"
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

Fixes #170. The underlying problem is that anything else but `id` (like `cluster_id`) will not recreate the child resource if the parent resource is changed.
Previously the root token wouldn't be updated when the consul cluster changes, because `cluster.cluster_id` was used instead of `cluster.id`.

Now a root token can be created like this:

```
resource "hcp_consul_cluster_root_token" "token" {
  cluster_id = hcp_consul_cluster.example.id
}
```

and because `id` is used, it will recreate the token when the cluster is updated. Relevant terraform-core issue: https://github.com/hashicorp/terraform/issues/8099.

`cluster_id` now understand both formats. When we release the next major version of this provider, we should only allow `id` going forward.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-205] should match the number of your PR.
-->

```release-note
* hcp_consul_cluster_root_token: use `.id` instead of `.cluster_id` when referring to the consul cluster. [GH-205]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
