### PR TITLE
Vault: enable paths_filter and scaling for Plus-tier

### DIFF
--- a/docs/data-sources/vault_cluster.md
+++ b/docs/data-sources/vault_cluster.md
@@ -38,6 +38,7 @@ data "hcp_vault_cluster" "example" {
 - **min_vault_version** (String) The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
 - **namespace** (String) The name of the customer namespace this HCP Vault cluster is located in.
 - **organization_id** (String) The ID of the organization this HCP Vault cluster is located in.
+- **paths_filter** (List of String) The performance replication [paths filter](https://learn.hashicorp.com/tutorials/vault/paths-filter). Applies to performance replication secondaries only and operates in "deny" mode only.
 - **primary_link** (String) The `self_link` of the HCP Vault Plus tier cluster which is the primary in the performance replication setup with this HCP Vault Plus tier cluster. If not specified, it is a standalone Plus tier HCP Vault cluster.
 - **project_id** (String) The ID of the project this HCP Vault cluster is located in.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.

--- a/docs/guides/vault-performance-replication.md
+++ b/docs/guides/vault-performance-replication.md
@@ -42,5 +42,6 @@ resource "hcp_vault_cluster" "secondary" {
   hvn_id       = hcp_hvn.secondary_network.hvn_id
   tier         = "plus_medium"
   primary_link = hcp_vault_cluster.primary.self_link
+  paths_filter = ["path/a", "path/b"]
 }
 ```

--- a/docs/guides/vault-performance-replication.md
+++ b/docs/guides/vault-performance-replication.md
@@ -11,7 +11,7 @@ Admins and Contributors can use the provider to create Plus tier clusters with V
 
 Although the clusters may reside in the same HVN, it is more likely that you will want to station your performance replication secondary in a different region, and therefore HVN, than your primary. When establishing performance replication links between clusters in different HVNs, an HVN peering connection is required. This can be defined explicitly using an [`hcp_hvn_peering_connection`](../resources/hvn_peering_connection.md), or HCP will create the connection automatically (peering connections can be imported after creation using [terraform import](https://www.terraform.io/cli/import)). Note HVN peering [CIDR block requirements](https://cloud.hashicorp.com/docs/hcp/network/routes#cidr-block-requirements).
 
--> **Note**: At this time, Plus tier clusters cannot be scaled.
+-> **Note:** Remember, when scaling performance replicated clusters, be sure to keep the size of all clusters in the group in sync.
 
 ### Performance replication example
 

--- a/docs/guides/vault-scaling.md
+++ b/docs/guides/vault-scaling.md
@@ -7,7 +7,11 @@ description: |-
 
 # Scale a cluster
 
-Admins are able to use the provider to change a cluster’s size or tier. Scaling down to a Development tier from any production-grade tier is not allowed. In addition, if you are using too much storage and want to scale down to a smaller size or tier, you will be unable to do so until you delete enough resources.
+Admins are able to use the provider to change a cluster’s size or tier. There are a few limitations on cluster scaling:
+
+- When scaling performance replicated Plus-tier clusters, be sure to keep the size of all clusters in the group in sync
+- Scaling down to the Development tier from any production-grade tier is not allowed
+- If you are using too much storage and want to scale down to a smaller size or tier, you will be unable to do so until you delete enough resources
 
 ### Scaling example
 

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -43,6 +43,7 @@ resource "hcp_vault_cluster" "example" {
 
 - **id** (String) The ID of this resource.
 - **min_vault_version** (String) The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.
+- **paths_filter** (List of String) The performance replication [paths filter](https://learn.hashicorp.com/tutorials/vault/paths-filter). Applies to performance replication secondaries only and operates in "deny" mode only.
 - **primary_link** (String) The `self_link` of the HCP Vault Plus tier cluster which is the primary in the performance replication setup with this HCP Vault Plus tier cluster. If not specified, it is a standalone Plus tier HCP Vault cluster.
 - **public_endpoint** (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - **tier** (String) Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://cloud.hashicorp.com/pricing/vault).

--- a/examples/guides/vault_perf_replication/replication.tf
+++ b/examples/guides/vault_perf_replication/replication.tf
@@ -23,4 +23,5 @@ resource "hcp_vault_cluster" "secondary" {
   hvn_id       = hcp_hvn.secondary_network.hvn_id
   tier         = "plus_medium"
   primary_link = hcp_vault_cluster.primary.self_link
+  paths_filter = ["path/a", "path/b"]
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
-	github.com/hashicorp/hcp-sdk-go v0.16.0
+	github.com/hashicorp/hcp-sdk-go v0.18.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/posener/complete v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/hashicorp/hc-install v0.3.1/go.mod h1:3LCdWcCDS1gaHC9mhHCGbkYfoY6vdsK
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
-github.com/hashicorp/hcp-sdk-go v0.16.0 h1:/UfRdiI1Z2AJGBi24aFO8MeNTWBa08EHyAvH1C9BWw8=
-github.com/hashicorp/hcp-sdk-go v0.16.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
+github.com/hashicorp/hcp-sdk-go v0.18.0 h1:SnYFPebdfbc/sjit71Zx5Ji9fuQFgjvpIdrlgjzlriE=
+github.com/hashicorp/hcp-sdk-go v0.18.0/go.mod h1:z0I0eZ+TVJJ7pycnCzMM/ouOw5D5Qnp/zylNXkqGEX0=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.15.0 h1:cqjh4d8HYNQrDoEmlSGelHmg2DYDh5yayckvJ5bV18E=

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -138,3 +138,49 @@ func UpdateVaultClusterTier(ctx context.Context, client *Client, loc *sharedmode
 
 	return updateResp.Payload, nil
 }
+
+// UpdateVaultPathsFilter will make a call to the Vault service to update the paths filter for a secondary cluster
+func UpdateVaultPathsFilter(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
+	clusterID string, params vaultmodels.HashicorpCloudVault20201125ClusterPerformanceReplicationPathsFilter) (*vaultmodels.HashicorpCloudVault20201125UpdatePathsFilterResponse, error) {
+
+	updateParams := vault_service.NewUpdatePathsFilterParams()
+	updateParams.Context = ctx
+	updateParams.ClusterID = clusterID
+	updateParams.LocationProjectID = loc.ProjectID
+	updateParams.LocationOrganizationID = loc.OrganizationID
+	updateParams.Body = &vaultmodels.HashicorpCloudVault20201125UpdatePathsFilterRequest{
+		// ClusterID and Location are repeated because the values above are required to populate the URL,
+		// and the values below are required in the API request body
+		ClusterID: clusterID,
+		Location:  loc,
+		Mode:      params.Mode,
+		Paths:     params.Paths,
+	}
+
+	updateResp, err := client.Vault.UpdatePathsFilter(updateParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return updateResp.Payload, nil
+}
+
+// DeleteVaultPathsFilter will make a call to the Vault service to delete the paths filter for a secondary cluster
+func DeleteVaultPathsFilter(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
+	clusterID string) (*vaultmodels.HashicorpCloudVault20201125DeletePathsFilterResponse, error) {
+
+	deleteParams := vault_service.NewDeletePathsFilterParams()
+	deleteParams.Context = ctx
+	deleteParams.ClusterID = clusterID
+	deleteParams.LocationProjectID = loc.ProjectID
+	deleteParams.LocationOrganizationID = loc.OrganizationID
+	deleteParams.LocationRegionProvider = &loc.Region.Provider
+	deleteParams.LocationRegionRegion = &loc.Region.Region
+
+	deleteResp, err := client.Vault.DeletePathsFilter(deleteParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return deleteResp.Payload, nil
+}

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -102,6 +102,14 @@ func dataSourceVaultCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"paths_filter": {
+				Description: "The performance replication [paths filter](https://learn.hashicorp.com/tutorials/vault/paths-filter). Applies to performance replication secondaries only and operates in \"deny\" mode only.",
+				Type:        schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
 		},
 	}
 }

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -197,6 +197,22 @@ func validateVaultClusterTier(v interface{}, path cty.Path) diag.Diagnostics {
 	return diagnostics
 }
 
+func validateVaultPathsFilter(v interface{}, path cty.Path) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+	p := v.(string)
+	pathRegex := regexp.MustCompile(`\A[\w-]+(/[\w-]+)*\z`)
+	if !pathRegex.MatchString(p) {
+		msg := fmt.Sprintf("paths filter path '%v' is invalid", p)
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       msg,
+			Detail:        msg + fmt.Sprintf(" (paths must match regex '%s').", pathRegex.String()),
+			AttributePath: path,
+		})
+	}
+	return diagnostics
+}
+
 func validateCIDRBlock(v interface{}, path cty.Path) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
 

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -392,6 +392,73 @@ func Test_validateVaultClusterTier(t *testing.T) {
 	}
 }
 
+func Test_validateVaultPathsFilter(t *testing.T) {
+	tcs := map[string]struct {
+		input    string
+		expected diag.Diagnostics
+	}{
+		"valid path": {
+			input:    "valid/path",
+			expected: nil,
+		},
+		"different valid path": {
+			input:    "_valid-path/2/2/2/valid",
+			expected: nil,
+		},
+		"invalid path with :": {
+			input: "valid/path:",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "paths filter path 'valid/path:' is invalid",
+					Detail:        "paths filter path 'valid/path:' is invalid (paths must match regex '\\A[\\w-]+(/[\\w-]+)*\\z').",
+					AttributePath: nil,
+				},
+			},
+		},
+		"invalid path with trailing /": {
+			input: "trailing/",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "paths filter path 'trailing/' is invalid",
+					Detail:        "paths filter path 'trailing/' is invalid (paths must match regex '\\A[\\w-]+(/[\\w-]+)*\\z').",
+					AttributePath: nil,
+				},
+			},
+		},
+		"invalid path with leading /": {
+			input: "/leading",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "paths filter path '/leading' is invalid",
+					Detail:        "paths filter path '/leading' is invalid (paths must match regex '\\A[\\w-]+(/[\\w-]+)*\\z').",
+					AttributePath: nil,
+				},
+			},
+		},
+		"invalid empty path": {
+			input: "",
+			expected: diag.Diagnostics{
+				diag.Diagnostic{
+					Severity:      diag.Error,
+					Summary:       "paths filter path '' is invalid",
+					Detail:        "paths filter path '' is invalid (paths must match regex '\\A[\\w-]+(/[\\w-]+)*\\z').",
+					AttributePath: nil,
+				},
+			},
+		},
+	}
+	for n, tc := range tcs {
+		t.Run(n, func(t *testing.T) {
+			r := require.New(t)
+			result := validateVaultPathsFilter(tc.input, nil)
+			r.Equal(tc.expected, result)
+		})
+	}
+}
+
 func Test_validateCIDRBlock(t *testing.T) {
 	tcs := map[string]struct {
 		input    string

--- a/templates/guides/vault-performance-replication.md.tmpl
+++ b/templates/guides/vault-performance-replication.md.tmpl
@@ -11,7 +11,7 @@ Admins and Contributors can use the provider to create Plus tier clusters with V
 
 Although the clusters may reside in the same HVN, it is more likely that you will want to station your performance replication secondary in a different region, and therefore HVN, than your primary. When establishing performance replication links between clusters in different HVNs, an HVN peering connection is required. This can be defined explicitly using an [`hcp_hvn_peering_connection`](../resources/hvn_peering_connection.md), or HCP will create the connection automatically (peering connections can be imported after creation using [terraform import](https://www.terraform.io/cli/import)). Note HVN peering [CIDR block requirements](https://cloud.hashicorp.com/docs/hcp/network/routes#cidr-block-requirements).
 
--> **Note**: At this time, Plus tier clusters cannot be scaled.
+-> **Note:** Remember, when scaling performance replicated clusters, be sure to keep the size of all clusters in the group in sync.
 
 ### Performance replication example
 

--- a/templates/guides/vault-scaling.md.tmpl
+++ b/templates/guides/vault-scaling.md.tmpl
@@ -7,7 +7,11 @@ description: |-
 
 # Scale a cluster
 
-Admins are able to use the provider to change a cluster’s size or tier. Scaling down to a Development tier from any production-grade tier is not allowed. In addition, if you are using too much storage and want to scale down to a smaller size or tier, you will be unable to do so until you delete enough resources.
+Admins are able to use the provider to change a cluster’s size or tier. There are a few limitations on cluster scaling:
+
+- When scaling performance replicated Plus-tier clusters, be sure to keep the size of all clusters in the group in sync
+- Scaling down to the Development tier from any production-grade tier is not allowed
+- If you are using too much storage and want to scale down to a smaller size or tier, you will be unable to do so until you delete enough resources
 
 ### Scaling example
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

Vault: enable configuring the `paths_filter` on performance replicated secondaries and enable scaling of Plus-tier clusters.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* Vault: enable paths_filter and scaling in Plus-tier [GH-281]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccPerformanceReplication_Validations'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccPerformanceReplication_Validations -timeout 120m
?       github.com/hashicorp/terraform-provider-hcp/internal/clients    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccPerformanceReplication_Validations
--- PASS: TestAccPerformanceReplication_Validations (5708.86s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   5709.379s
```
