### PR TITLE
Implement Vault cluster scaling

### DIFF
--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -110,3 +110,31 @@ func UpdateVaultClusterPublicIps(ctx context.Context, client *Client, loc *share
 
 	return updateResp.Payload, nil
 }
+
+// UpdateVaultCluster will make a call to the Vault service to update the Vault cluster configuration.
+func UpdateVaultClusterTier(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
+	clusterID string, tier vaultmodels.HashicorpCloudVault20201125Tier) (*vaultmodels.HashicorpCloudVault20201125UpdateResponse, error) {
+
+	updateParams := vault_service.NewUpdateParams()
+	updateParams.Context = ctx
+	updateParams.ClusterID = clusterID
+	updateParams.ClusterLocationProjectID = loc.ProjectID
+	updateParams.ClusterLocationOrganizationID = loc.OrganizationID
+	updateParams.Body = &vaultmodels.HashicorpCloudVault20201125InputCluster{
+		// ClusterID and Location are repeated because the values above are required to populate the URL,
+		// and the values below are required in the API request body
+		ID:       clusterID,
+		Location: loc,
+		// NOTE: if this function is ever modified to update more than just the tier,
+		// the tier must ALWAYS be specified, since the 0-value is valid and will not
+		// be ignored.
+		Config: &vaultmodels.HashicorpCloudVault20201125InputClusterConfig{Tier: tier},
+	}
+
+	updateResp, err := client.Vault.Update(updateParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return updateResp.Payload, nil
+}

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -292,22 +292,8 @@ func resourceVaultClusterUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	// Confirm public_endpoint or tier have changed.
-	changed := d.HasChange("public_endpoint") || d.HasChange("tier")
-	if !changed {
+	if !(d.HasChange("tier") || d.HasChange("public_endpoint")) {
 		return nil
-	}
-
-	if d.HasChange("public_endpoint") {
-		// Invoke update public IPs endpoint.
-		updateResp, err := clients.UpdateVaultClusterPublicIps(ctx, client, cluster.Location, clusterID, d.Get("public_endpoint").(bool))
-		if err != nil {
-			return diag.Errorf("error updating Vault cluster public endpoint (%s): %v", clusterID, err)
-		}
-
-		// Wait for the update cluster operation.
-		if err := clients.WaitForOperation(ctx, client, "update Vault cluster public endpoint", cluster.Location, updateResp.Operation.ID); err != nil {
-			return diag.Errorf("unable to update Vault cluster public endpoint (%s): %v", clusterID, err)
-		}
 	}
 
 	if d.HasChange("tier") {
@@ -321,6 +307,19 @@ func resourceVaultClusterUpdate(ctx context.Context, d *schema.ResourceData, met
 		// Wait for the update cluster operation.
 		if err := clients.WaitForOperation(ctx, client, "update Vault cluster tier", cluster.Location, updateResp.Operation.ID); err != nil {
 			return diag.Errorf("unable to update Vault cluster tier (%s): %v", clusterID, err)
+		}
+	}
+
+	if d.HasChange("public_endpoint") {
+		// Invoke update public IPs endpoint.
+		updateResp, err := clients.UpdateVaultClusterPublicIps(ctx, client, cluster.Location, clusterID, d.Get("public_endpoint").(bool))
+		if err != nil {
+			return diag.Errorf("error updating Vault cluster public endpoint (%s): %v", clusterID, err)
+		}
+
+		// Wait for the update cluster operation.
+		if err := clients.WaitForOperation(ctx, client, "update Vault cluster public endpoint", cluster.Location, updateResp.Operation.ID); err != nil {
+			return diag.Errorf("unable to update Vault cluster public endpoint (%s): %v", clusterID, err)
 		}
 	}
 

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-var vaultCluster = `
+const vaultCluster = `
 resource "hcp_vault_cluster" "test" {
 	cluster_id         = "test-vault-cluster"
 	hvn_id             = hcp_hvn.test.hvn_id
@@ -19,7 +19,7 @@ resource "hcp_vault_cluster" "test" {
 `
 
 // sets public_endpoint to true
-var updatedVaultClusterPublic = `
+const updatedVaultClusterPublic = `
 resource "hcp_vault_cluster" "test" {
 	cluster_id         = "test-vault-cluster"
 	hvn_id             = hcp_hvn.test.hvn_id
@@ -29,7 +29,7 @@ resource "hcp_vault_cluster" "test" {
 `
 
 // changes tier
-var updatedVaultClusterTier = `
+const updatedVaultClusterTier = `
 resource "hcp_vault_cluster" "test" {
 	cluster_id         = "test-vault-cluster"
 	hvn_id             = hcp_hvn.test.hvn_id

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -19,12 +19,21 @@ resource "hcp_vault_cluster" "test" {
 `
 
 // sets public_endpoint to true
-var updatedVaultCluster = `
+var updatedVaultClusterPublic = `
 resource "hcp_vault_cluster" "test" {
 	cluster_id         = "test-vault-cluster"
 	hvn_id             = hcp_hvn.test.hvn_id
 	tier               = "dev"
 	public_endpoint    = true
+}
+`
+
+// changes tier
+var updatedVaultClusterTier = `
+resource "hcp_vault_cluster" "test" {
+	cluster_id         = "test-vault-cluster"
+	hvn_id             = hcp_hvn.test.hvn_id
+	tier               = "standard_small"
 }
 `
 
@@ -142,9 +151,9 @@ func TestAccVaultCluster(t *testing.T) {
 					resource.TestCheckResourceAttrPair(vaultClusterResourceName, "created_at", vaultClusterDataSourceName, "created_at"),
 				),
 			},
-			// This step verifies the successful update of updatable fields.
+			// This step verifies the successful update of "public_endpoint".
 			{
-				Config: testConfig(setTestAccVaultClusterConfig(updatedVaultCluster)),
+				Config: testConfig(setTestAccVaultClusterConfig(updatedVaultClusterPublic)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVaultClusterExists(vaultClusterResourceName),
 					resource.TestCheckResourceAttr(vaultClusterResourceName, "public_endpoint", "true"),
@@ -152,6 +161,14 @@ func TestAccVaultCluster(t *testing.T) {
 					testAccCheckFullURL(vaultClusterResourceName, "vault_public_endpoint_url", "8200"),
 					resource.TestCheckResourceAttrSet(vaultClusterResourceName, "vault_private_endpoint_url"),
 					testAccCheckFullURL(vaultClusterResourceName, "vault_private_endpoint_url", "8200"),
+				),
+			},
+			// This step verifies the successful update of "tier".
+			{
+				Config: testConfig(setTestAccVaultClusterConfig(updatedVaultClusterTier)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVaultClusterExists(vaultClusterResourceName),
+					resource.TestCheckResourceAttr(vaultClusterResourceName, "tier", "STANDARD_SMALL"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

Implement Vault cluster scaling. When the `tier` is changed, invoke a scaling operation to scale the cluster to the new tier.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* Vault cluster: implement cluster tier scaling [GH-228]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run= TestAccVaultCluster'

... <7014 lines of output>

--- PASS: TestAccVaultCluster (1498.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	1499.340s
```
