### PR TITLE
Prep v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.21.0 (Unreleased)
+
+FEATURES:
+
+* resource/vault: Implement cluster tier scaling [GH-228]
+* docs: Add cluster tier scaling guide [GH-228]
+
+IMPROVEMENTS:
+
+* datasource/packer: Improve error messages for requests made to HCP Packer. [GH-229]
+* provider: Bump `terraform-plugin-sdk/v2` dependency [GH-230]
+* provider: Bump `terraform-plugin-docs` from 0.5.0 to 0.5.1 [GH-223]
+* provider: Bump `go-openapi/strfmt` from 0.21.0 to 0.21.1 [GH-226]
+
 ## 0.20.0 (November 04, 2021)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.20.0"
+      version = "~> 0.21.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.20.0"
+      version = "~> 0.21.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Prep for the release of v0.21.0, which includes update-able tiers on Vault clusters and beautified error messaging on the Packer datasource! ✨ 

### :building_construction: Acceptance tests

Output from acceptance testing:

**Note:** Some tests failed on initial run due to transient environmental issues, so I re-ran them separately.
```
$ make testacc 

--- PASS: TestProvider (0.00s)
--- PASS: TestAccHvnPeering (574.74s)
--- PASS: TestAccConsulCluster (1240.86s)
--- PASS: TestAccConsulSnapshot (737.67s)
--- PASS: TestAccHvnPeeringConnection (304.21s)
--- PASS: TestAccHvnRoute (691.75s)
--- PASS: TestAccHvn (146.21s)
--- PASS: TestAccVaultCluster (2496.24s)

# make testacc TESTARGS='-run=TestAcc_dataSourcePacker'

--- PASS: TestAcc_dataSourcePackerIteration (7.01s)
--- PASS: TestAcc_dataSourcePackerImage (7.48s)
--- PASS: TestAcc_dataSourcePacker (8.97s)

# make testacc TESTARGS='-run=TestAccTGW'

--- PASS: TestAccTGWAttachment (514.86s)
```
