### PR TITLE
add labels to the returned image data

### DIFF
--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -52,6 +52,7 @@ output "packer-registry-ubuntu" {
 - **cloud_image_id** (String) Cloud Image ID or URL string identifying this image for the builder that built it.
 - **component_type** (String) Name of the builder that built this. Ex: 'amazon-ebs.example'
 - **created_at** (String) Creation time of this build.
+- **labels** (Map of String) Labels associated with this build.
 - **organization_id** (String) The ID of the organization this HCP Packer registry is located in.
 - **packer_run_uuid** (String) UUID of this build.
 - **project_id** (String) The ID of the project this HCP Packer registry is located in.

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -79,6 +79,11 @@ func dataSourcePackerImage() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"labels": {
+				Description: "Labels associated with this build.",
+				Type:        schema.TypeMap,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -131,6 +136,9 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 					return diag.FromErr(err)
 				}
 				if err := d.Set("packer_run_uuid", build.PackerRunUUID); err != nil {
+					return diag.FromErr(err)
+				}
+				if err := d.Set("labels", build.Labels); err != nil {
 					return diag.FromErr(err)
 				}
 			}

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -174,6 +174,7 @@ func upsertBuild(t *testing.T, bucketSlug, fingerprint, iterationID string) {
 					Region:  "us-east-1",
 				},
 			},
+			Labels: map[string]string{"test-key": "test-value"},
 		},
 	}
 	_, err = client.Packer.PackerServiceUpdateBuild(updateBuildParams, nil)

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -59,6 +59,7 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr("data.hcp_packer_image.foo", "labels.test-key", "test-value"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

Adds build labels to the schema and sets them so users can access them. 

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* {hcp_packer_image }: {Add build labels to the hcp_packer_image data source} [GH-217]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTARGS="-run TestAcc_dataSourcePackerImage"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run TestAcc_dataSourcePackerImage -timeout 120m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (8.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	9.064s
```
