### PR TITLE
Prep 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.23.0 (Unreleased)
+
+:tada: Azure support is coming soon!
+
+FEATURES:
+
+* resource/consul_cluster: adds Azure on Consul (internal only)  [GH-247]
+* resource/azure_peering_connection: adds Azure peering resource (internal only)  [GH-248]
+
+FIXES:
+
+* datasource/hcp_packer: Update tests to only set CloudProvider on CreateBuild [GH-260]
+* datasource/hcp_packer: Do not fail packer datasources for iteration with revoke_at set to the future [GH-262]
+
+IMPROVEMENTS:
+
+* resource/aws_network_peering: add wait_for_active_state input [GH-258]
+* provider: Bump `actions/setup-go` from 2.1.4 to 2.2.0 ([#251](https://github.com/hashicorp/terraform-provider-hcp/issues/251))
+* provider: Bump `github.com/go-openapi/strfmt` from 0.21.1 to 0.21.2 ([#253](https://github.com/hashicorp/terraform-provider-hcp/pull/253))
+* provider: Bump `google.golang.org/grpc` from 1.42.0 to 1.44.0 ([#253](https://github.com/hashicorp/terraform-provider-hcp/pull/253))
+* provider: Bump `github.com/hashicorp/go-version` from 1.3.0 to 1.4.0 ([#253](https://github.com/hashicorp/terraform-provider-hcp/pull/253))
+* provider: Bump `github.com/hashicorp/terraform-plugin-sdk/v2` from 2.10.0 to 2.10.1 ([#253](https://github.com/hashicorp/terraform-provider-hcp/pull/253))
+* provider: Bump `github.com/go-openapi/runtime` from 0.21.0 to 0.23.1 ([#255](https://github.com/hashicorp/terraform-provider-hcp/pull/253))
+
 ## 0.22.0 (January 26, 2022)
 
 IMPROVEMENTS:

--- a/docs/data-sources/azure_peering_connection.md
+++ b/docs/data-sources/azure_peering_connection.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_azure_peering_connection (Data Source)
 
--> **Note:** This data source is currently in internal preview only. 
+-> **Note:** Azure support coming soon. This data source is currently in internal preview only.
 
 The Azure peering connection data source provides information about a peering connection between an HVN and a peer Azure VNet.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,6 @@ description: |-
 
 # HashiCorp Cloud Platform (HCP) Provider
 
-~> **Known Issue:** There is a known issue with v0.21.0 of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Vault cluster if the tier is changed, which could result in data loss. See the Release Notes on Github for more detail. Please upgrade to the patch v0.21.1 or beyond to avoid this issue.
-
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
@@ -38,7 +36,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.22.0"
+      version = "~> 0.23.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,9 @@ description: |-
 
 # HashiCorp Cloud Platform (HCP) Provider
 
--> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
+-> Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
+
+-> Azure support coming soon!
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 

--- a/docs/resources/azure_peering_connection.md
+++ b/docs/resources/azure_peering_connection.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_azure_peering_connection (Resource)
 
--> **Note:** This resource is currently in internal preview only.
+-> **Note:** Azure support coming soon. This resource is currently in internal preview only.
 
 The Azure peering connection resource allows you to manage a peering connection between an HVN and a peer Azure VNet.
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.22.0"
+      version = "~> 0.23.0"
     }
   }
 }

--- a/internal/provider/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment_test.go
@@ -67,11 +67,19 @@ resource "hcp_aws_transit_gateway_attachment" "example" {
   resource_share_arn            = aws_ram_resource_share.example.arn
 }
 
+// This data source is the same as the resource above, but waits for the connection to be Active before returning.
+data "hcp_aws_transit_gateway_attachment" "example" {
+  hvn_id                               = hcp_hvn.test.hvn_id
+  transit_gateway_attachment_id        = hcp_aws_transit_gateway_attachment.example.transit_gateway_attachment_id
+  wait_for_active_state                = true
+}
+
+// The route depends on the data source, rather than the resource, to ensure the TGW is in an Active state.
 resource "hcp_hvn_route" "route" {
  hvn_link         = hcp_hvn.test.self_link
  hvn_route_id     = "hvn-to-tgw-attachment"
  destination_cidr = aws_vpc.example.cidr_block
- target_link      = hcp_aws_transit_gateway_attachment.example.self_link
+ target_link      = data.hcp_aws_transit_gateway_attachment.example.self_link
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {

--- a/templates/data-sources/azure_peering_connection.md.tmpl
+++ b/templates/data-sources/azure_peering_connection.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Type}} ({{.Name}})
 
--> **Note:** This data source is currently in internal preview only. 
+-> **Note:** Azure support coming soon. This data source is currently in internal preview only.
 
 {{ .Description | trimspace }}
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,8 +7,6 @@ description: |-
 
 # HashiCorp Cloud Platform (HCP) Provider
 
-~> **Known Issue:** There is a known issue with v0.21.0 of the HCP Provider in which Terraform will incorrectly recommend a rebuild of a Vault cluster if the tier is changed, which could result in data loss. See the Release Notes on Github for more detail. Please upgrade to the patch v0.21.1 or beyond to avoid this issue.
-
 -> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,7 +7,9 @@ description: |-
 
 # HashiCorp Cloud Platform (HCP) Provider
 
--> **Note:** Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
+-> Please refer to the provider's [Release Notes](https://github.com/hashicorp/terraform-provider-hcp/releases) for critical fixes.
+
+-> Azure support coming soon!
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 

--- a/templates/resources/azure_peering_connection.md.tmpl
+++ b/templates/resources/azure_peering_connection.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Type}} ({{.Name}})
 
--> **Note:** This resource is currently in internal preview only.
+-> **Note:** Azure support coming soon. This resource is currently in internal preview only.
 
 {{ .Description | trimspace }}
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps the release of v0.23.0.

As a bonus, fixes the TGW acceptance test flakiness.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc

--- PASS: TestAcc_dataSourcePacker (8.67s)
--- PASS: TestAcc_dataSourcePacker_revokedIteration (8.01s)
--- PASS: TestAcc_dataSourcePacker_iterationScheduledToBeRevoked (7.31s)
--- PASS: TestAcc_dataSourcePackerImage (7.65s)
--- PASS: TestAcc_dataSourcePackerIteration (7.00s)
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (7.50s)
--- PASS: TestAcc_dataSourcePackerIteration_iterationScheduledToBeRevoked (7.28s)

--- PASS: TestAccAwsPeering (701.04s)
--- PASS: TestAccHvnPeeringConnection (298.53s)
--- PASS: TestAccHvnRoute (662.17s)
--- PASS: TestAccHvnOnly (139.74s)
--- PASS: TestAccTGWAttachment (767.44s)

--- PASS: TestAccConsulCluster (1382.74s)
--- PASS: TestAccConsulSnapshot (863.72s)

--- PASS: TestAccVaultCluster (2358.48s)
```
