### PR TITLE
Prep 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.32.0 (June 15, 2022)
+
+IMPROVEMENTS:
+
+* provider: Bump `github.com/hashicorp/terraform-plugin-docs` from 0.9.0 to 0.10.1 ([#328](https://github.com/hashicorp/terraform-provider-hcp/pull/328))
+* provider: Fixes error handling when Terraform cannot connect to status.hashicorp.com ([#325](https://github.com/hashicorp/terraform-provider-hcp/pull/325))
+
 ## 0.31.0 (June 8, 2022)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.31.0"
+      version = "~> 0.32.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.31.0"
+      version = "~> 0.32.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps release of 0.32.0, which contains a bug fix for the HCP Status checker.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsHvnOnly'

--- PASS: TestAccAwsHvnOnly (129.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	130.338s
```
