### PR TITLE
Update source channel with metadata on hcp_aws_network_peering

### DIFF
--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -105,6 +105,13 @@ func resourceAwsNetworkPeering() *schema.Resource {
 func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
+	var err error
+	// Updates the source channel to include data about the module used.
+	client, err = client.UpdateSourceChannel(d)
+	if err != nil {
+		log.Printf("[DEBUG] Failed to update analytics with module name (%s)", err)
+	}
+
 	peeringID := d.Get("peering_id").(string)
 	hvnID := d.Get("hvn_id").(string)
 	peerAccountID := d.Get("peer_account_id").(string)
@@ -117,7 +124,7 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	// Check for an existing HVN
-	_, err := clients.GetHvnByID(ctx, client, loc, hvnID)
+	_, err = clients.GetHvnByID(ctx, client, loc, hvnID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			return diag.Errorf("unable to find the HVN (%s) for the network peering", hvnID)


### PR DESCRIPTION
### :hammer_and_wrench: Description

In testing out #197, I realized it would be useful to also have the module_name set on the `hcp_aws_network_peering`. That totally skipped my mind when reviewing the previous PR.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
NONE
```

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run TestAccHvnPeering'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run TestAccHvnPeering -timeout 120m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccHvnPeering
--- PASS: TestAccHvnPeering (225.32s)
=== RUN   TestAccHvnPeeringConnection
--- PASS: TestAccHvnPeeringConnection (115.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	341.279s

```
