### PR TITLE
Add check for revoked iterations to HCP Packer datasources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
-	github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4
+	github.com/hashicorp/hcp-sdk-go v0.16.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/posener/complete v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/go-openapi/runtime v0.21.0
 	github.com/go-openapi/strfmt v0.21.1
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
-	github.com/hashicorp/hcp-sdk-go v0.14.0
+	github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/posener/complete v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsK
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
-github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4 h1:H4V7J/mUKzMpmTqnnDloH0r7mk2Jwn4oKUvealKE9cQ=
-github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.16.0 h1:/UfRdiI1Z2AJGBi24aFO8MeNTWBa08EHyAvH1C9BWw8=
+github.com/hashicorp/hcp-sdk-go v0.16.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.15.0 h1:cqjh4d8HYNQrDoEmlSGelHmg2DYDh5yayckvJ5bV18E=

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2Opti
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcp-sdk-go v0.14.0 h1:0+elHACiRu4L+rR+1k9khlu7zaGYq9e/8gy4N4pz0NU=
 github.com/hashicorp/hcp-sdk-go v0.14.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4 h1:H4V7J/mUKzMpmTqnnDloH0r7mk2Jwn4oKUvealKE9cQ=
+github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.15.0 h1:cqjh4d8HYNQrDoEmlSGelHmg2DYDh5yayckvJ5bV18E=

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1U
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
@@ -373,8 +375,6 @@ github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsK
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
-github.com/hashicorp/hcp-sdk-go v0.14.0 h1:0+elHACiRu4L+rR+1k9khlu7zaGYq9e/8gy4N4pz0NU=
-github.com/hashicorp/hcp-sdk-go v0.14.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4 h1:H4V7J/mUKzMpmTqnnDloH0r7mk2Jwn4oKUvealKE9cQ=
 github.com/hashicorp/hcp-sdk-go v0.15.1-0.20220112153249-f565607d7cc4/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -17,8 +17,8 @@ import (
 	cloud_consul "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/client/consul_service"
 
-	cloud_vault "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/preview/2020-11-25/client"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/preview/2020-11-25/client/vault_service"
+	cloud_vault "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client/vault_service"
 
 	cloud_packer "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/preview/2020-11-25/client/vault_service"
-	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/preview/2020-11-25/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client/vault_service"
+	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
 )
 
 // GetVaultClusterByID gets an Vault cluster by its ID.

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -114,7 +114,7 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 	if !time.Time(iteration.RevokeAt).IsZero() {
 		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
 		// to build new images.
-		return diag.Errorf("the iteration %s is revoked and can not be used", iteration.ID)
+		return diag.Errorf("the iteration %s is revoked and can not be used. A valid iteration should be used instead.", iteration.ID)
 	}
 
 	found := false

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -111,6 +111,12 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	if !time.Time(iteration.RevokeAt).IsZero() {
+		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
+		// to build new images.
+		return diag.Errorf("the iteration %s is revoked and can not be used", iteration.ID)
+	}
+
 	found := false
 	for _, build := range iteration.Builds {
 		if build.CloudProvider != cloudProvider {

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -171,7 +171,8 @@ func dataSourcePackerImageIterationRead(ctx context.Context, d *schema.ResourceD
 	if !time.Time(iteration.RevokeAt).IsZero() {
 		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
 		// to build new images.
-		return diag.Errorf("the iteration %s is revoked and can not be used", iteration.ID)
+		return diag.Errorf("the iteration %s assigned to channel %s is revoked and can not be used. A valid iteration"+
+			" must be assigned to this channel before proceeding", iteration.ID, channelSlug)
 	}
 
 	d.SetId(iteration.ID)

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -2,11 +2,15 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/google/uuid"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-operation/preview/2020-05-05/client/operation_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/client/packer_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
@@ -17,8 +21,9 @@ import (
 )
 
 const (
-	acctestBucket  = "alpine-acctest"
-	acctestChannel = "production"
+	acctestAlpineBucket      = "alpine-acctest"
+	acctestUbuntuBucket      = "ubuntu-acctest"
+	acctestProductionChannel = "production"
 )
 
 var (
@@ -26,8 +31,95 @@ var (
 	data "hcp_packer_image_iteration" "alpine" {
 		bucket_name  = %q
 		channel = %q
-	}`, acctestBucket, acctestChannel)
+	}`, acctestAlpineBucket, acctestProductionChannel)
+	testAccPackerUbuntuProductionImage = fmt.Sprintf(`
+	data "hcp_packer_image_iteration" "ubuntu" {
+		bucket_name  = %q
+		channel = %q
+	}`, acctestUbuntuBucket, acctestProductionChannel)
 )
+
+func upsertRegistry(t *testing.T) {
+	t.Helper()
+
+	client := testAccProvider.Meta().(*clients.Client)
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		OrganizationID: client.Config.OrganizationID,
+		ProjectID:      client.Config.ProjectID,
+	}
+
+	params := packer_service.NewPackerServiceCreateRegistryParams()
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+	params.Body = &models.HashicorpCloudPackerCreateRegistryRequest{
+		FeatureTier: models.HashicorpCloudPackerRegistryConfigTierSTANDARD,
+	}
+
+	resp, err := client.Packer.PackerServiceCreateRegistry(params, nil)
+	if err, ok := err.(*packer_service.PackerServiceCreateRegistryDefault); ok {
+		switch err.Code() {
+		case int(codes.AlreadyExists), http.StatusConflict:
+			// all good here !
+			return
+		default:
+			t.Errorf("unexpected CreateRegistry error, expected nil or 409. Got code: %d err: %v", err.Code(), err)
+			return
+		}
+	}
+
+	waitForOperation(t, loc, "Create Registry", resp.Payload.Operation.ID, client)
+	return
+}
+
+func waitForOperation(
+	t *testing.T,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	operationName string,
+	operationID string,
+	client *clients.Client,
+) {
+	timeout := "5s"
+	params := operation_service.NewWaitParams()
+	params.ID = operationID
+	params.Timeout = &timeout
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+
+	operation := func() error {
+		resp, err := client.Operation.Wait(params, nil)
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
+		}
+
+		if resp.Payload.Operation.Error != nil {
+			t.Errorf("Operation failed: %s", resp.Payload.Operation.Error.Message)
+		}
+
+		switch resp.Payload.Operation.State {
+		case "PENDING":
+			msg := fmt.Sprintf("==> Operation \"%s\" pending...", operationName)
+			return fmt.Errorf(msg)
+		case "RUNNING":
+			msg := fmt.Sprintf("==> Operation \"%s\" running...", operationName)
+			return fmt.Errorf(msg)
+		case "DONE":
+		default:
+			t.Errorf("Operation returned unknown state: %s", resp.Payload.Operation.State)
+		}
+		return nil
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 10 * time.Second
+	bo.RandomizationFactor = 0.5
+	bo.Multiplier = 1.5
+	bo.MaxInterval = 30 * time.Second
+	bo.MaxElapsedTime = 40 * time.Minute
+	err := backoff.Retry(operation, bo)
+	if err != nil {
+		t.Errorf("unexpected error: %#v", err)
+	}
+}
 
 func upsertBucket(t *testing.T, bucketSlug string) {
 	t.Helper()
@@ -93,7 +185,7 @@ func upsertIteration(t *testing.T, bucketSlug, fingerprint string) {
 	t.Errorf("unexpected CreateIteration error, expected nil or 409. Got %v", err)
 }
 
-func revokeIteration(t *testing.T, iterationID, revokeIn string) {
+func revokeIteration(t *testing.T, iterationID, bucketSlug, revokeIn string) {
 	t.Helper()
 	client := testAccProvider.Meta().(*clients.Client)
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
@@ -105,7 +197,10 @@ func revokeIteration(t *testing.T, iterationID, revokeIn string) {
 	params.LocationOrganizationID = loc.OrganizationID
 	params.LocationProjectID = loc.ProjectID
 	params.IterationID = iterationID
-	params.Body = &models.HashicorpCloudPackerUpdateIterationRequest{RevokeIn: revokeIn}
+	params.Body = &models.HashicorpCloudPackerUpdateIterationRequest{
+		BucketSlug: bucketSlug,
+		RevokeIn:   revokeIn,
+	}
 
 	_, err := client.Packer.PackerServiceUpdateIteration(params, nil)
 	if err != nil {
@@ -204,7 +299,7 @@ func upsertBuild(t *testing.T, bucketSlug, fingerprint, iterationID string) {
 	}
 }
 
-func createChannel(t *testing.T, bucketSlug, channelSlug string) {
+func createChannel(t *testing.T, bucketSlug, channelSlug, iterationID string) {
 	t.Helper()
 
 	client := testAccProvider.Meta().(*clients.Client)
@@ -218,8 +313,8 @@ func createChannel(t *testing.T, bucketSlug, channelSlug string) {
 	createChParams.LocationProjectID = loc.ProjectID
 	createChParams.BucketSlug = bucketSlug
 	createChParams.Body = &models.HashicorpCloudPackerCreateChannelRequest{
-		Slug:               channelSlug,
-		IncrementalVersion: 1,
+		Slug:        channelSlug,
+		IterationID: iterationID,
 	}
 
 	_, err := client.Packer.PackerServiceCreateChannel(createChParams, nil)
@@ -228,16 +323,16 @@ func createChannel(t *testing.T, bucketSlug, channelSlug string) {
 	}
 	if err, ok := err.(*packer_service.PackerServiceCreateChannelDefault); ok {
 		switch err.Code() {
-		case int(codes.Aborted), http.StatusConflict:
+		case int(codes.AlreadyExists), http.StatusConflict:
 			// all good here !
-			updateChannel(t, bucketSlug, channelSlug)
+			updateChannel(t, bucketSlug, channelSlug, iterationID)
 			return
 		}
 	}
 	t.Errorf("unexpected CreateChannel error, expected nil. Got %v", err)
 }
 
-func updateChannel(t *testing.T, bucketSlug, channelSlug string) {
+func updateChannel(t *testing.T, bucketSlug, channelSlug, iterationID string) {
 	t.Helper()
 
 	client := testAccProvider.Meta().(*clients.Client)
@@ -252,7 +347,7 @@ func updateChannel(t *testing.T, bucketSlug, channelSlug string) {
 	updateChParams.BucketSlug = bucketSlug
 	updateChParams.Slug = channelSlug
 	updateChParams.Body = &models.HashicorpCloudPackerUpdateChannelRequest{
-		IncrementalVersion: 1,
+		IterationID: iterationID,
 	}
 
 	_, err := client.Packer.PackerServiceUpdateChannel(updateChParams, nil)
@@ -335,24 +430,24 @@ func TestAcc_dataSourcePacker(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t, false) },
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(*terraform.State) error {
-			itID := getIterationIDFromFingerPrint(t, acctestBucket, fingerprint)
-			deleteChannel(t, acctestBucket, acctestChannel)
-			deleteIteration(t, acctestBucket, itID)
-			deleteBucket(t, acctestBucket)
+			itID := getIterationIDFromFingerPrint(t, acctestAlpineBucket, fingerprint)
+			deleteChannel(t, acctestAlpineBucket, acctestProductionChannel)
+			deleteIteration(t, acctestAlpineBucket, itID)
+			deleteBucket(t, acctestAlpineBucket)
 			return nil
 		},
 
 		Steps: []resource.TestStep{
 			// testing that getting the production channel of the alpine image
 			// works.
-
 			{
 				PreConfig: func() {
-					upsertBucket(t, acctestBucket)
-					upsertIteration(t, acctestBucket, fingerprint)
-					itID := getIterationIDFromFingerPrint(t, acctestBucket, fingerprint)
-					upsertBuild(t, acctestBucket, fingerprint, itID)
-					createChannel(t, acctestBucket, acctestChannel)
+					upsertRegistry(t)
+					upsertBucket(t, acctestAlpineBucket)
+					upsertIteration(t, acctestAlpineBucket, fingerprint)
+					itID := getIterationIDFromFingerPrint(t, acctestAlpineBucket, fingerprint)
+					upsertBuild(t, acctestAlpineBucket, fingerprint, itID)
+					createChannel(t, acctestAlpineBucket, acctestProductionChannel, itID)
 				},
 				Config: testConfig(testAccPackerAlpineProductionImage),
 				Check: resource.ComposeTestCheckFunc(
@@ -365,39 +460,37 @@ func TestAcc_dataSourcePacker(t *testing.T) {
 }
 
 func TestAcc_dataSourcePacker_revokedIteration(t *testing.T) {
-	resourceName := "data.hcp_packer_image_iteration.alpine"
-	fingerprint := "43"
+	fingerprint := fmt.Sprintf("%d", rand.Int())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t, false) },
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(*terraform.State) error {
-			itID := getIterationIDFromFingerPrint(t, acctestBucket, fingerprint)
-			deleteChannel(t, acctestBucket, acctestChannel)
-			deleteIteration(t, acctestBucket, itID)
-			deleteBucket(t, acctestBucket)
+			itID := getIterationIDFromFingerPrint(t, acctestUbuntuBucket, fingerprint)
+			deleteChannel(t, acctestUbuntuBucket, acctestProductionChannel)
+			deleteIteration(t, acctestUbuntuBucket, itID)
+			deleteBucket(t, acctestUbuntuBucket)
 			return nil
 		},
 		Steps: []resource.TestStep{
 			// testing that getting a revoked iteration fails properly
 			{
 				PreConfig: func() {
-					upsertBucket(t, acctestBucket)
-					upsertIteration(t, acctestBucket, fingerprint)
-					itID := getIterationIDFromFingerPrint(t, acctestBucket, fingerprint)
-					upsertBuild(t, acctestBucket, fingerprint, itID)
-					createChannel(t, acctestBucket, acctestChannel)
+					upsertRegistry(t)
+					upsertBucket(t, acctestUbuntuBucket)
+					upsertIteration(t, acctestUbuntuBucket, fingerprint)
+					itID := getIterationIDFromFingerPrint(t, acctestUbuntuBucket, fingerprint)
+					upsertBuild(t, acctestUbuntuBucket, fingerprint, itID)
+					createChannel(t, acctestUbuntuBucket, acctestProductionChannel, itID)
 					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
 					// it's assigned to a channel
-					revokeIteration(t, itID, "5s")
+					revokeIteration(t, itID, acctestUbuntuBucket, "5s")
 					// Sleep to make sure the iteration is revoked when we test
 					time.Sleep(5 * time.Second)
 				},
-				Config: testConfig(testAccPackerAlpineProductionImage),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-				),
+				Config:      testConfig(testAccPackerUbuntuProductionImage),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} is revoked and can not be used`),
 			},
 		},
 	})

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -2,15 +2,19 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
-	acctestImageBucket  = "alpine-acctest-imagetest"
-	acctestImageChannel = "production-image-test"
+	acctestImageBucket       = "alpine-acctest-imagetest"
+	acctestImageUbuntuBucket = "ubuntu-acctest-imagetest"
+	acctestImageChannel      = "production-image-test"
 )
 
 var (
@@ -26,6 +30,18 @@ var (
 		iteration_id   = data.hcp_packer_iteration.alpine-imagetest.id
 		region         = "us-east-1"
 	}`, acctestImageBucket, acctestImageChannel, acctestImageBucket)
+	testAccPackerImageUbuntuProduction = fmt.Sprintf(`
+	data "hcp_packer_iteration" "ubuntu-imagetest" {
+		bucket_name  = %q
+		channel = %q
+	}
+
+	data "hcp_packer_image" "foo" {
+		bucket_name    = %q
+		cloud_provider = "aws"
+		iteration_id   = data.hcp_packer_iteration.ubuntu-imagetest.id
+		region         = "us-east-1"
+	}`, acctestImageUbuntuBucket, acctestImageChannel, acctestImageUbuntuBucket)
 )
 
 func TestAcc_dataSourcePackerImage(t *testing.T) {
@@ -52,7 +68,7 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 					upsertIteration(t, acctestImageBucket, fingerprint)
 					itID := getIterationIDFromFingerPrint(t, acctestImageBucket, fingerprint)
 					upsertBuild(t, acctestImageBucket, fingerprint, itID)
-					createChannel(t, acctestImageBucket, acctestImageChannel)
+					createChannel(t, acctestImageBucket, acctestImageChannel, itID)
 				},
 				Config: testAccPackerImageAlpineProduction,
 				Check: resource.ComposeTestCheckFunc(
@@ -60,6 +76,44 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr("data.hcp_packer_image.foo", "labels.test-key", "test-value"),
 				),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
+	fingerprint := fmt.Sprintf("%d", rand.Int())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, false) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			itID := getIterationIDFromFingerPrint(t, acctestImageUbuntuBucket, fingerprint)
+			deleteChannel(t, acctestImageUbuntuBucket, acctestImageChannel)
+			deleteIteration(t, acctestImageUbuntuBucket, itID)
+			deleteBucket(t, acctestImageUbuntuBucket)
+			return nil
+		},
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			// Testing that getting the production channel of the alpine image
+			// works.
+			{
+				PreConfig: func() {
+					upsertBucket(t, acctestImageUbuntuBucket)
+					upsertIteration(t, acctestImageUbuntuBucket, fingerprint)
+					itID := getIterationIDFromFingerPrint(t, acctestImageUbuntuBucket, fingerprint)
+					upsertBuild(t, acctestImageUbuntuBucket, fingerprint, itID)
+					createChannel(t, acctestImageUbuntuBucket, acctestImageChannel, itID)
+					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
+					// it's assigned to a channel
+					revokeIteration(t, itID, acctestImageUbuntuBucket, "5s")
+					// Sleep to make sure the iteration is revoked when we test
+					time.Sleep(5 * time.Second)
+				},
+				Config:      testAccPackerImageUbuntuProduction,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} is revoked and can not be used`),
 			},
 		},
 	})

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -2,19 +2,15 @@ package provider
 
 import (
 	"fmt"
-	"math/rand"
-	"regexp"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
-	acctestImageBucket       = "alpine-acctest-imagetest"
-	acctestImageUbuntuBucket = "ubuntu-acctest-imagetest"
-	acctestImageChannel      = "production-image-test"
+	acctestImageBucket  = "alpine-acctest-imagetest"
+	acctestImageChannel = "production-image-test"
 )
 
 var (
@@ -30,18 +26,6 @@ var (
 		iteration_id   = data.hcp_packer_iteration.alpine-imagetest.id
 		region         = "us-east-1"
 	}`, acctestImageBucket, acctestImageChannel, acctestImageBucket)
-	testAccPackerImageUbuntuProduction = fmt.Sprintf(`
-	data "hcp_packer_iteration" "ubuntu-imagetest" {
-		bucket_name  = %q
-		channel = %q
-	}
-
-	data "hcp_packer_image" "foo" {
-		bucket_name    = %q
-		cloud_provider = "aws"
-		iteration_id   = data.hcp_packer_iteration.ubuntu-imagetest.id
-		region         = "us-east-1"
-	}`, acctestImageUbuntuBucket, acctestImageChannel, acctestImageUbuntuBucket)
 )
 
 func TestAcc_dataSourcePackerImage(t *testing.T) {
@@ -52,10 +36,9 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t, false) },
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(*terraform.State) error {
-			itID := getIterationIDFromFingerPrint(t, acctestImageBucket, fingerprint)
-			deleteChannel(t, acctestImageBucket, acctestImageChannel)
-			deleteIteration(t, acctestImageBucket, itID)
-			deleteBucket(t, acctestImageBucket)
+			deleteChannel(t, acctestImageBucket, acctestImageChannel, false)
+			deleteIteration(t, acctestImageBucket, fingerprint, false)
+			deleteBucket(t, acctestImageBucket, false)
 			return nil
 		},
 		PreventPostDestroyRefresh: true,
@@ -66,7 +49,10 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 				PreConfig: func() {
 					upsertBucket(t, acctestImageBucket)
 					upsertIteration(t, acctestImageBucket, fingerprint)
-					itID := getIterationIDFromFingerPrint(t, acctestImageBucket, fingerprint)
+					itID, err := getIterationIDFromFingerPrint(t, acctestImageBucket, fingerprint)
+					if err != nil {
+						t.Fatal(err.Error())
+					}
 					upsertBuild(t, acctestImageBucket, fingerprint, itID)
 					createChannel(t, acctestImageBucket, acctestImageChannel, itID)
 				},
@@ -76,44 +62,6 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr("data.hcp_packer_image.foo", "labels.test-key", "test-value"),
 				),
-			},
-		},
-	})
-}
-
-func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
-	fingerprint := fmt.Sprintf("%d", rand.Int())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t, false) },
-		ProviderFactories: providerFactories,
-		CheckDestroy: func(*terraform.State) error {
-			itID := getIterationIDFromFingerPrint(t, acctestImageUbuntuBucket, fingerprint)
-			deleteChannel(t, acctestImageUbuntuBucket, acctestImageChannel)
-			deleteIteration(t, acctestImageUbuntuBucket, itID)
-			deleteBucket(t, acctestImageUbuntuBucket)
-			return nil
-		},
-		PreventPostDestroyRefresh: true,
-		Steps: []resource.TestStep{
-			// Testing that getting the production channel of the alpine image
-			// works.
-			{
-				PreConfig: func() {
-					upsertBucket(t, acctestImageUbuntuBucket)
-					upsertIteration(t, acctestImageUbuntuBucket, fingerprint)
-					itID := getIterationIDFromFingerPrint(t, acctestImageUbuntuBucket, fingerprint)
-					upsertBuild(t, acctestImageUbuntuBucket, fingerprint, itID)
-					createChannel(t, acctestImageUbuntuBucket, acctestImageChannel, itID)
-					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
-					// it's assigned to a channel
-					revokeIteration(t, itID, acctestImageUbuntuBucket, "5s")
-					// Sleep to make sure the iteration is revoked when we test
-					time.Sleep(5 * time.Second)
-				},
-				Config:      testAccPackerImageUbuntuProduction,
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} is revoked and can not be used`),
 			},
 		},
 	})

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -107,7 +107,8 @@ func dataSourcePackerIterationRead(ctx context.Context, d *schema.ResourceData, 
 	if !time.Time(iteration.RevokeAt).IsZero() {
 		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
 		// to build new images.
-		return diag.Errorf("the iteration %s is revoked and can not be used", iteration.ID)
+		return diag.Errorf("the iteration %s assigned to channel %s is revoked and can not be used. A valid iteration"+
+			" must be assigned to this channel before proceeding", iteration.ID, channelSlug)
 	}
 
 	d.SetId(iteration.ID)

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"log"
+	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -98,13 +99,18 @@ func dataSourcePackerIterationRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	if channel.Pointer == nil {
+	if channel.Iteration == nil {
 		return diag.Errorf("no iteration information found for the specified channel %s", channelSlug)
 	}
 
-	iteration := channel.Pointer.Iteration
+	iteration := channel.Iteration
+	if !time.Time(iteration.RevokeAt).IsZero() {
+		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
+		// to build new images.
+		return diag.Errorf("the iteration %s is revoked and can not be used", iteration.ID)
+	}
 
-	d.SetId(channel.Pointer.Iteration.ID)
+	d.SetId(iteration.ID)
 
 	if err := d.Set("author_id", iteration.AuthorID); err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -2,15 +2,19 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
-	acctestIterationBucket  = "alpine-acctest-itertest"
-	acctestIterationChannel = "production-iter-test"
+	acctestIterationBucket       = "alpine-acctest-itertest"
+	acctestIterationUbuntuBucket = "ubuntu-acctest-itertest"
+	acctestIterationChannel      = "production-iter-test"
 )
 
 var (
@@ -19,6 +23,11 @@ var (
 		bucket_name  = %q
 		channel = %q
 	}`, acctestIterationBucket, acctestIterationChannel)
+	testAccPackerIterationUbuntuProduction = fmt.Sprintf(`
+	data "hcp_packer_iteration" "ubuntu" {
+		bucket_name  = %q
+		channel = %q
+	}`, acctestIterationUbuntuBucket, acctestIterationChannel)
 )
 
 func TestAcc_dataSourcePackerIteration(t *testing.T) {
@@ -45,13 +54,51 @@ func TestAcc_dataSourcePackerIteration(t *testing.T) {
 					upsertIteration(t, acctestIterationBucket, fingerprint)
 					itID := getIterationIDFromFingerPrint(t, acctestIterationBucket, fingerprint)
 					upsertBuild(t, acctestIterationBucket, fingerprint, itID)
-					createChannel(t, acctestIterationBucket, acctestIterationChannel)
+					createChannel(t, acctestIterationBucket, acctestIterationChannel, itID)
 				},
 				Config: testConfig(testAccPackerIterationAlpineProduction),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 				),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
+	fingerprint := fmt.Sprintf("%d", rand.Int())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, false) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			itID := getIterationIDFromFingerPrint(t, acctestIterationUbuntuBucket, fingerprint)
+			deleteChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel)
+			deleteIteration(t, acctestIterationUbuntuBucket, itID)
+			deleteBucket(t, acctestIterationUbuntuBucket)
+			return nil
+		},
+
+		Steps: []resource.TestStep{
+			// testing that getting the production channel of the alpine image
+			// works.
+			{
+				PreConfig: func() {
+					upsertBucket(t, acctestIterationUbuntuBucket)
+					upsertIteration(t, acctestIterationUbuntuBucket, fingerprint)
+					itID := getIterationIDFromFingerPrint(t, acctestIterationUbuntuBucket, fingerprint)
+					upsertBuild(t, acctestIterationUbuntuBucket, fingerprint, itID)
+					createChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, itID)
+					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
+					// it's assigned to a channel
+					revokeIteration(t, itID, acctestIterationUbuntuBucket, "5s")
+					// Sleep to make sure the iteration is revoked when we test
+					time.Sleep(5 * time.Second)
+				},
+				Config:      testConfig(testAccPackerIterationUbuntuProduction),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} is revoked and can not be used`),
 			},
 		},
 	})

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/preview/2020-11-25/models"
+	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-cty/cty"
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2021-02-04/models"
-	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/preview/2020-11-25/models"
+	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -376,8 +376,8 @@ func Test_validateVaultClusterTier(t *testing.T) {
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,
-					Summary:       "expected 'development' to be one of: [dev standard_small standard_medium standard_large starter_small]",
-					Detail:        "expected 'development' to be one of: [dev standard_small standard_medium standard_large starter_small] (value is case-insensitive).",
+					Summary:       "expected 'development' to be one of: [dev standard_small standard_medium standard_large starter_small plus_small plus_medium plus_large]",
+					Detail:        "expected 'development' to be one of: [dev standard_small standard_medium standard_large starter_small plus_small plus_medium plus_large] (value is case-insensitive).",
 					AttributePath: nil,
 				},
 			},


### PR DESCRIPTION
### :hammer_and_wrench: Description

This adds a check for revoked iterations. For HCP Packer GA, revoking iterations will be possible and if an iteration is revoked it must never be used and the `terraform plan|apply` should fail. 

Since I updated the hcp-sdk-go version, I had to make some changes to vault's import and tests. Changes were checked and validated with @kkredit 

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* datasource/hcp_packer_image: Add check for revoked iterations [GH-240]
* datasource/hcp_packer_iteration: Add check for revoked iterations [GH-240]
* datasource/hcp_packer_image_iteration: Add check for revoked iterations [GH-240]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAcc_dataSourcePacker'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAcc_dataSourcePackerImage -timeout 120m
?       github.com/hashicorp/terraform-provider-hcp/internal/clients    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (27.25s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (13.53s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   41.102s
...
```
