### PR TITLE
Prep 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.0 (April 14, 2022)
+
+FIXES:
+
+* provider: only warn on all platform outage statuses ([#290](https://github.com/hashicorp/terraform-provider-hcp/issues/290))
+
 ## 0.25.0 (April 05, 2022)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.25.0"
+      version = "~> 0.26.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.25.0"
+      version = "~> 0.26.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

This release includes a fix that allows the provider to continue working during an outage.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

Note: In the interest of getting a fix out quickly, only the Consul tests were run.

```
$ make testacc TESTARGS='-run=TestAccConsulCluster'

--- PASS: TestAccConsulCluster (1480.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	1485.755s
```
