### PR TITLE
Remove revocation check

### DIFF
--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -111,13 +111,6 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	revokeAt := time.Time(iteration.RevokeAt)
-	if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
-		// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
-		// to build new images.
-		return diag.Errorf("the iteration %s is revoked and can not be used. A valid iteration should be used instead.", iteration.ID)
-	}
-
 	found := false
 	for _, build := range iteration.Builds {
 		if build.CloudProvider != cloudProvider {

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"log"
-	"time"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/preview/2021-04-30/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
@@ -167,14 +166,6 @@ func dataSourcePackerImageIterationRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	iteration := channel.Iteration
-
-	revokeAt := time.Time(iteration.RevokeAt)
-	if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
-		// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
-		// to build new images.
-		return diag.Errorf("the iteration %s assigned to channel %s is revoked and can not be used. A valid iteration"+
-			" must be assigned to this channel before proceeding", iteration.ID, channelSlug)
-	}
 
 	d.SetId(iteration.ID)
 

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	acctestAlpineBucket        = "alpine-acctest"
-	acctestProductionChannel   = "production"
+	acctestAlpineBucket      = "alpine-acctest"
+	acctestProductionChannel = "production"
 )
 
 var (

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -177,6 +177,29 @@ func upsertIteration(t *testing.T, bucketSlug, fingerprint string) {
 	t.Errorf("unexpected CreateIteration error, expected nil or 409. Got %v", err)
 }
 
+func revokeIteration(t *testing.T, iterationID, bucketSlug, revokeIn string) {
+	t.Helper()
+	client := testAccProvider.Meta().(*clients.Client)
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		OrganizationID: client.Config.OrganizationID,
+		ProjectID:      client.Config.ProjectID,
+	}
+
+	params := packer_service.NewPackerServiceUpdateIterationParams()
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+	params.IterationID = iterationID
+	params.Body = &models.HashicorpCloudPackerUpdateIterationRequest{
+		BucketSlug: bucketSlug,
+		RevokeIn:   revokeIn,
+	}
+
+	_, err := client.Packer.PackerServiceUpdateIteration(params, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func getIterationIDFromFingerPrint(t *testing.T, bucketSlug string, fingerprint string) (string, error) {
 	t.Helper()
 

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -2,15 +2,18 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
-	acctestImageBucket  = "alpine-acctest-imagetest"
-	acctestImageChannel = "production-image-test"
+	acctestImageBucket       = "alpine-acctest-imagetest"
+	acctestUbuntuImageBucket = "ubuntu-acctest-imagetest"
+	acctestImageChannel      = "production-image-test"
 )
 
 var (
@@ -26,6 +29,19 @@ var (
 		iteration_id   = data.hcp_packer_iteration.alpine-imagetest.id
 		region         = "us-east-1"
 	}`, acctestImageBucket, acctestImageChannel, acctestImageBucket)
+
+	testAccPackerImageUbuntuProduction = fmt.Sprintf(`
+	data "hcp_packer_iteration" "ubuntu-imagetest" {
+		bucket_name  = %q
+		channel = %q
+	}
+
+	data "hcp_packer_image" "ubuntu-foo" {
+		bucket_name    = %q
+		cloud_provider = "aws"
+		iteration_id   = data.hcp_packer_iteration.ubuntu-imagetest.id
+		region         = "us-east-1"
+	}`, acctestUbuntuImageBucket, acctestImageChannel, acctestUbuntuImageBucket)
 )
 
 func TestAcc_dataSourcePackerImage(t *testing.T) {
@@ -61,6 +77,48 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr("data.hcp_packer_image.foo", "labels.test-key", "test-value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
+	fingerprint := fmt.Sprintf("%d", rand.Int())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			// testing that getting a revoked iteration fails properly
+			{
+				PlanOnly: true,
+				PreConfig: func() {
+					// CheckDestroy doesn't get called when the test fails and doesn't
+					// produce any tf state. In this case we destroy any existing resource
+					// before creating them.
+					deleteChannel(t, acctestUbuntuImageBucket, acctestImageChannel, false)
+					deleteIteration(t, acctestUbuntuImageBucket, fingerprint, false)
+					deleteBucket(t, acctestUbuntuImageBucket, false)
+
+					upsertRegistry(t)
+					upsertBucket(t, acctestUbuntuImageBucket)
+					upsertIteration(t, acctestUbuntuImageBucket, fingerprint)
+					itID, err := getIterationIDFromFingerPrint(t, acctestUbuntuImageBucket, fingerprint)
+					if err != nil {
+						t.Fatal(err.Error())
+					}
+					upsertBuild(t, acctestUbuntuImageBucket, fingerprint, itID)
+					createChannel(t, acctestUbuntuImageBucket, acctestImageChannel, itID)
+					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
+					// it's assigned to a channel
+					revokeIteration(t, itID, acctestUbuntuImageBucket, "5s")
+					// Sleep to make sure the iteration is revoked when we test
+					time.Sleep(5 * time.Second)
+				},
+				Config: testConfig(testAccPackerImageUbuntuProduction),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "cloud_image_id", "error_revoked"),
 				),
 			},
 		},

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"log"
-	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -104,14 +103,6 @@ func dataSourcePackerIterationRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	iteration := channel.Iteration
-
-	revokeAt := time.Time(iteration.RevokeAt)
-	if !revokeAt.IsZero() && revokeAt.Before(time.Now().UTC()) {
-		// If RevokeAt is not a zero date and is before NOW, it means this iteration is revoked and should not be used
-		// to build new images.
-		return diag.Errorf("the iteration %s assigned to channel %s is revoked and can not be used. A valid iteration"+
-			" must be assigned to this channel before proceeding", iteration.ID, channelSlug)
-	}
 
 	d.SetId(iteration.ID)
 

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	acctestIterationBucket              = "alpine-acctest-itertest"
-	acctestIterationUbuntuBucket        = "ubuntu-acctest-itertest"
-	acctestIterationChannel             = "production-iter-test"
+	acctestIterationBucket       = "alpine-acctest-itertest"
+	acctestIterationUbuntuBucket = "ubuntu-acctest-itertest"
+	acctestIterationChannel      = "production-iter-test"
 )
 
 var (

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -2,10 +2,7 @@ package provider
 
 import (
 	"fmt"
-	"math/rand"
-	"regexp"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -14,7 +11,6 @@ import (
 const (
 	acctestIterationBucket              = "alpine-acctest-itertest"
 	acctestIterationUbuntuBucket        = "ubuntu-acctest-itertest"
-	acctestIterationAnotherUbuntuBucket = "another-ubuntu-acctest-itertest"
 	acctestIterationChannel             = "production-iter-test"
 )
 
@@ -24,16 +20,6 @@ var (
 		bucket_name  = %q
 		channel = %q
 	}`, acctestIterationBucket, acctestIterationChannel)
-	testAccPackerIterationUbuntuProduction = fmt.Sprintf(`
-	data "hcp_packer_iteration" "ubuntu" {
-		bucket_name  = %q
-		channel = %q
-	}`, acctestIterationUbuntuBucket, acctestIterationChannel)
-	testAccPackerIterationAnotherUbuntuProduction = fmt.Sprintf(`
-	data "hcp_packer_iteration" "another-ubuntu" {
-		bucket_name  = %q
-		channel = %q
-	}`, acctestIterationAnotherUbuntuBucket, acctestIterationChannel)
 )
 
 func TestAcc_dataSourcePackerIteration(t *testing.T) {
@@ -65,83 +51,6 @@ func TestAcc_dataSourcePackerIteration(t *testing.T) {
 					createChannel(t, acctestIterationBucket, acctestIterationChannel, itID)
 				},
 				Config: testConfig(testAccPackerIterationAlpineProduction),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-				),
-			},
-		},
-	})
-}
-
-func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
-	fingerprint := fmt.Sprintf("%d", rand.Int())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProviderFactories: providerFactories,
-		Steps: []resource.TestStep{
-			// testing that getting the production channel of the alpine image
-			// works.
-			{
-				PreConfig: func() {
-					// CheckDestroy doesn't get called when the test fails and doesn't
-					// produce any tf state. In this case we destroy any existing resource
-					// before creating them.
-					deleteChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, false)
-					deleteIteration(t, acctestIterationUbuntuBucket, fingerprint, false)
-					deleteBucket(t, acctestIterationUbuntuBucket, false)
-
-					upsertBucket(t, acctestIterationUbuntuBucket)
-					upsertIteration(t, acctestIterationUbuntuBucket, fingerprint)
-					itID, err := getIterationIDFromFingerPrint(t, acctestIterationUbuntuBucket, fingerprint)
-					if err != nil {
-						t.Fatal(err.Error())
-					}
-					upsertBuild(t, acctestIterationUbuntuBucket, fingerprint, itID)
-					createChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, itID)
-					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
-					// it's assigned to a channel
-					revokeIteration(t, itID, acctestIterationUbuntuBucket, "5s")
-					// Sleep to make sure the iteration is revoked when we test
-					time.Sleep(5 * time.Second)
-				},
-				Config:      testConfig(testAccPackerIterationUbuntuProduction),
-				ExpectError: regexp.MustCompile(`Error: the iteration (\d|\w){26} assigned to channel (\w|\W)* is revoked and can not be used. A valid iteration must be assigned to this channel before proceeding`),
-			},
-		},
-	})
-}
-
-func TestAcc_dataSourcePackerIteration_iterationScheduledToBeRevoked(t *testing.T) {
-	resourceName := "data.hcp_packer_iteration.another-ubuntu"
-	fingerprint := fmt.Sprintf("%d", rand.Int())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProviderFactories: providerFactories,
-		CheckDestroy: func(*terraform.State) error {
-			deleteChannel(t, acctestIterationAnotherUbuntuBucket, acctestIterationChannel, false)
-			deleteIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint, false)
-			deleteBucket(t, acctestIterationAnotherUbuntuBucket, false)
-			return nil
-		},
-		Steps: []resource.TestStep{
-			// testing that getting an iteration with scheduled revocation works
-			{
-				PreConfig: func() {
-					upsertBucket(t, acctestIterationAnotherUbuntuBucket)
-					upsertIteration(t, acctestIterationAnotherUbuntuBucket, fingerprint)
-					itID, err := getIterationIDFromFingerPrint(t, acctestIterationAnotherUbuntuBucket, fingerprint)
-					if err != nil {
-						t.Fatal(err.Error())
-					}
-					upsertBuild(t, acctestIterationAnotherUbuntuBucket, fingerprint, itID)
-					createChannel(t, acctestIterationAnotherUbuntuBucket, acctestIterationChannel, itID)
-					// Schedule revocation to the future
-					revokeIteration(t, itID, acctestIterationAnotherUbuntuBucket, "1d")
-				},
-				Config: testConfig(testAccPackerIterationAnotherUbuntuProduction),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

This removes the hcp packer iteration revocation check.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* datasource/hcp_packer_image: Remove check for revoked iterations [GH-264]
* datasource/hcp_packer_iteration: Remove check for revoked iterations [GH-264]
* datasource/hcp_packer_image_iteration: Remove check for revoked iterations [GH-264]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./internal/... -v -run=TestAcc_dataSourcePacker -timeout 120m
?       github.com/hashicorp/terraform-provider-hcp/internal/clients    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (30.83s)
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (27.13s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (26.82s)
=== RUN   TestAcc_dataSourcePackerIteration
--- PASS: TestAcc_dataSourcePackerIteration (27.02s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   112.175s
```
