### PR TITLE
Remove beta notes from hcp packer data sources

### DIFF
--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_packer_image (Data Source)
 
--> **Note:** This feature is currently in beta.
-
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id.
 
 ## Example Usage

--- a/docs/data-sources/packer_image_iteration.md
+++ b/docs/data-sources/packer_image_iteration.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_packer_image_iteration (Data Source)
 
--> **Note:** This feature is currently in beta.
-
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 
 ## Example Usage

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_packer_iteration (Data Source)
 
--> **Note:** This feature is currently in beta.
-
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 
 ## Example Usage


### PR DESCRIPTION
HCP Packer recently completed a GA launch! This PR removes the notes about HCP Packer data sources being in beta because they're not anymore! 🥳 