### PR TITLE
fix peer_vnet_region in azure_peering example

### DIFF
--- a/docs/resources/azure_peering_connection.md
+++ b/docs/resources/azure_peering_connection.md
@@ -29,7 +29,7 @@ resource "hcp_azure_peering_connection" "peer" {
   peer_subscription_id     = azurerm_subscription.sub.subscription_id
   peer_tenant_id           = "<tenant UUID>"
   peer_resource_group_name = azurerm_resource_group.rg.name
-  peer_vnet_region         = azure_rm_virtual_network.region
+  peer_vnet_region         = azurerm_virtual_network.location
 }
 
 // This data source is the same as the resource above, but waits for the connection to be Active before returning.
@@ -50,6 +50,8 @@ resource "hcp_hvn_route" "route" {
 provider "azurerm" {
   features {}
 }
+
+provider "azuread" {}
 
 data "azurerm_subscription" "sub" {
   subscription_id = "<subscription UUID>"

--- a/examples/resources/hcp_azure_peering_connection/resource.tf
+++ b/examples/resources/hcp_azure_peering_connection/resource.tf
@@ -13,7 +13,7 @@ resource "hcp_azure_peering_connection" "peer" {
   peer_subscription_id     = azurerm_subscription.sub.subscription_id
   peer_tenant_id           = "<tenant UUID>"
   peer_resource_group_name = azurerm_resource_group.rg.name
-  peer_vnet_region         = azure_rm_virtual_network.region
+  peer_vnet_region         = azurerm_virtual_network.location
 }
 
 // This data source is the same as the resource above, but waits for the connection to be Active before returning.
@@ -34,6 +34,8 @@ resource "hcp_hvn_route" "route" {
 provider "azurerm" {
   features {}
 }
+
+provider "azuread" {}
 
 data "azurerm_subscription" "sub" {
   subscription_id = "<subscription UUID>"


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixes Azure peering documentation example.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* docs: fix peer_vnet_region in azure_peering example [GH-nnnn]
```