### PR TITLE
Fix Azure HVN acceptance test

### DIFF
--- a/internal/provider/resource_hvn_test.go
+++ b/internal/provider/resource_hvn_test.go
@@ -39,98 +39,150 @@ data "hcp_hvn" "test" {
 
 // This includes tests against both the resource and the corresponding datasource
 // to shorten testing time.
-func TestAccHvnOnly(t *testing.T) {
+func TestAccAwsHvnOnly(t *testing.T) {
 	resourceName := "hcp_hvn.test"
 	dataSourceName := "data.hcp_hvn.test"
 
-	cases := map[string]struct {
-		config   string
-		provider string
-		region   string
-	}{
-		"when the cloud provider is AWS": {
-			testAccAwsHvnConfig,
-			"aws",
-			"us-west-2",
-		},
-		// Currently in public beta
-		// "when the cloud provider is Azure": {
-		// 	testAccAzureHvnConfig,
-		// 	"azure",
-		// 	"useast",
-		// },
-	}
-
-	for _, tc := range cases {
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-			ProviderFactories: providerFactories,
-			CheckDestroy:      testAccCheckHvnDestroy,
-			Steps: []resource.TestStep{
-				// Tests create
-				{
-					Config: testConfig(tc.config),
-					Check: resource.ComposeTestCheckFunc(
-						testAccCheckHvnExists(resourceName),
-						resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
-						resource.TestCheckResourceAttr(resourceName, "cloud_provider", tc.provider),
-						resource.TestCheckResourceAttr(resourceName, "region", tc.region),
-						resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
-						resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-						resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-						resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-						resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
-						testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
-					),
-				},
-				// Tests import
-				{
-					ResourceName: resourceName,
-					ImportState:  true,
-					ImportStateIdFunc: func(s *terraform.State) (string, error) {
-						rs, ok := s.RootModule().Resources[resourceName]
-						if !ok {
-							return "", fmt.Errorf("not found: %s", resourceName)
-						}
-
-						return rs.Primary.Attributes["hvn_id"], nil
-					},
-					ImportStateVerify: true,
-				},
-				// Tests read
-				{
-					Config: testConfig(tc.config),
-					Check: resource.ComposeTestCheckFunc(
-						testAccCheckHvnExists(resourceName),
-						resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
-						resource.TestCheckResourceAttr(resourceName, "cloud_provider", tc.provider),
-						resource.TestCheckResourceAttr(resourceName, "region", tc.region),
-						resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
-						resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-						resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-						resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-						resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
-						testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
-					),
-				},
-				// Tests datasource
-				{
-					Config: testConfig(tc.config),
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttrPair(resourceName, "hvn_id", dataSourceName, "hvn_id"),
-						resource.TestCheckResourceAttrPair(resourceName, "cloud_provider", dataSourceName, "cloud_provider"),
-						resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "region"),
-						resource.TestCheckResourceAttrPair(resourceName, "cidr_block", dataSourceName, "cidr_block"),
-						resource.TestCheckResourceAttrPair(resourceName, "organization_id", dataSourceName, "organization_id"),
-						resource.TestCheckResourceAttrPair(resourceName, "project_id", dataSourceName, "project_id"),
-						resource.TestCheckResourceAttrPair(resourceName, "provider_account_id", dataSourceName, "provider_account_id"),
-						resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
-						resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
-					),
-				},
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckHvnDestroy,
+		Steps: []resource.TestStep{
+			// Tests create
+			{
+				Config: testConfig(testAccAwsHvnConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHvnExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
+					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+				),
 			},
-		})
-	}
+			// Tests import
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+
+					return rs.Primary.Attributes["hvn_id"], nil
+				},
+				ImportStateVerify: true,
+			},
+			// Tests read
+			{
+				Config: testConfig(testAccAwsHvnConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHvnExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
+					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+				),
+			},
+			// Tests datasource
+			{
+				Config: testConfig(testAccAwsHvnConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "hvn_id", dataSourceName, "hvn_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloud_provider", dataSourceName, "cloud_provider"),
+					resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "cidr_block", dataSourceName, "cidr_block"),
+					resource.TestCheckResourceAttrPair(resourceName, "organization_id", dataSourceName, "organization_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "project_id", dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "provider_account_id", dataSourceName, "provider_account_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
+					resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
+				),
+			},
+		},
+	})
+}
+
+// Currently in public beta
+func TestAccAzureHvnOnly(t *testing.T) {
+	resourceName := "hcp_hvn.test"
+	dataSourceName := "data.hcp_hvn.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckHvnDestroy,
+		Steps: []resource.TestStep{
+			// Tests create
+			{
+				Config: testConfig(testAccAzureHvnConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHvnExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "azure"),
+					resource.TestCheckResourceAttr(resourceName, "region", "useast"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+				),
+			},
+			// Tests import
+			{
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+
+					return rs.Primary.Attributes["hvn_id"], nil
+				},
+				ImportStateVerify: true,
+			},
+			// Tests read
+			{
+				Config: testConfig(testAccAzureHvnConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHvnExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "azure"),
+					resource.TestCheckResourceAttr(resourceName, "region", "useast"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+				),
+			},
+			// Tests datasource
+			{
+				Config: testConfig(testAccAzureHvnConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "hvn_id", dataSourceName, "hvn_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloud_provider", dataSourceName, "cloud_provider"),
+					resource.TestCheckResourceAttrPair(resourceName, "region", dataSourceName, "region"),
+					resource.TestCheckResourceAttrPair(resourceName, "cidr_block", dataSourceName, "cidr_block"),
+					resource.TestCheckResourceAttrPair(resourceName, "organization_id", dataSourceName, "organization_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "project_id", dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
+					resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckHvnExists(name string) resource.TestCheckFunc {

--- a/internal/provider/resource_hvn_test.go
+++ b/internal/provider/resource_hvn_test.go
@@ -29,7 +29,7 @@ var testAccAzureHvnConfig = `
 resource "hcp_hvn" "test" {
 	hvn_id         = "test-hvn"
 	cloud_provider = "azure"
-	region         = "useast"
+	region         = "eastus"
 }
 
 data "hcp_hvn" "test" {
@@ -130,7 +130,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 					testAccCheckHvnExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "azure"),
-					resource.TestCheckResourceAttr(resourceName, "region", "useast"),
+					resource.TestCheckResourceAttr(resourceName, "region", "eastus"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -159,7 +159,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 					testAccCheckHvnExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "azure"),
-					resource.TestCheckResourceAttr(resourceName, "region", "useast"),
+					resource.TestCheckResourceAttr(resourceName, "region", "eastus"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),


### PR DESCRIPTION
### :hammer_and_wrench: Description

Quick fix and refactor of the HVN tests.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAzureHvnOnly'

--- PASS: TestAccAzureHvnOnly (280.39s)
PASS
```
