### PR TITLE
Prep 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.24.0 (Unreleased)
+
+FEATURES:
+
+* hcp_vault_cluster: add support for performance replication in Plus tier clusters [GH-266]
+
+FIXES:
+
+* hcp_consul_cluster: Fix min_consul_version on creation not taking affect [GH-252]
+
 ## 0.23.1 (March 03, 2022)
 
 FIXES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.23.1"
+      version = "~> 0.24.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.23.1"
+      version = "~> 0.24.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps the release of 0.24.0, which includes plus-tier Consul cluster performance replication as well as a Consul cluster min_version fix!

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc

--- PASS: TestAcc_dataSourcePacker (8.63s)
--- PASS: TestAcc_dataSourcePackerImage (8.27s)
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (11.92s)
--- PASS: TestAcc_dataSourcePackerIteration (7.44s)

--- PASS: TestAccHvnOnly (116.67s)
--- PASS: TestAccAwsPeering (722.72s)
--- PASS: TestAccTGWAttachment (1094.38s)
--- PASS: TestAccHvnPeeringConnection (283.36s)
--- PASS: TestAccHvnRoute (768.12s)

--- PASS: TestAccConsulCluster (1530.54s)
--- PASS: TestAccConsulSnapshot (963.21s)
```
