### PR TITLE
Do not fail packer datasources for iteration with revoke_at set to the future

### DIFF
--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -111,8 +111,9 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	if !time.Time(iteration.RevokeAt).IsZero() {
-		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
+	revokeAt := time.Time(iteration.RevokeAt)
+	if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
+		// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
 		// to build new images.
 		return diag.Errorf("the iteration %s is revoked and can not be used. A valid iteration should be used instead.", iteration.ID)
 	}

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -168,8 +168,9 @@ func dataSourcePackerImageIterationRead(ctx context.Context, d *schema.ResourceD
 
 	iteration := channel.Iteration
 
-	if !time.Time(iteration.RevokeAt).IsZero() {
-		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
+	revokeAt := time.Time(iteration.RevokeAt)
+	if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
+		// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
 		// to build new images.
 		return diag.Errorf("the iteration %s assigned to channel %s is revoked and can not be used. A valid iteration"+
 			" must be assigned to this channel before proceeding", iteration.ID, channelSlug)

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -527,17 +527,16 @@ func TestAcc_dataSourcePacker_iterationScheduledToBeRevoked(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
 		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			deleteChannel(t, acctestAnotherUbuntuBucket, acctestProductionChannel, false)
+			deleteIteration(t, acctestAnotherUbuntuBucket, fingerprint, false)
+			deleteBucket(t, acctestAnotherUbuntuBucket, false)
+			return nil
+		},
 		Steps: []resource.TestStep{
 			// testing that getting an iteration with scheduled revocation works
 			{
 				PreConfig: func() {
-					// CheckDestroy doesn't get called when the test fails and doesn't
-					// produce any tf state. In this case we destroy any existing resource
-					// before creating them.
-					deleteChannel(t, acctestAnotherUbuntuBucket, acctestProductionChannel, false)
-					deleteIteration(t, acctestAnotherUbuntuBucket, fingerprint, false)
-					deleteBucket(t, acctestAnotherUbuntuBucket, false)
-
 					upsertRegistry(t)
 					upsertBucket(t, acctestAnotherUbuntuBucket)
 					upsertIteration(t, acctestAnotherUbuntuBucket, fingerprint)

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	acctestAlpineBucket      = "alpine-acctest"
-	acctestUbuntuBucket      = "ubuntu-acctest"
-	acctestProductionChannel = "production"
+	acctestAlpineBucket        = "alpine-acctest"
+	acctestUbuntuBucket        = "ubuntu-acctest"
+	acctestAnotherUbuntuBucket = "another-ubuntu-acctest"
+	acctestProductionChannel   = "production"
 )
 
 var (
@@ -37,6 +38,12 @@ var (
 		bucket_name  = %q
 		channel = %q
 	}`, acctestUbuntuBucket, acctestProductionChannel)
+
+	testAccPackerAnotherUbuntuProductionImage = fmt.Sprintf(`
+	data "hcp_packer_image_iteration" "another-ubuntu" {
+		bucket_name  = %q
+		channel = %q
+	}`, acctestAnotherUbuntuBucket, acctestProductionChannel)
 )
 
 func upsertRegistry(t *testing.T) {
@@ -508,6 +515,47 @@ func TestAcc_dataSourcePacker_revokedIteration(t *testing.T) {
 				},
 				Config:      testConfig(testAccPackerUbuntuProductionImage),
 				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} assigned to channel (\w|\W)* is revoked and can not be used. A valid iteration must be assigned to this channel before proceeding`),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePacker_iterationScheduledToBeRevoked(t *testing.T) {
+	resourceName := "data.hcp_packer_image_iteration.another-ubuntu"
+	fingerprint := fmt.Sprintf("%d", rand.Int())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			// testing that getting an iteration with scheduled revocation works
+			{
+				PreConfig: func() {
+					// CheckDestroy doesn't get called when the test fails and doesn't
+					// produce any tf state. In this case we destroy any existing resource
+					// before creating them.
+					deleteChannel(t, acctestAnotherUbuntuBucket, acctestProductionChannel, false)
+					deleteIteration(t, acctestAnotherUbuntuBucket, fingerprint, false)
+					deleteBucket(t, acctestAnotherUbuntuBucket, false)
+
+					upsertRegistry(t)
+					upsertBucket(t, acctestAnotherUbuntuBucket)
+					upsertIteration(t, acctestAnotherUbuntuBucket, fingerprint)
+					itID, err := getIterationIDFromFingerPrint(t, acctestAnotherUbuntuBucket, fingerprint)
+					if err != nil {
+						t.Fatal(err.Error())
+					}
+					upsertBuild(t, acctestAnotherUbuntuBucket, fingerprint, itID)
+					createChannel(t, acctestAnotherUbuntuBucket, acctestProductionChannel, itID)
+					// Schedule revocation to the future
+					revokeIteration(t, itID, acctestAnotherUbuntuBucket, "1d")
+
+				},
+				Config: testConfig(testAccPackerAnotherUbuntuProductionImage),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
 			},
 		},
 	})

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -104,8 +104,10 @@ func dataSourcePackerIterationRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	iteration := channel.Iteration
-	if !time.Time(iteration.RevokeAt).IsZero() {
-		// If RevokeAt is not a zero date, it means this iteration is revoked and should not be used
+
+	revokeAt := time.Time(iteration.RevokeAt)
+	if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
+		// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
 		// to build new images.
 		return diag.Errorf("the iteration %s assigned to channel %s is revoked and can not be used. A valid iteration"+
 			" must be assigned to this channel before proceeding", iteration.ID, channelSlug)

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -80,13 +80,6 @@ func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
 		ProviderFactories: providerFactories,
-		CheckDestroy: func(*terraform.State) error {
-			deleteChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, false)
-			deleteIteration(t, acctestIterationUbuntuBucket, fingerprint, false)
-			deleteBucket(t, acctestIterationUbuntuBucket, false)
-			return nil
-		},
-
 		Steps: []resource.TestStep{
 			// testing that getting the production channel of the alpine image
 			// works.
@@ -133,18 +126,10 @@ func TestAcc_dataSourcePackerIteration_iterationScheduledToBeRevoked(t *testing.
 			deleteBucket(t, acctestIterationAnotherUbuntuBucket, false)
 			return nil
 		},
-
 		Steps: []resource.TestStep{
 			// testing that getting an iteration with scheduled revocation works
 			{
 				PreConfig: func() {
-					// CheckDestroy doesn't get called when the test fails and doesn't
-					// produce any tf state. In this case we destroy any existing resource
-					// before creating them.
-					deleteChannel(t, acctestIterationAnotherUbuntuBucket, acctestIterationChannel, false)
-					deleteIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint, false)
-					deleteBucket(t, acctestIterationAnotherUbuntuBucket, false)
-
 					upsertBucket(t, acctestIterationAnotherUbuntuBucket)
 					upsertIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint)
 					itID, err := getIterationIDFromFingerPrint(t, acctestIterationAnotherUbuntuBucket, fingerprint)

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	acctestIterationBucket       = "alpine-acctest-itertest"
-	acctestIterationUbuntuBucket = "ubuntu-acctest-itertest"
-	acctestIterationChannel      = "production-iter-test"
+	acctestIterationBucket              = "alpine-acctest-itertest"
+	acctestIterationUbuntuBucket        = "ubuntu-acctest-itertest"
+	acctestIterationAnotherUbuntuBucket = "another-ubuntu-acctest-itertest"
+	acctestIterationChannel             = "production-iter-test"
 )
 
 var (
@@ -28,6 +29,11 @@ var (
 		bucket_name  = %q
 		channel = %q
 	}`, acctestIterationUbuntuBucket, acctestIterationChannel)
+	testAccPackerIterationAnotherUbuntuProduction = fmt.Sprintf(`
+	data "hcp_packer_iteration" "another-ubuntu" {
+		bucket_name  = %q
+		channel = %q
+	}`, acctestIterationAnotherUbuntuBucket, acctestIterationChannel)
 )
 
 func TestAcc_dataSourcePackerIteration(t *testing.T) {
@@ -109,6 +115,52 @@ func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
 				},
 				Config:      testConfig(testAccPackerIterationUbuntuProduction),
 				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} assigned to channel (\w|\W)* is revoked and can not be used. A valid iteration must be assigned to this channel before proceeding`),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePackerIteration_iterationScheduledToBeRevoked(t *testing.T) {
+	resourceName := "data.hcp_packer_iteration.another-ubuntu"
+	fingerprint := fmt.Sprintf("%d", rand.Int())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			deleteChannel(t, acctestIterationAnotherUbuntuBucket, acctestIterationChannel, false)
+			deleteIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint, false)
+			deleteBucket(t, acctestIterationAnotherUbuntuBucket, false)
+			return nil
+		},
+
+		Steps: []resource.TestStep{
+			// testing that getting an iteration with scheduled revocation works
+			{
+				PreConfig: func() {
+					// CheckDestroy doesn't get called when the test fails and doesn't
+					// produce any tf state. In this case we destroy any existing resource
+					// before creating them.
+					deleteChannel(t, acctestIterationAnotherUbuntuBucket, acctestIterationChannel, false)
+					deleteIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint, false)
+					deleteBucket(t, acctestIterationAnotherUbuntuBucket, false)
+
+					upsertBucket(t, acctestIterationAnotherUbuntuBucket)
+					upsertIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint)
+					itID, err := getIterationIDFromFingerPrint(t, acctestIterationAnotherUbuntuBucket, fingerprint)
+					if err != nil {
+						t.Fatal(err.Error())
+					}
+					upsertBuild(t, acctestIterationAnotherUbuntuBucket, fingerprint, itID)
+					createChannel(t, acctestIterationAnotherUbuntuBucket, acctestIterationChannel, itID)
+					// Schedule revocation to the future
+					revokeIteration(t, itID, acctestIterationAnotherUbuntuBucket, "1d")
+				},
+				Config: testConfig(testAccPackerIterationAnotherUbuntuProduction),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
### :hammer_and_wrench: Description

The `hcp_packer_x` datasources were checking if an iteration had a `revoke_at` to tell if it's revoked or not. This was wrong because a revoke_at set to the future means that revocation is scheduled and the iteration is currently valid. 
This PR fixes this behaviour and only fails for `revoked_at <= now`

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* datasource/hcp_packer_image: Fix check for revoked iterations to consider scheduled revocation valid [GH-262]
* datasource/hcp_packer_iteration: Add check for revoked iterations to consider scheduled revocation valid [GH-262]
* datasource/hcp_packer_image_iteration: Add check for revoked iterations to consider scheduled revocation valid [GH-262]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./internal/... -v -run=TestAcc_dataSourcePacker -timeout 120m
?       github.com/hashicorp/terraform-provider-hcp/internal/clients    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (29.76s)
=== RUN   TestAcc_dataSourcePacker_revokedIteration
--- PASS: TestAcc_dataSourcePacker_revokedIteration (13.60s)
=== RUN   TestAcc_dataSourcePacker_iterationScheduledToBeRevoked
--- PASS: TestAcc_dataSourcePacker_iterationScheduledToBeRevoked (26.23s)
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (27.55s)
=== RUN   TestAcc_dataSourcePackerIteration
--- PASS: TestAcc_dataSourcePackerIteration (27.64s)
=== RUN   TestAcc_dataSourcePackerIteration_revokedIteration
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (13.19s)
=== RUN   TestAcc_dataSourcePackerIteration_iterationScheduledToBeRevoked
--- PASS: TestAcc_dataSourcePackerIteration_iterationScheduledToBeRevoked (26.87s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   165.150s

```
