### PR TITLE
Prep 0.27.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,14 +6,14 @@
 *consul* @hashicorp/cloud-consul @hashicorp/cloud-experiences-go
 /internal/consul/ @hashicorp/cloud-consul @hashicorp/cloud-experiences-go
 
-# all Vault resources and clients are owned by the vault-cloud team
-*vault* @hashicorp/vault-cloud @hashicorp/cloud-experiences-go
-
 # all Networking resources and clients are owned by the cloud-control-plane team
 *hvn* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *aws* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *tgw* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *peering* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+
+# all Vault resources and clients are owned by the vault-cloud team
+*vault* @hashicorp/vault-cloud @hashicorp/cloud-experiences-go
 
 # Statuspage.io configuration is owned by the Cloud SRE team
 /internal/provider/provider.go @hashicorp/cloud-sre

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,11 @@
 # all Networking resources and clients are owned by the cloud-control-plane team
 *hvn* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *aws* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
-*tgw* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+*azure* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
 *peering* @hashicorp/cloud-control-plane @hashicorp/cloud-experiences-go
+
+# all Packer resources and clients are owned by the cloud-packer team
+*packer* @hashicorp/cloud-packer @hashicorp/cloud-experiences-go
 
 # all Vault resources and clients are owned by the vault-cloud team
 *vault* @hashicorp/vault-cloud @hashicorp/cloud-experiences-go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.0 (May 2, 2022)
+
+⚠️ Note: To continue receiving warnings when HCP is reporting degraded performance or an outage, upgrade to this version. ⚠️
+
+* provider: provider reports all HCP component statuses [GH-298]
+
 ## 0.26.0 (April 14, 2022)
 
 FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 0.27.0 (May 2, 2022)
+## 0.27.0 (May 5, 2022)
 
 ⚠️ Note: To continue receiving warnings when HCP is reporting degraded performance or an outage, upgrade to this version. ⚠️
 
 * provider: provider reports all HCP component statuses [GH-298]
+* provider: Bump `actions/upload-artifact` from 2 to 3 [GH-288]
+* provider: Bump `google.golang.org/grpc` from 1.45.0 to 1.46.0 [GH-296]
+* provider: Bump `github.com/go-openapi/runtime` from 0.23.3 to 0.24.0 [GH-300]
+* docs: fix peer_vnet_region in azure_peering example [GH-303]
+* docs: add contributors guide on breaking changes [GH-294]
 
 ## 0.26.0 (April 14, 2022)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.26.0"
+      version = "~> 0.27.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.26.0"
+      version = "~> 0.27.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Includes a [status checker update](https://github.com/hashicorp/terraform-provider-hcp/pull/298), doc updates, and dependency bumps.

### :building_construction: Acceptance tests

Output from acceptance testing:

Running one test is sufficient for these changes:
```
$ make testacc TESTARGS='-run=TestAccHvnOnly'

--- PASS: TestAccHvnOnly (143.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	143.667s
```
