### PR TITLE
Add revoke_at to HCP Packer datasources output

### DIFF
--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -56,7 +56,7 @@ output "packer-registry-ubuntu" {
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `packer_run_uuid` (String) UUID of this build.
 - `project_id` (String) The ID of the project this HCP Packer registry is located in.
-- `revoke_at` (String) The revocation time of this build
+- `revoke_at` (String) The revocation time of this build. This field will be null for any build that has not been revoked or scheduled for revocation.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -56,6 +56,7 @@ output "packer-registry-ubuntu" {
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `packer_run_uuid` (String) UUID of this build.
 - `project_id` (String) The ID of the project this HCP Packer registry is located in.
+- `revoke_at` (String) The revocation time of this build
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -39,7 +39,7 @@ data "hcp_packer_iteration" "hardened-source" {
 - `incremental_version` (Number) Incremental version of this iteration
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `project_id` (String) The ID of the project this HCP Packer registry is located in.
-- `revoke_at` (String) The revocation time of this iteration
+- `revoke_at` (String) The revocation time of this iteration. This field will be null for any iteration that has not been revoked or scheduled for revocation.
 - `ulid` (String) The ULID of this iteration.
 - `updated_at` (String) Time this build was last updated.
 

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -39,6 +39,7 @@ data "hcp_packer_iteration" "hardened-source" {
 - `incremental_version` (Number) Incremental version of this iteration
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `project_id` (String) The ID of the project this HCP Packer registry is located in.
+- `revoke_at` (String) The revocation time of this iteration
 - `ulid` (String) The ULID of this iteration.
 - `updated_at` (String) Time this build was last updated.
 

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -84,6 +84,11 @@ func dataSourcePackerImage() *schema.Resource {
 				Type:        schema.TypeMap,
 				Computed:    true,
 			},
+			"revoke_at": {
+				Description: "The revocation time of this build",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -140,6 +145,11 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 				}
 				if err := d.Set("labels", build.Labels); err != nil {
 					return diag.FromErr(err)
+				}
+				if !time.Time(iteration.RevokeAt).IsZero() {
+					if err := d.Set("revoke_at", iteration.RevokeAt.String()); err != nil {
+						return diag.FromErr(err)
+					}
 				}
 			}
 		}

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -85,7 +85,7 @@ func dataSourcePackerImage() *schema.Resource {
 				Computed:    true,
 			},
 			"revoke_at": {
-				Description: "The revocation time of this build",
+				Description: "The revocation time of this build. This field will be null for any build that has not been revoked or scheduled for revocation.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"log"
+	"time"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
@@ -52,6 +53,11 @@ func dataSourcePackerImageIteration() *schema.Resource {
 			},
 			"created_at": {
 				Description: "Creation time of this iteration",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"revoke_at": {
+				Description: "The revocation time of this iteration",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -174,6 +180,11 @@ func dataSourcePackerImageIterationRead(ctx context.Context, d *schema.ResourceD
 	}
 	if err := d.Set("created_at", iteration.CreatedAt.String()); err != nil {
 		return diag.FromErr(err)
+	}
+	if !time.Time(iteration.RevokeAt).IsZero() {
+		if err := d.Set("revoke_at", iteration.RevokeAt.String()); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if err := d.Set("builds", flattenPackerBuildList(iteration.Builds)); err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -57,7 +57,7 @@ func dataSourcePackerImageIteration() *schema.Resource {
 				Computed:    true,
 			},
 			"revoke_at": {
-				Description: "The revocation time of this iteration",
+				Description: "The revocation time of this iteration. This field will be null for any iteration that has not been revoked or scheduled for revocation.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
+	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-operation/preview/2020-05-05/client/operation_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
@@ -199,7 +200,7 @@ func upsertIteration(t *testing.T, bucketSlug, fingerprint string) {
 	t.Errorf("unexpected CreateIteration error, expected nil or 409. Got %v", err)
 }
 
-func revokeIteration(t *testing.T, iterationID, bucketSlug, revokeIn string) {
+func revokeIteration(t *testing.T, iterationID, bucketSlug string, revokeAt strfmt.DateTime) {
 	t.Helper()
 	client := testAccProvider.Meta().(*clients.Client)
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
@@ -213,7 +214,7 @@ func revokeIteration(t *testing.T, iterationID, bucketSlug, revokeIn string) {
 	params.IterationID = iterationID
 	params.Body = &models.HashicorpCloudPackerUpdateIterationRequest{
 		BucketSlug: bucketSlug,
-		RevokeIn:   revokeIn,
+		RevokeAt:   revokeAt,
 	}
 
 	_, err := client.Packer.PackerServiceUpdateIteration(params, nil)

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -97,6 +98,7 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 
 func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 	fingerprint := fmt.Sprintf("%d", rand.Int())
+	revokeAt := strfmt.DateTime(time.Now().UTC().Add(5 * time.Minute))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
@@ -124,12 +126,13 @@ func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 					createChannel(t, acctestUbuntuImageBucket, acctestImageChannel, itID)
 					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
 					// it's assigned to a channel
-					revokeIteration(t, itID, acctestUbuntuImageBucket, "5s")
+					revokeIteration(t, itID, acctestUbuntuImageBucket, revokeAt)
 					// Sleep to make sure the iteration is revoked when we test
 					time.Sleep(5 * time.Second)
 				},
 				Config: testConfig(testAccPackerImageUbuntuProduction),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "revoke_at", revokeAt.String()),
 					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "cloud_image_id", "error_revoked"),
 				),
 			},

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -28,7 +28,13 @@ var (
 		cloud_provider = "aws"
 		iteration_id   = data.hcp_packer_iteration.alpine-imagetest.id
 		region         = "us-east-1"
-	}`, acctestImageBucket, acctestImageChannel, acctestImageBucket)
+	}
+
+	# we make sure that this won't fail even when revoke_at is not set
+	output "revoke_at" {
+  		value = data.hcp_packer_iteration.alpine-imagetest.revoke_at
+	}
+`, acctestImageBucket, acctestImageChannel, acctestImageBucket)
 
 	testAccPackerImageUbuntuProduction = fmt.Sprintf(`
 	data "hcp_packer_iteration" "ubuntu-imagetest" {
@@ -41,7 +47,13 @@ var (
 		cloud_provider = "aws"
 		iteration_id   = data.hcp_packer_iteration.ubuntu-imagetest.id
 		region         = "us-east-1"
-	}`, acctestUbuntuImageBucket, acctestImageChannel, acctestUbuntuImageBucket)
+	}
+
+	# we make sure that this won't fail even when revoke_at is not set
+	output "revoke_at" {
+  		value = data.hcp_packer_image.ubuntu-foo.revoke_at
+	}
+`, acctestUbuntuImageBucket, acctestImageChannel, acctestUbuntuImageBucket)
 )
 
 func TestAcc_dataSourcePackerImage(t *testing.T) {

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -49,11 +49,6 @@ var (
 		iteration_id   = data.hcp_packer_iteration.ubuntu-imagetest.id
 		region         = "us-east-1"
 	}
-
-	# we make sure that this won't fail even when revoke_at is not set
-	output "revoke_at" {
-  		value = data.hcp_packer_image.ubuntu-foo.revoke_at
-	}
 `, acctestUbuntuImageBucket, acctestImageChannel, acctestUbuntuImageBucket)
 )
 

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"log"
+	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -73,6 +74,11 @@ func dataSourcePackerIteration() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"revoke_at": {
+				Description: "The revocation time of this iteration",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -126,6 +132,11 @@ func dataSourcePackerIterationRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	if err := d.Set("updated_at", iteration.UpdatedAt.String()); err != nil {
 		return diag.FromErr(err)
+	}
+	if !time.Time(iteration.RevokeAt).IsZero() {
+		if err := d.Set("revoke_at", iteration.RevokeAt.String()); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -75,7 +75,7 @@ func dataSourcePackerIteration() *schema.Resource {
 				Computed:    true,
 			},
 			"revoke_at": {
-				Description: "The revocation time of this iteration",
+				Description: "The revocation time of this iteration. This field will be null for any iteration that has not been revoked or scheduled for revocation.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -25,6 +27,13 @@ var (
   		value = data.hcp_packer_iteration.alpine.revoke_at
 	}
 `, acctestIterationBucket, acctestIterationChannel)
+
+	testAccPackerIterationUbuntuProduction = fmt.Sprintf(`
+	data "hcp_packer_iteration" "ubuntu" {
+		bucket_name  = %q
+		channel = %q
+	}
+`, acctestIterationUbuntuBucket, acctestIterationChannel)
 )
 
 func TestAcc_dataSourcePackerIteration(t *testing.T) {
@@ -59,6 +68,50 @@ func TestAcc_dataSourcePackerIteration(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
+	resourceName := "data.hcp_packer_iteration.ubuntu"
+	fingerprint := "43"
+	revokeAt := strfmt.DateTime(time.Now().UTC().Add(5 * time.Minute))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			deleteChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, false)
+			deleteIteration(t, acctestIterationUbuntuBucket, fingerprint, false)
+			deleteBucket(t, acctestIterationUbuntuBucket, false)
+			return nil
+		},
+
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					upsertRegistry(t)
+					upsertBucket(t, acctestIterationUbuntuBucket)
+					upsertIteration(t, acctestIterationUbuntuBucket, fingerprint)
+					itID, err := getIterationIDFromFingerPrint(t, acctestIterationUbuntuBucket, fingerprint)
+					if err != nil {
+						t.Fatal(err.Error())
+					}
+					upsertBuild(t, acctestIterationUbuntuBucket, fingerprint, itID)
+					createChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, itID)
+					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
+					// it's assigned to a channel
+					revokeIteration(t, itID, acctestIterationUbuntuBucket, revokeAt)
+					// Sleep to make sure the iteration is revoked when we test
+					time.Sleep(5 * time.Second)
+				},
+				Config: testConfig(testAccPackerIterationUbuntuProduction),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "revoke_at", revokeAt.String()),
 				),
 			},
 		},

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -19,7 +19,12 @@ var (
 	data "hcp_packer_iteration" "alpine" {
 		bucket_name  = %q
 		channel = %q
-	}`, acctestIterationBucket, acctestIterationChannel)
+	}
+    # we make sure that this won't fail even when revoke_at is not set
+	output "revoke_at" {
+  		value = data.hcp_packer_iteration.alpine.revoke_at
+	}
+`, acctestIterationBucket, acctestIterationChannel)
 )
 
 func TestAcc_dataSourcePackerIteration(t *testing.T) {


### PR DESCRIPTION
### :hammer_and_wrench: Description

HCP Packer will no longer return `error_revoked` so we are adding the `revoke_at` timestamp to all of our datasources. 

### :ship: Release Note

```release-note
* datasource/hcp_packer_image: Include `revoke_at` in the data source output. [GH-330]
* datasource/hcp_packer_iteration: Include `revoke_at` in the data source output. [GH-330]
* datasource/hcp_packer_image_iteration: Include `revoke_at` in the data source output. [GH-330]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
==> Checking that code complies with gofmt requirements...
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (24.79s)
=== RUN   TestAcc_dataSourcePacker_revokedIteration
--- PASS: TestAcc_dataSourcePacker_revokedIteration (29.26s)
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (24.83s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (23.77s)
=== RUN   TestAcc_dataSourcePackerIteration
--- PASS: TestAcc_dataSourcePackerIteration (22.89s)
=== RUN   TestAcc_dataSourcePackerIteration_revokedIteration
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (28.78s)
PASS

```
