### PR TITLE
Prep 0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.20.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* datasource/hcp_packer_image: Add build labels to the hcp_packer_image data source [GH-217]
+* provider: Bump `go-openapi/runtime` dependency [GH-218]
+* provider: Bump `go-openapi/strfmt` dependency [GH-218]
+* provider: Bump `actions/checkout` dependency [GH-219]
+* provider: Bump `google.golang.org/grpc` dependency [GH-220]
+
 ## 0.19.0 (October 27, 2021)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.19.0"
+      version = "~> 0.20.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.19.0"
+      version = "~> 0.20.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps the release of 0.20.0, which includes some dependency bumps and adds `labels` to the packer image datasource.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc 

PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	4344.272s
```
