### PR TITLE
Update the error messaging for the Packer service datasources

### DIFF
--- a/internal/clients/packer.go
+++ b/internal/clients/packer.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
@@ -21,7 +22,7 @@ func GetPackerChannelBySlug(ctx context.Context, client *Client, loc *sharedmode
 
 	getResp, err := client.Packer.PackerServiceGetChannel(getParams, nil)
 	if err != nil {
-		return nil, err
+		return nil, handleGetChannelError(err.(*packer_service.PackerServiceGetChannelDefault))
 	}
 
 	return getResp.Payload.Channel, nil
@@ -41,8 +42,20 @@ func GetIterationFromId(ctx context.Context, client *Client, loc *sharedmodels.H
 
 	it, err := client.Packer.PackerServiceGetIteration(params, nil)
 	if err != nil {
-		return nil, err
+		return nil, handleGetIterationError(err.(*packer_service.PackerServiceGetIterationDefault))
 	}
 
 	return it.Payload.Iteration, nil
+}
+
+// handleGetChannelError returns a formatted error for the GetChannel error.
+// The upstream API does a good job of providing detailed error messages so we just display the error message, with no status code.
+func handleGetChannelError(err *packer_service.PackerServiceGetChannelDefault) error {
+	return errors.New(err.Payload.Error)
+}
+
+// handleGetIterationError returns a formatted error for the GetIteration error.
+// The upstream API does a good job of providing detailed error messages so we just display the error message, with no status code.
+func handleGetIterationError(err *packer_service.PackerServiceGetIterationDefault) error {
+	return errors.New(err.Payload.Error)
 }

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -315,9 +315,8 @@ func TestAcc_dataSourcePacker(t *testing.T) {
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(*terraform.State) error {
 			itID := getIterationIDFromFingerPrint(t, acctestBucket, fingerprint)
-			// delete iteration before channel to ensure hard delete of channel.
-			deleteIteration(t, acctestBucket, itID)
 			deleteChannel(t, acctestBucket, acctestChannel)
+			deleteIteration(t, acctestBucket, itID)
 			deleteBucket(t, acctestBucket)
 			return nil
 		},

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -37,9 +37,8 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(*terraform.State) error {
 			itID := getIterationIDFromFingerPrint(t, acctestImageBucket, fingerprint)
-			// delete iteration before channel to ensure hard delete of channel.
-			deleteIteration(t, acctestImageBucket, itID)
 			deleteChannel(t, acctestImageBucket, acctestImageChannel)
+			deleteIteration(t, acctestImageBucket, itID)
 			deleteBucket(t, acctestImageBucket)
 			return nil
 		},

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -30,9 +30,8 @@ func TestAcc_dataSourcePackerIteration(t *testing.T) {
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(*terraform.State) error {
 			itID := getIterationIDFromFingerPrint(t, acctestIterationBucket, fingerprint)
-			// delete iteration before channel to ensure hard delete of channel.
-			deleteIteration(t, acctestIterationBucket, itID)
 			deleteChannel(t, acctestIterationBucket, acctestIterationChannel)
+			deleteIteration(t, acctestIterationBucket, itID)
 			deleteBucket(t, acctestIterationBucket)
 			return nil
 		},


### PR DESCRIPTION
The upstream Packer cloud service has been updated to return actionable errors for the majority of its endpoints. This change updates the client functions to return only the error message, stripped of any HTTP methods or status codes, from the API.

Closes #224 

<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* datasource/packer: Improve error messages for requests made to HCP Packer. [GH-229](https://github.com/hashicorp/terraform-provider-hcp/pull/229)
```

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAcc_dataSourcePacker'

...
```

<details>
<summary> Updated Error Messaging </summary>

```
~>  terraform apply
╷
│ Error: This HCP Packer registry was deactivated by the administrator. To reactivate, please visit the HCP Packer tab in https://portal.cloud.hashicorp.com/.
│
│   with data.hcp_packer_iteration.example,
│   on main.tf line 13, in data "hcp_packer_iteration" "example":
│   13: data "hcp_packer_iteration" "example" {
│

~>  terraform apply
╷
│ Error: No HPC Packer registry was found for this organization and project. To create a registry, please visit the HCP Packer tab in https://portal.cloud.hashicorp.com/.
│
│   with data.hcp_packer_iteration.example,
│   on main.tf line 13, in data "hcp_packer_iteration" "example":
│   13: data "hcp_packer_iteration" "example" {
│
```
</details>

<details>
<summary>Previous Error Messaging</summary>

```
~>  terraform apply
╷
│ Error: [GET /packer/2021-04-30/organizations/{location.organization_id}/projects/{location.project_id}/images/{bucket_slug}/channels/{slug}][400] PackerService_GetChannel default  &{Code:9 Details:[] Error:This HCP Packer registry was deactivated by the administrator. To reactivate, please visit the HCP Packer tab in https://portal.cloud.hashicorp.com/. Message:This HCP Packer registry was deactivated by the administrator. To reactivate, please visit the HCP Packer tab in https://portal.cloud.hashicorp.com/.}
│
│   with data.hcp_packer_iteration.example,
│   on main.tf line 14, in data "hcp_packer_iteration" "example":
│   14: data "hcp_packer_iteration" "example" {
│
╵
```
</details>
