### PR TITLE
Prep 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.24.1 (Unreleased)
+
+FIXES:
+
+* docs: Remove beta notes from Packer data sources ([#278](https://github.com/hashicorp/terraform-provider-hcp/pull/278))
+
 ## 0.24.0 (March 09, 2022)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.24.0"
+      version = "~> 0.24.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.24.0"
+      version = "~> 0.24.1"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps the release of 0.24.1, which includes removing the beta notes from Packer datasources in docs.


### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch? 

This is just a documentation update.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
