### PR TITLE
Vault: enabled metrics_config and audit_log_config for HCP Vault

### DIFF
--- a/examples/resources/hcp_vault_cluster/resource.tf
+++ b/examples/resources/hcp_vault_cluster/resource.tf
@@ -9,6 +9,14 @@ resource "hcp_vault_cluster" "example" {
   cluster_id = "vault-cluster"
   hvn_id     = hcp_hvn.example.hvn_id
   tier       = "standard_large"
+  metrics_config {
+    datadog_api_key = "test_datadog"
+    datadog_region =       "us1"
+  }
+  audit_log_config {
+    datadog_api_key = "test_datadog"
+    datadog_region  = "us1"
+  }
   lifecycle {
     prevent_destroy = true
   }

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -110,6 +110,66 @@ func dataSourceVaultCluster() *schema.Resource {
 				},
 				Computed: true,
 			},
+			"metrics_config": {
+				Description: "The metrics configuration for export. (https://learn.hashicorp.com/tutorials/cloud/vault-metrics-guide#metrics-streaming-configuration)",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"grafana_endpoint": {
+							Description: "Grafana endpoint for streaming metrics",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"grafana_user": {
+							Description: "Grafana user for streaming metrics",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"splunk_hecendpoint": {
+							Description: "Splunk endpoint for streaming metrics",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"datadog_region": {
+							Description: "Datadog region for streaming metrics",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"audit_log_config": {
+				Description: "The audit logs configuration for export. (https://learn.hashicorp.com/tutorials/cloud/vault-metrics-guide#metrics-streaming-configuration)",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"grafana_endpoint": {
+							Description: "Grafana endpoint for streaming audit logs",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"grafana_user": {
+							Description: "Grafana user for streaming audit logs",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"splunk_hecendpoint": {
+							Description: "Splunk endpoint for streaming audit logs",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"datadog_region": {
+							Description: "Datadog region for streaming audit logs",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Add support to metrics and audit log to the HCP Vault resource


### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* Vault: enable metrics_config and audit_log_config  [GH-nnnn]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

https://user-images.githubusercontent.com/97476714/170169244-73934537-7f0c-4ec6-a8d4-15e5a792955d.png
https://user-images.githubusercontent.com/97476714/170177128-9f341b0b-6bd9-4efd-90ac-568d0bd14dd8.png
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
