### PR TITLE
Bump Packer datasources to public beta

### DIFF
--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_packer_image (Data Source)
 
--> **Note:** This feature is currently in private beta.
+-> **Note:** This feature is currently in beta.
 
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id.
 

--- a/docs/data-sources/packer_image_iteration.md
+++ b/docs/data-sources/packer_image_iteration.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_packer_image_iteration (Data Source)
 
--> **Note:** This feature is currently in private beta.
+-> **Note:** This feature is currently in beta.
 
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_packer_iteration (Data Source)
 
--> **Note:** This feature is currently in private beta.
+-> **Note:** This feature is currently in beta.
 
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 

--- a/templates/data-sources/packer_image.md.tmpl
+++ b/templates/data-sources/packer_image.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Type}} ({{.Name}})
 
--> **Note:** This feature is currently in private beta.
+-> **Note:** This feature is currently in beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/packer_image_iteration.md.tmpl
+++ b/templates/data-sources/packer_image_iteration.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Type}} ({{.Name}})
 
--> **Note:** This feature is currently in private beta.
+-> **Note:** This feature is currently in beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/packer_iteration.md.tmpl
+++ b/templates/data-sources/packer_iteration.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Type}} ({{.Name}})
 
--> **Note:** This feature is currently in private beta.
+-> **Note:** This feature is currently in beta.
 
 {{ .Description | trimspace }}
 


### PR DESCRIPTION
This change replaces `This feature is currently in private beta.` with
`This feature is currently in beta.`
