### PR TITLE
Update HCP status checker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,6 @@
 *aws* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *tgw* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *peering* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+
+# Statuspage.io configuration is owned by the Cloud SRE team
+/internal/provider/provider.go @hashicorp/cloud-sre

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,11 +161,11 @@ func getProjectFromCredentials(ctx context.Context, client *clients.Client) (*mo
 const statuspageUrl = "https://status.hashicorp.com/api/v2/components.json"
 
 var hcpComponentIds = map[string]string{
-	// TODO: HCP API, component ID is TBD)
-	"b4pr9x7288zy": "HCP Consul",
+	"0q55nwmxngkc": "HCP API",
+	"sxffkgfb4fhb": "HCP Consul",
 	"0mbkqnrzg33w": "HCP Packer",
 	"mgv1p2j9x444": "HCP Portal",
-	"c32yfw32879v": "HCP Vault",
+	"mb7xrbx9gjnq": "HCP Vault",
 }
 
 type statuspage struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -158,8 +158,24 @@ func getProjectFromCredentials(ctx context.Context, client *clients.Client) (*mo
 }
 
 // Status endpoint for prod.
-const statuspageUrl = "https://pdrzb3d64wsj.statuspage.io/api/v2/components.json"
-const statuspageHcpComponentId = "ym75hzpmfq4q"
+const statuspageUrl = "https://status.hashicorp.com/api/v2/components.json"
+
+var hcpComponentIds = map[string]string{
+	// TODO: HCP API, component ID is TBD)
+	"b4pr9x7288zy": "HCP Consul",
+	"0mbkqnrzg33w": "HCP Packer",
+	"mgv1p2j9x444": "HCP Portal",
+	"c32yfw32879v": "HCP Vault",
+}
+
+type statuspage struct {
+	Components []component `json:"components"`
+}
+
+type component struct {
+	ID     string `json:"id"`
+	Status status `json:"status"`
+}
 
 type status string
 
@@ -171,15 +187,6 @@ const (
 	majorOutage                = "major_outage"
 	underMaintenance           = "under_maintenance"
 )
-
-type statuspage struct {
-	Components []component `json:"components"`
-}
-
-type component struct {
-	ID     string `json:"id"`
-	Status status `json:"status"`
-}
 
 func isHCPOperational() diag.Diagnostics {
 	req, err := http.NewRequest("GET", statuspageUrl, nil)
@@ -205,38 +212,50 @@ func isHCPOperational() diag.Diagnostics {
 		log.Printf("Unable unmarshal response to verify HCP status: %s", err)
 	}
 
-	var st status
+	// Translate the status page component IDs into a map of component name and operation status.
+	var systemStatus = map[string]status{}
+
 	for _, c := range sp.Components {
-		if c.ID == statuspageHcpComponentId {
-			st = c.Status
+		name, ok := hcpComponentIds[c.ID]
+		if ok {
+			systemStatus[name] = c.Status
+		}
+	}
+
+	operational := true
+	for _, st := range systemStatus {
+		if st != "operational" {
+			operational = false
 		}
 	}
 
 	var diags diag.Diagnostics
 
-	switch st {
-	case operational:
-		log.Printf("HCP is fully operational.")
-	case partialOutage, majorOutage:
+	if !operational {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  "HCP is experiencing an outage, you may encounter errors.",
-			Detail:   "Please check https://status.hashicorp.com for more details.",
-		})
-	case degradedPerformance:
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "HCP is experiencing degraded performance.",
-			Detail:   "Please check https://status.hashicorp.com for more details.",
-		})
-	case underMaintenance:
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "HCP is undergoing maintenance that may affect performance.",
-			Detail:   "Please check https://status.hashicorp.com for more details.",
+			Summary:  "You may experience issues using HCP.",
+			Detail: fmt.Sprintf("HCP is reporting the following:\n\n") +
+				printStatus(systemStatus) +
+				"\nPlease check https://status.hashicorp.com for more details.",
 		})
 	}
 
 	return diags
+}
 
+func printStatus(m map[string]status) string {
+	var maxLenKey int
+	for k := range m {
+		if len(k) > maxLenKey {
+			maxLenKey = len(k)
+		}
+	}
+
+	pr := ""
+	for k, v := range m {
+		pr = pr + fmt.Sprintf("%s:%*s %s\n", k, 5+(maxLenKey-len(k)), " ", v)
+	}
+
+	return pr
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

**TODO BEFORE MERGE:** 
- [x] add HCP API component ID
- [x] update Consul component ID
- [x] update Vault component ID

Our status page has been updated with a new path. It also now reports a list of HCP components, rather than a single rollup component. This required some refactoring of our status page checker.

Now, when any single HCP component is reporting non-operational, the provider will the warning below with the statuses of all HCP components.

```
$  terraform plan        
╷
│ Warning: You may experience issues using HCP.
│ 
│   with provider["localhost/providers/hcp"],
│   on example.tf line 151, in provider "hcp":
│  151: provider "hcp" {}
│ 
│ HCP is reporting the following:
│ 
│ HCP Vault:       operational
│ HCP Packer:      operational
│ HCP API:         major_outage
│ HCP Portal:      operational
│ HCP Consul:      degraded_performance
│ 
│ Please check https://status.hashicorp.com for more details.
╵
```

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* provider: provider reports all HCP component statuses [GH-298]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccHvnOnly'

--- PASS: TestAccHvnOnly (128.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	130.369s
```
