### PR TITLE
Add wait_for_active_state to AWS peering datasource

### DIFF
--- a/docs/data-sources/aws_network_peering.md
+++ b/docs/data-sources/aws_network_peering.md
@@ -14,8 +14,9 @@ The AWS network peering data source provides information about an existing netwo
 
 ```terraform
 data "hcp_aws_network_peering" "test" {
-  hvn_id     = var.hvn_id
-  peering_id = var.peering_id
+  hvn_id                = var.hvn_id
+  peering_id            = var.peering_id
+  wait_for_active_state = true
 }
 ```
 
@@ -31,6 +32,7 @@ data "hcp_aws_network_peering" "test" {
 
 - **id** (String) The ID of this resource.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **wait_for_active_state** (Boolean) If `true`, Terraform will wait for the network peering to reach an `ACTIVE` state before continuing. Default `false`.
 
 ### Read-Only
 

--- a/docs/guides/peering.md
+++ b/docs/guides/peering.md
@@ -39,7 +39,8 @@ resource "aws_vpc" "peer" {
   cidr_block = "10.220.0.0/16"
 }
 
-// Create an HCP network peering to peer your HVN with your AWS VPC.
+// Create an HCP network peering to peer your HVN with your AWS VPC. 
+// This resource initially returns in a Pending state, because its provider_peering_id is required to complete acceptance of the connection.
 resource "hcp_aws_network_peering" "example" {
   peering_id      = var.peer_id
   hvn_id          = hcp_hvn.example.hvn_id
@@ -48,17 +49,25 @@ resource "hcp_aws_network_peering" "example" {
   peer_vpc_region = var.region
 }
 
-// Create an HVN route that targets your HCP network peering and matches your AWS VPC's CIDR block
-resource "hcp_hvn_route" "example" {
-  hvn_link         = hcp_hvn.hvn.self_link
-  hvn_route_id     = var.route_id
-  destination_cidr = aws_vpc.peer.cidr_block
-  target_link      = hcp_aws_network_peering.example.self_link
+// This data source is the same as the resource above, but waits for the connection to be Active before returning.
+data "hcp_aws_network_peering" "example" {
+  hvn_id                = hcp_hvn.example.hvn_id
+  peering_id            = hcp_aws_network_peering.example.peering_id
+  wait_for_active_state = true
 }
 
 // Accept the VPC peering within your AWS account.
 resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = hcp_aws_network_peering.example.provider_peering_id
   auto_accept               = true
+}
+
+// Create an HVN route that targets your HCP network peering and matches your AWS VPC's CIDR block.
+// The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
+resource "hcp_hvn_route" "example" {
+  hvn_link         = hcp_hvn.hvn.self_link
+  hvn_route_id     = var.route_id
+  destination_cidr = aws_vpc.peer.cidr_block
+  target_link      = data.hcp_aws_network_peering.example.self_link
 }
 ```

--- a/examples/data-sources/hcp_aws_network_peering/data-source.tf
+++ b/examples/data-sources/hcp_aws_network_peering/data-source.tf
@@ -1,4 +1,5 @@
 data "hcp_aws_network_peering" "test" {
-  hvn_id     = var.hvn_id
-  peering_id = var.peering_id
+  hvn_id                = var.hvn_id
+  peering_id            = var.peering_id
+  wait_for_active_state = true
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR adds the `wait_for_active_state` to the AWS peering datasource. This flag can be used in conjunction with a peering resource to ensure there is no race condition between HVN route and peering connection creation.

The issue that arises is that the peering resource initially returns in a `pending` state, because it must be accepted on the AWS side (by the `aws_vpc_peering_connection_accepter`). Once it is accepted, it becomes `active`. The HVN route resource requires an active peering connection to successfully create, but since the peering returns in a `pending` state, a race occurs between creation of the HVN route and peering acceptance. The HVN route can get stuck in a `pending` state.

The `wait_for_active_state` flag on the peering datasource solves this issue. Since the datasource will wait for the peering to be `active` before returning, an HVN route can depend on the datasource safely.

⚡ [Implicit dependencies](https://learn.hashicorp.com/tutorials/terraform/dependencies?in=terraform/0-13#manage-implicit-dependencies) must be used to ensure the correct order of creation of resources.

Example TF config.
```
resource "hcp_hvn" "example" {
  hvn_id         = var.hvn_id
  cloud_provider = "aws"
  region         = var.region
  cidr_block     = "172.25.16.0/20"
}

resource "aws_vpc" "peer" {
  cidr_block = "10.220.0.0/16"
}

// This resource initially returns in a Pending state, because its provider_peering_id is required to complete acceptance of the connection.
resource "hcp_aws_network_peering" "example" {
  peering_id      = var.peer_id
  hvn_id          = hcp_hvn.example.hvn_id
  peer_vpc_id     = aws_vpc.peer.id
  peer_account_id = aws_vpc.peer.owner_id
  peer_vpc_region = var.region
}

// This data source is the same as the resource above, but waits for the connection to be Active before returning.
data "hcp_aws_network_peering" "example" {
  hvn_id                = hcp_hvn.example.hvn_id
  peering_id            = hcp_aws_network_peering.example.peering_id
  wait_for_active_state = true
}

// The VPC accepter depends on the hcp_aws_network_peering returning in a pending state.
resource "aws_vpc_peering_connection_accepter" "peer" {
  vpc_peering_connection_id = hcp_aws_network_peering.example.provider_peering_id
  auto_accept               = true
}

// The route depends on the data source, rather than the resource, to ensure the peering is already in an Active state before kicking off creation.
resource "hcp_hvn_route" "example" {
  hvn_link         = hcp_hvn.hvn.self_link
  hvn_route_id     = var.route_id
  destination_cidr = aws_vpc.peer.cidr_block
  target_link      = data.hcp_aws_network_peering.example.self_link
}
```

### :ship: Release Note
```release-note
* aws_network_peering: add wait_for_active_state input [GH-249]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality? 
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsPeering'

--- PASS: TestAccAwsPeering (718.86s)
```
