### PR TITLE
TCE-1769: Azure networking resources (internal only)

### DIFF
--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -37,7 +37,7 @@ resource "hcp_hvn" "example" {
 
 ### Required
 
-- **cloud_provider** (String) The provider where the HVN is located. Only 'aws' and 'azure' are available at this time.
+- **cloud_provider** (String) The provider where the HVN is located. Only 'aws' is available at this time.
 - **hvn_id** (String) The ID of the HashiCorp Virtual Network (HVN).
 - **region** (String) The region where the HVN is located.
 

--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -37,7 +37,7 @@ resource "hcp_hvn" "example" {
 
 ### Required
 
-- **cloud_provider** (String) The provider where the HVN is located. Only 'aws' is available at this time.
+- **cloud_provider** (String) The provider where the HVN is located. Only 'aws' and 'azure' are available at this time.
 - **hvn_id** (String) The ID of the HashiCorp Virtual Network (HVN).
 - **region** (String) The region where the HVN is located.
 

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -34,6 +34,7 @@ var deleteConsulClusterTimeout = time.Minute * 25
 // where a HCP Consul cluster can be provisioned.
 var consulCusterResourceCloudProviders = []string{
 	"aws",
+	"azure",
 }
 
 // resourceConsulCluster represents an HCP Consul cluster.

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -34,6 +34,7 @@ var deleteConsulClusterTimeout = time.Minute * 25
 // where a HCP Consul cluster can be provisioned.
 var consulCusterResourceCloudProviders = []string{
 	"aws",
+	// Available to internal users only
 	"azure",
 }
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -22,6 +22,7 @@ var hvnDeleteTimeout = time.Minute * 10
 
 var hvnResourceCloudProviders = []string{
 	"aws",
+	// Available to internal users only
 	"azure",
 }
 
@@ -51,7 +52,7 @@ func resourceHvn() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			"cloud_provider": {
-				Description:      "The provider where the HVN is located. Only 'aws' and 'azure' are available at this time.",
+				Description:      "The provider where the HVN is located. Only 'aws' is available at this time.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -284,8 +284,8 @@ func setHvnResourceData(d *schema.ResourceData, hvn *networkmodels.HashicorpClou
 	case "aws":
 		providerAccountID = hvn.ProviderNetworkData.AwsNetworkData.AccountID
 	case "azure":
-		providerAccountID = "azure-todo"
 		// TODO: providerAccountID = hvn.ProviderNetworkData.AzureNetworkData.TenantID
+		providerAccountID = ""
 	}
 	if err := d.Set("provider_account_id", providerAccountID); err != nil {
 		return err

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -277,7 +277,16 @@ func setHvnResourceData(d *schema.ResourceData, hvn *networkmodels.HashicorpClou
 	if err := d.Set("created_at", hvn.CreatedAt.String()); err != nil {
 		return err
 	}
-	if err := d.Set("provider_account_id", hvn.ProviderNetworkData.AwsNetworkData.AccountID); err != nil {
+
+	var providerAccountID string
+	switch d.Get("cloud_provider") {
+	case "aws":
+		providerAccountID = hvn.ProviderNetworkData.AwsNetworkData.AccountID
+	case "azure":
+		providerAccountID = "azure-todo"
+		// TODO: providerAccountID = hvn.ProviderNetworkData.AzureNetworkData.TenantID
+	}
+	if err := d.Set("provider_account_id", providerAccountID); err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -22,6 +22,7 @@ var hvnDeleteTimeout = time.Minute * 10
 
 var hvnResourceCloudProviders = []string{
 	"aws",
+	"azure",
 }
 
 func resourceHvn() *schema.Resource {
@@ -50,7 +51,7 @@ func resourceHvn() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			"cloud_provider": {
-				Description:      "The provider where the HVN is located. Only 'aws' is available at this time.",
+				Description:      "The provider where the HVN is located. Only 'aws' and 'azure' are available at this time.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,

--- a/internal/provider/resource_hvn_test.go
+++ b/internal/provider/resource_hvn_test.go
@@ -29,7 +29,7 @@ var testAccAzureHvnConfig = `
 resource "hcp_hvn" "test" {
 	hvn_id         = "test-hvn"
 	cloud_provider = "azure"
-	region         = "westus2"
+	region         = "useast"
 }
 
 data "hcp_hvn" "test" {
@@ -57,7 +57,7 @@ func TestAccHvn(t *testing.T) {
 		"when the cloud provider is Azure": {
 			testAccAzureHvnConfig,
 			"azure",
-			"westus2",
+			"useast",
 		},
 	}
 

--- a/internal/provider/resource_hvn_test.go
+++ b/internal/provider/resource_hvn_test.go
@@ -24,6 +24,7 @@ data "hcp_hvn" "test" {
 }
 `
 
+// Currently internal only
 var testAccAzureHvnConfig = `
 resource "hcp_hvn" "test" {
 	hvn_id         = "test-hvn"
@@ -52,6 +53,7 @@ func TestAccHvn(t *testing.T) {
 			"aws",
 			"us-west-2",
 		},
+		// Currently internal only
 		"when the cloud provider is Azure": {
 			testAccAzureHvnConfig,
 			"azure",

--- a/internal/provider/resource_hvn_test.go
+++ b/internal/provider/resource_hvn_test.go
@@ -12,11 +12,23 @@ import (
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-var testAccHvnConfig = `
+var testAccAwsHvnConfig = `
 resource "hcp_hvn" "test" {
 	hvn_id         = "test-hvn"
 	cloud_provider = "aws"
 	region         = "us-west-2"
+}
+
+data "hcp_hvn" "test" {
+	hvn_id = hcp_hvn.test.hvn_id
+}
+`
+
+var testAccAzureHvnConfig = `
+resource "hcp_hvn" "test" {
+	hvn_id         = "test-hvn"
+	cloud_provider = "azure"
+	region         = "westus2"
 }
 
 data "hcp_hvn" "test" {
@@ -30,74 +42,93 @@ func TestAccHvn(t *testing.T) {
 	resourceName := "hcp_hvn.test"
 	dataSourceName := "data.hcp_hvn.test"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t, false) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testAccCheckHvnDestroy,
-		Steps: []resource.TestStep{
-			// Tests create
-			{
-				Config: testConfig(testAccHvnConfig),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHvnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
-					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
-					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
-					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
-					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
-				),
-			},
-			// Tests import
-			{
-				ResourceName: resourceName,
-				ImportState:  true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs, ok := s.RootModule().Resources[resourceName]
-					if !ok {
-						return "", fmt.Errorf("not found: %s", resourceName)
-					}
-
-					return rs.Primary.Attributes["hvn_id"], nil
-				},
-				ImportStateVerify: true,
-			},
-			// Tests read
-			{
-				Config: testConfig(testAccHvnConfig),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHvnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
-					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
-					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
-					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
-					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
-				),
-			},
-			// Tests datasource
-			{
-				Config: testConfig(testAccHvnConfig),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName, "hvn_id", dataSourceName, "hvn_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "cloud_provider", dataSourceName, "cloud_provider"),
-					resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "region"),
-					resource.TestCheckResourceAttrPair(resourceName, "cidr_block", dataSourceName, "cidr_block"),
-					resource.TestCheckResourceAttrPair(resourceName, "organization_id", dataSourceName, "organization_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "project_id", dataSourceName, "project_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "provider_account_id", dataSourceName, "provider_account_id"),
-					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
-					resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
-				),
-			},
+	cases := map[string]struct {
+		config   string
+		provider string
+		region   string
+	}{
+		"when the cloud provider is AWS": {
+			testAccAwsHvnConfig,
+			"aws",
+			"us-west-2",
 		},
-	})
+		"when the cloud provider is Azure": {
+			testAccAzureHvnConfig,
+			"azure",
+			"westus2",
+		},
+	}
+
+	for _, tc := range cases {
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t, false) },
+			ProviderFactories: providerFactories,
+			CheckDestroy:      testAccCheckHvnDestroy,
+			Steps: []resource.TestStep{
+				// Tests create
+				{
+					Config: testConfig(tc.config),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckHvnExists(resourceName),
+						resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+						resource.TestCheckResourceAttr(resourceName, "cloud_provider", tc.provider),
+						resource.TestCheckResourceAttr(resourceName, "region", tc.region),
+						resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+						resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+						resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+						resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+						resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
+						testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+					),
+				},
+				// Tests import
+				{
+					ResourceName: resourceName,
+					ImportState:  true,
+					ImportStateIdFunc: func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return "", fmt.Errorf("not found: %s", resourceName)
+						}
+
+						return rs.Primary.Attributes["hvn_id"], nil
+					},
+					ImportStateVerify: true,
+				},
+				// Tests read
+				{
+					Config: testConfig(tc.config),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckHvnExists(resourceName),
+						resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+						resource.TestCheckResourceAttr(resourceName, "cloud_provider", tc.provider),
+						resource.TestCheckResourceAttr(resourceName, "region", tc.region),
+						resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+						resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+						resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+						resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+						resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
+						testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+					),
+				},
+				// Tests datasource
+				{
+					Config: testConfig(tc.config),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrPair(resourceName, "hvn_id", dataSourceName, "hvn_id"),
+						resource.TestCheckResourceAttrPair(resourceName, "cloud_provider", dataSourceName, "cloud_provider"),
+						resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "region"),
+						resource.TestCheckResourceAttrPair(resourceName, "cidr_block", dataSourceName, "cidr_block"),
+						resource.TestCheckResourceAttrPair(resourceName, "organization_id", dataSourceName, "organization_id"),
+						resource.TestCheckResourceAttrPair(resourceName, "project_id", dataSourceName, "project_id"),
+						resource.TestCheckResourceAttrPair(resourceName, "provider_account_id", dataSourceName, "provider_account_id"),
+						resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
+						resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
+					),
+				},
+			},
+		})
+	}
 }
 
 func testAccCheckHvnExists(name string) resource.TestCheckFunc {


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR adds support for Consul on Azure with updates to the `hcp_hvn` and `hcp_consul_cluster` resources. **This feature is available for internal users only.**

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* resource/consul_cluster: adds Azure on Consul (internal only)  [GH-247]
```

### 🧪 Example Config
```
provider "hcp" {}

resource "hcp_hvn" "hvn" {
  hvn_id         = "hvn-test"
  cloud_provider = "azure"
  region         = "useast"
  cidr_block     = "172.25.16.0/20"
}

resource "hcp_consul_cluster" "example" {
  cluster_id = "azure-consul-cluster"
  hvn_id     = hcp_hvn.hvn.hvn_id
  tier       = "standard"
  size       = "small"
}
```

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

TODO.
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
