### PR TITLE
Prep v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-## 0.21.0 (December 09, 2021)
+## 0.21.1 (Unreleased)
 
 FEATURES:
 
 * resource/vault: Implement cluster tier scaling ([#228](https://github.com/hashicorp/terraform-provider-hcp/issues/228))
 * docs: Add cluster tier scaling guide ([#228](https://github.com/hashicorp/terraform-provider-hcp/issues/228))
+
+FIXES:
+
+* resource/vault: when changing tiers, do not force new ([#233](https://github.com/hashicorp/terraform-provider-hcp/issues/233))
 
 IMPROVEMENTS:
 
@@ -11,6 +15,10 @@ IMPROVEMENTS:
 * provider: Bump `terraform-plugin-sdk/v2` dependency ([#230](https://github.com/hashicorp/terraform-provider-hcp/issues/230))
 * provider: Bump `terraform-plugin-docs` from 0.5.0 to 0.5.1 ([#223](https://github.com/hashicorp/terraform-provider-hcp/issues/223))
 * provider: Bump `go-openapi/strfmt` from 0.21.0 to 0.21.1 ([#226](https://github.com/hashicorp/terraform-provider-hcp/issues/226))
+
+## 0.21.0 (December 08, 2021)
+
+⚠️ Note: There is an issue with this version of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Vault cluster if the tier is changed, which could result in data loss. For this reason, the v0.21.0 release and tag is no longer available to use. Please upgrade to the patch v0.21.1 or beyond. ⚠️
 
 ## 0.20.0 (November 04, 2021)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.21.0"
+      version = "~> 0.21.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ description: |-
 
 # HashiCorp Cloud Platform (HCP) Provider
 
+~> **Known Issue:** There is a known issue with v0.21.0 of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Vault cluster if the tier is changed, which could result in data loss. See the Release Notes on Github for more detail. Please upgrade to the patch v0.21.1 or beyond to avoid this issue.
+
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.21.0"
+      version = "~> 0.21.1"
     }
   }
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,6 +7,8 @@ description: |-
 
 # HashiCorp Cloud Platform (HCP) Provider
 
+~> **Known Issue:** There is a known issue with v0.21.0 of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Vault cluster if the tier is changed, which could result in data loss. See the Release Notes on Github for more detail. Please upgrade to the patch v0.21.1 or beyond to avoid this issue.
+
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.


### PR DESCRIPTION
### :hammer_and_wrench: Description

⚠️ `v0.21.0` included an escaped defect, in which Terraform will incorrectly recommend a rebuild of a Vault cluster if the tier is changed, which could result in data loss. For this reason, that release is no longer available for use. Please upgrade to the patch `v0.21.1` once released.

Prep release of 0.21.1, which includes a hot fix to prevent Vault cluster tier updates from re-creating the cluster.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc 

--- PASS: TestProvider (0.00s)
--- PASS: TestAccHvnPeering (574.74s)
--- PASS: TestAccConsulCluster (1240.86s)
--- PASS: TestAccConsulSnapshot (737.67s)
--- PASS: TestAccHvnPeeringConnection (304.21s)
--- PASS: TestAccHvnRoute (691.75s)
--- PASS: TestAccHvn (146.21s)
--- PASS: TestAccVaultCluster (2496.24s)

# make testacc TESTARGS='-run=TestAcc_dataSourcePacker'

--- PASS: TestAcc_dataSourcePackerIteration (7.01s)
--- PASS: TestAcc_dataSourcePackerImage (7.48s)
--- PASS: TestAcc_dataSourcePacker (8.97s)

# make testacc TESTARGS='-run=TestAccTGW'

--- PASS: TestAccTGWAttachment (514.86s)
```
