### PR TITLE
Prep v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.22.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* datasource/packer: Add check for revoked iterations to HCP Packer datasources ([#240](https://github.com/hashicorp/terraform-provider-hcp/issues/240))
+
+FIXES:
+
+* docs: Correct root token documentation ([#241](https://github.com/hashicorp/terraform-provider-hcp/issues/241))
+
 ## 0.21.1 (December 09, 2021)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.21.1"
+      version = "~> 0.22.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.21.1"
+      version = "~> 0.22.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps release of v0.22.0, which includes a Consul doc fix and a Packer datasource improvement.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc 

--- PASS: TestAccHvnPeering (631.62s)
--- PASS: TestAccTGWAttachment (528.28s)
--- PASS: TestAccConsulCluster (1403.59s)
--- PASS: TestAccConsulSnapshot (830.49s)
--- PASS: TestAccHvnPeeringConnection (262.14s)
--- PASS: TestAccHvnRoute (581.28s)
--- PASS: TestAccHvn (151.58s)

# make testacc TESTARGS='-run=TestAccVaultCluster'

--- PASS: TestAccVaultCluster (2093.66s)
```
