### PR TITLE
Vault secondary tier by reference

### DIFF
--- a/docs/guides/vault-performance-replication.md
+++ b/docs/guides/vault-performance-replication.md
@@ -40,7 +40,7 @@ resource "hcp_hvn" "secondary_network" {
 resource "hcp_vault_cluster" "secondary" {
   cluster_id   = "vault-cluster"
   hvn_id       = hcp_hvn.secondary_network.hvn_id
-  tier         = "plus_medium"
+  tier         = hcp_vault_cluster.primary.tier
   primary_link = hcp_vault_cluster.primary.self_link
   paths_filter = ["path/a", "path/b"]
 }

--- a/examples/guides/vault_perf_replication/replication.tf
+++ b/examples/guides/vault_perf_replication/replication.tf
@@ -21,7 +21,7 @@ resource "hcp_hvn" "secondary_network" {
 resource "hcp_vault_cluster" "secondary" {
   cluster_id   = "vault-cluster"
   hvn_id       = hcp_hvn.secondary_network.hvn_id
-  tier         = "plus_medium"
+  tier         = hcp_vault_cluster.primary.tier
   primary_link = hcp_vault_cluster.primary.self_link
   paths_filter = ["path/a", "path/b"]
 }

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -64,7 +64,7 @@ func resourceAwsNetworkPeering() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return strings.EqualFold(old, new)
+					return strings.ToLower(old) == strings.ToLower(new)
 				},
 			},
 			// Computed outputs

--- a/internal/provider/resource_azure_peering_connection.go
+++ b/internal/provider/resource_azure_peering_connection.go
@@ -62,7 +62,7 @@ func resourceAzurePeeringConnection() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return strings.EqualFold(old, new)
+					return strings.ToLower(old) == strings.ToLower(new)
 				},
 			},
 			"peer_tenant_id": {

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -68,7 +68,7 @@ func resourceVaultCluster() *schema.Resource {
 				Computed:         true,
 				ValidateDiagFunc: validateVaultClusterTier,
 				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-					return strings.EqualFold(old, new)
+					return strings.ToLower(old) == strings.ToLower(new)
 				},
 			},
 			"public_endpoint": {

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -100,6 +100,7 @@ func resourceVaultCluster() *schema.Resource {
 					ValidateDiagFunc: validateVaultPathsFilter,
 				},
 				Optional: true,
+				Computed: true,
 			},
 			"organization_id": {
 				Description: "The ID of the organization this HCP Vault cluster is located in.",

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -100,7 +100,6 @@ func resourceVaultCluster() *schema.Resource {
 					ValidateDiagFunc: validateVaultPathsFilter,
 				},
 				Optional: true,
-				Computed: true,
 			},
 			"organization_id": {
 				Description: "The ID of the organization this HCP Vault cluster is located in.",
@@ -582,6 +581,8 @@ func setVaultClusterResourceData(d *schema.ResourceData, cluster *vaultmodels.Ha
 		} else {
 			d.Set("paths_filter", nil)
 		}
+	} else {
+		d.Set("paths_filter", nil)
 	}
 
 	return nil

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -381,7 +381,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id   = "test-secondary"
 					hvn_id       = hcp_hvn.hvn1.hvn_id
-					tier         = "plus_medium"
+					tier         = hcp_vault_cluster.c1.tier
 					primary_link = "not-present"
 				}
 				`)),
@@ -399,7 +399,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id        = "test-secondary"
 					hvn_id            = hcp_hvn.hvn1.hvn_id
-					tier              = "plus_small"
+					tier              = hcp_vault_cluster.c1.tier
 					primary_link      = hcp_vault_cluster.c1.self_link
 					min_vault_version = "v1.0.1"
 				}
@@ -418,7 +418,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id   = "test-secondary"
 					hvn_id       = hcp_hvn.hvn1.hvn_id
-					tier         = "plus_small"
+					tier         = hcp_vault_cluster.c1.tier
 					primary_link = hcp_vault_cluster.c1.self_link
 					paths_filter = ["path/a", "path/b"]
 				}
@@ -456,7 +456,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id   = "test-secondary"
 					hvn_id       = hcp_hvn.hvn1.hvn_id
-					tier         = "plus_small"
+					tier         = hcp_vault_cluster.c1.tier
 					primary_link = hcp_vault_cluster.c1.self_link
 					paths_filter = ["path/a", "path/c"]
 				}
@@ -478,7 +478,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id   = "test-secondary"
 					hvn_id       = hcp_hvn.hvn1.hvn_id
-					tier         = "plus_small"
+					tier         = hcp_vault_cluster.c1.tier
 					primary_link = hcp_vault_cluster.c1.self_link
 				}
 				`)),
@@ -498,7 +498,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id   = "test-secondary"
 					hvn_id       = hcp_hvn.hvn2.hvn_id
-					tier         = "plus_small"
+					tier         = hcp_vault_cluster.c1.tier
 					primary_link = hcp_vault_cluster.c1.self_link
 				}
 				`)),
@@ -534,7 +534,7 @@ func TestAccPerformanceReplication_Validations(t *testing.T) {
 				resource "hcp_vault_cluster" "c2" {
 					cluster_id   = "test-secondary"
 					hvn_id       = hcp_hvn.hvn2.hvn_id
-					tier         = "plus_medium"
+					tier         = hcp_vault_cluster.c1.tier
 					primary_link = hcp_vault_cluster.c1.self_link
 				}
 				`)),


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

HashiCorp contributors, please consider: what stage of release is your feature in?
If the feature is for internal Hashicorp usage only, it should be maintained on a feature branch until ready for beta release.
If the feature is for select beta users, it can be merged to main and released as a new minor version. A beta banner must be added to the documentation.
If the feature is ready for all HCP users, it can be merged to main and released as a new minor version. You may wish to coordinate with the release of the feature in the UI.
-->

### :hammer_and_wrench: Description

No new features, just a couple minor improvements
- Recommend setting Vault performance secondary tiers via reference to primary
- Add 'computed: true' to Vault paths_filter
- Replace strings.EqualFold with ToLower in diff supression functions, since EqualFold was causing unexpected behavior

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
NONE
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
