### PR TITLE
Add CIDR Validator that matches backend validator

### DIFF
--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -74,7 +74,7 @@ func resourceHvn() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validateCidrBlock,
+				ValidateDiagFunc: validateCIDRBlock,
 				Computed:         true,
 			},
 			// Computed outputs

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -55,7 +55,7 @@ func resourceHvnRoute() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validateCidrBlock,
+				ValidateDiagFunc: validateCIDRBlock,
 			},
 			"target_link": {
 				Description: "A unique URL identifying the target of the HVN route. Examples of the target: [`aws_network_peering`](aws_network_peering.md), [`aws_transit_gateway_attachment`](aws_transit_gateway_attachment.md)",

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -197,7 +197,7 @@ func validateVaultClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
 	return diagnostics
 }
 
-func validateCidrBlock(v interface{}, path cty.Path) diag.Diagnostics {
+func validateCIDRBlock(v interface{}, path cty.Path) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 
 	// validRanges contains the set of IP ranges considered valid.

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -392,7 +392,7 @@ func Test_validateVaultClusterTier(t *testing.T) {
 	}
 }
 
-func Test_validateCidrBlock(t *testing.T) {
+func Test_validateCIDRBlock(t *testing.T) {
 	tcs := map[string]struct {
 		input    string
 		expected diag.Diagnostics
@@ -628,7 +628,7 @@ func Test_validateCidrBlock(t *testing.T) {
 	for n, tc := range tcs {
 		t.Run(n, func(t *testing.T) {
 			r := require.New(t)
-			result := validateCidrBlock(tc.input, nil)
+			result := validateCIDRBlock(tc.input, nil)
 			r.Equal(tc.expected, result)
 		})
 	}


### PR DESCRIPTION
### :hammer_and_wrench: Description

Adds CIDR Validator and tests to list of validators to match backend validators