### PR TITLE
Edit Azure peering example code

### DIFF
--- a/docs/resources/azure_peering_connection.md
+++ b/docs/resources/azure_peering_connection.md
@@ -51,9 +51,7 @@ provider "azurerm" {
   features {}
 }
 
-provider "azuread" {
-  features {}
-}
+provider "azuread" {}
 
 data "azurerm_subscription" "sub" {
   subscription_id = "<subscription UUID>"

--- a/docs/resources/azure_peering_connection.md
+++ b/docs/resources/azure_peering_connection.md
@@ -29,7 +29,7 @@ resource "hcp_azure_peering_connection" "peer" {
   peer_subscription_id     = azurerm_subscription.sub.subscription_id
   peer_tenant_id           = "<tenant UUID>"
   peer_resource_group_name = azurerm_resource_group.rg.name
-  peer_vnet_region         = azure_rm_virtual_network.region
+  peer_vnet_region         = azurerm_virtual_network.location
 }
 
 // This data source is the same as the resource above, but waits for the connection to be Active before returning.
@@ -48,6 +48,10 @@ resource "hcp_hvn_route" "route" {
 }
 
 provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {
   features {}
 }
 


### PR DESCRIPTION
I was following the example code for the resource `hcp_azure_peering_connection` on the [Terraform Registry](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/resources/azure_peering_connection#example-usage).  These were the corrections I needed to make for the example to work for me.