### PR TITLE
HCS-2849: Do not suppress min_consul_version on creation

### DIFF
--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -96,8 +96,11 @@ func resourceConsulCluster() *schema.Resource {
 				ValidateDiagFunc: validateSemVer,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 					// Suppress diff for non specified value
-					if new == "" || old == "" {
+					if new == "" {
 						return true
+					}
+					if old == "" {
+						return false
 					}
 
 					actualConsulVersion := version.Must(version.NewVersion(old))

--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -12,9 +12,10 @@ import (
 
 var consulCluster = `
 resource "hcp_consul_cluster" "test" {
-	cluster_id = "test-consul-cluster"
-	hvn_id     = hcp_hvn.test.hvn_id
-	tier       = "standard"
+	cluster_id         = "test-consul-cluster"
+	hvn_id             = hcp_hvn.test.hvn_id
+	tier               = "standard"
+	min_consul_version = "v1.10.6"
 }
 `
 
@@ -81,7 +82,7 @@ func TestAccConsulCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "consul_config_file"),
 					resource.TestCheckResourceAttrSet(resourceName, "consul_ca_file"),
-					resource.TestCheckResourceAttrSet(resourceName, "consul_version"),
+					resource.TestCheckResourceAttr(resourceName, "consul_version", "v1.10.6"),
 					resource.TestCheckNoResourceAttr(resourceName, "consul_public_endpoint_url"),
 					resource.TestCheckResourceAttrSet(resourceName, "consul_private_endpoint_url"),
 					testAccCheckFullURL(resourceName, "consul_private_endpoint_url", ""),

--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -15,7 +15,7 @@ resource "hcp_consul_cluster" "test" {
 	cluster_id         = "test-consul-cluster"
 	hvn_id             = hcp_hvn.test.hvn_id
 	tier               = "standard"
-	min_consul_version = "v1.10.6"
+	min_consul_version = data.hcp_consul_versions.test.recommended
 }
 `
 
@@ -36,6 +36,8 @@ func setTestAccConsulClusterConfig(consulCluster string) string {
 		region         = "us-west-2"
 	}
 
+	data "hcp_consul_versions" "test" {}
+
 	%s
 	
 	data "hcp_consul_cluster" "test" {
@@ -54,6 +56,7 @@ func setTestAccConsulClusterConfig(consulCluster string) string {
 func TestAccConsulCluster(t *testing.T) {
 	resourceName := "hcp_consul_cluster.test"
 	dataSourceName := "data.hcp_consul_cluster.test"
+	dataSourceVersionName := "data.hcp_consul_versions.test"
 	rootTokenResourceName := "hcp_consul_cluster_root_token.test"
 
 	resource.Test(t, resource.TestCase{
@@ -82,7 +85,7 @@ func TestAccConsulCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "consul_config_file"),
 					resource.TestCheckResourceAttrSet(resourceName, "consul_ca_file"),
-					resource.TestCheckResourceAttr(resourceName, "consul_version", "v1.10.6"),
+					resource.TestCheckResourceAttrPair(resourceName, "consul_version", dataSourceVersionName, "recommended"),
 					resource.TestCheckNoResourceAttr(resourceName, "consul_public_endpoint_url"),
 					resource.TestCheckResourceAttrSet(resourceName, "consul_private_endpoint_url"),
 					testAccCheckFullURL(resourceName, "consul_private_endpoint_url", ""),


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

This commit fixes an issue where we would always suppress the
min_consul_version on create, because a previous value for the cluster
did not exist to compare against.


### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* hcp_consul_cluster: Fix min_consul_version on creation not taking affect [GH-252]
```

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccConsulCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccConsulCluster -timeout 120m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.159s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.117s [no tests to run]




=== RUN   TestAccConsulCluster
--- PASS: TestAccConsulCluster (2036.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	2036.757s
```
