### PR TITLE
Prep 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.23.1 (Unreleased)
+
+FIXES:
+
+* datasource/hcp_packer_image: Remove check for revoked iterations [GH-264]
+* datasource/hcp_packer_iteration: Remove check for revoked iterations [GH-264]
+* datasource/hcp_packer_image_iteration: Remove check for revoked iterations [GH-264]
+
 ## 0.23.0 (March 03, 2022)
 
 :tada: Azure support is coming soon!

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.23.0"
+      version = "~> 0.23.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.23.0"
+      version = "~> 0.23.1"
     }
   }
 }

--- a/internal/provider/resource_hvn_route_test.go
+++ b/internal/provider/resource_hvn_route_test.go
@@ -41,11 +41,19 @@ resource "hcp_aws_network_peering" "peering" {
   peer_vpc_region = "us-west-2"
 }
 
+// This data source is the same as the resource above, but waits for the connection to be Active before returning.
+data "hcp_aws_network_peering" "peering" {
+  hvn_id                    = hcp_hvn.test.hvn_id
+  peering_id                = hcp_aws_network_peering.peering.peering_id
+  wait_for_active_state     = true
+}
+
+// The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
 resource "hcp_hvn_route" "route" {
   hvn_route_id = "peering-route"
   hvn_link = hcp_hvn.test.self_link
   destination_cidr = "172.31.0.0/16"
-  target_link = hcp_aws_network_peering.peering.self_link
+  target_link = data.hcp_aws_network_peering.peering.self_link
 }
 
 resource "aws_vpc_peering_connection_accepter" "peering-accepter" {


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps patch 0.23.1, with a Packer fix for revoked iterations.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc

--- PASS: TestAcc_dataSourcePacker (9.47s)
--- PASS: TestAcc_dataSourcePackerImage (7.78s)
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (11.71s)
--- PASS: TestAcc_dataSourcePackerIteration (7.17s)

--- PASS: TestAccAwsPeering (723.25s)
--- PASS: TestAccTGWAttachment (728.34s)
--- PASS: TestAccHvnOnly (152.64s)
--- PASS: TestAccHvnRoute (715.49s)

--- PASS: TestAccConsulCluster (1342.73s)
--- PASS: TestAccConsulSnapshot (884.67s)
--- PASS: TestAccHvnPeeringConnection (297.26s)

--- PASS: TestAccVaultCluster (2306.89s)
```
