### PR TITLE
doc fixes

### DIFF
--- a/docs/data-sources/azure_peering_connection.md
+++ b/docs/data-sources/azure_peering_connection.md
@@ -5,7 +5,7 @@ description: |-
   The Azure peering connection data source provides information about a peering connection between an HVN and a peer Azure VNet.
 ---
 
-# Data Source (hcp_azure_peering_connection)
+# hcp_azure_peering_connection (Data Source)
 
 -> **Note:** This data source is currently in public beta.
 

--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -5,7 +5,7 @@ description: |-
   The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id.
 ---
 
-# Data Source (hcp_packer_image)
+# hcp_packer_image (Data Source)
 
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id.
 

--- a/docs/data-sources/packer_image_iteration.md
+++ b/docs/data-sources/packer_image_iteration.md
@@ -5,7 +5,7 @@ description: |-
   The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 ---
 
-# Data Source (hcp_packer_image_iteration)
+# hcp_packer_image_iteration (Data Source)
 
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -5,7 +5,7 @@ description: |-
   The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 ---
 
-# Data Source (hcp_packer_iteration)
+# hcp_packer_iteration (Data Source)
 
 The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
 

--- a/docs/resources/aws_transit_gateway_attachment.md
+++ b/docs/resources/aws_transit_gateway_attachment.md
@@ -5,7 +5,7 @@ description: |-
   The AWS transit gateway attachment resource allows you to manage a transit gateway attachment. The transit gateway attachment attaches an HVN to a user-owned transit gateway in AWS. Note that the HVN and transit gateway must be located in the same AWS region.
 ---
 
-# Resource (hcp_aws_transit_gateway_attachment)
+# hcp_aws_transit_gateway_attachment (Resource)
 
 ~> **Security Notice:** This resource contains sensitive input. Please see this [list of recommendations](https://www.terraform.io/docs/language/state/sensitive-data.html) for storing sensitive information in Terraform.
 

--- a/docs/resources/azure_peering_connection.md
+++ b/docs/resources/azure_peering_connection.md
@@ -5,7 +5,7 @@ description: |-
   The Azure peering connection resource allows you to manage a peering connection between an HVN and a peer Azure VNet.
 ---
 
-# Resource (hcp_azure_peering_connection)
+# hcp_azure_peering_connection (Resource)
 
 -> **Note:** This data source is currently in public beta.
 

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -5,7 +5,7 @@ description: |-
   The Consul cluster resource allows you to manage an HCP Consul cluster.
 ---
 
-# Resource (hcp_consul_cluster)
+# hcp_consul_cluster (Resource)
 
 -> Consul on Azure is now available in public beta. [Get started with end-to-end deployment configuration](https://learn.hashicorp.com/tutorials/cloud/consul-end-to-end-overview).
 

--- a/docs/resources/consul_cluster_root_token.md
+++ b/docs/resources/consul_cluster_root_token.md
@@ -5,7 +5,7 @@ description: |-
   The cluster root token resource is the token used to bootstrap the cluster's ACL system. You can also generate this root token from the HCP Consul UI.
 ---
 
-# Resource (hcp_consul_cluster_root_token)
+# hcp_consul_cluster_root_token (Resource)
 
 ~> **Security Notice:** Please see this [list of recommendations](https://www.terraform.io/docs/language/state/sensitive-data.html) for storing sensitive information in Terraform.
 

--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -37,7 +37,7 @@ resource "hcp_hvn" "example" {
 
 ### Required
 
-- `cloud_provider` (String) The provider where the HVN is located. Only 'aws' is available at this time.
+- `cloud_provider` (String) The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 - `hvn_id` (String) The ID of the HashiCorp Virtual Network (HVN).
 - `region` (String) The region where the HVN is located.
 

--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -5,7 +5,7 @@ description: |-
   The HVN resource allows you to manage a HashiCorp Virtual Network in HCP.
 ---
 
-# Resource (hcp_hvn)
+# hcp_hvn (Resource)
 
 The HVN resource allows you to manage a HashiCorp Virtual Network in HCP.
 

--- a/docs/resources/hvn_route.md
+++ b/docs/resources/hvn_route.md
@@ -5,7 +5,7 @@ description: |-
   The HVN route resource allows you to manage an HVN route.
 ---
 
-# Resource (hcp_hvn_route)
+# hcp_hvn_route (Resource)
 
 ~> **Migration Required:** The release of HVN Routes in v0.7.0 includes breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
 Please pin to the previous version to avoid disruption until you are ready to migrate.

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -5,7 +5,7 @@ description: |-
   The Vault cluster resource allows you to manage an HCP Vault cluster.
 ---
 
-# Resource (hcp_vault_cluster)
+# hcp_vault_cluster (Resource)
 
 The Vault cluster resource allows you to manage an HCP Vault cluster.
 

--- a/docs/resources/vault_cluster_admin_token.md
+++ b/docs/resources/vault_cluster_admin_token.md
@@ -5,7 +5,7 @@ description: |-
   The Vault cluster admin token resource generates an admin-level token for the HCP Vault cluster.
 ---
 
-# Resource (hcp_vault_cluster_admin_token)
+# hcp_vault_cluster_admin_token (Resource)
 
 ~> **Security Notice:** Please see this [list of recommendations](https://www.terraform.io/docs/language/state/sensitive-data.html) for storing sensitive information in Terraform.
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -52,7 +52,7 @@ func resourceHvn() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			"cloud_provider": {
-				Description:      "The provider where the HVN is located. Only 'aws' is available at this time.",
+				Description:      "The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,

--- a/templates/data-sources/azure_peering_connection.md.tmpl
+++ b/templates/data-sources/azure_peering_connection.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 -> **Note:** This data source is currently in public beta.
 

--- a/templates/data-sources/packer_image.md.tmpl
+++ b/templates/data-sources/packer_image.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/packer_image_iteration.md.tmpl
+++ b/templates/data-sources/packer_image_iteration.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/packer_iteration.md.tmpl
+++ b/templates/data-sources/packer_iteration.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/aws_transit_gateway_attachment.md.tmpl
+++ b/templates/resources/aws_transit_gateway_attachment.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 ~> **Security Notice:** This resource contains sensitive input. Please see this [list of recommendations](https://www.terraform.io/docs/language/state/sensitive-data.html) for storing sensitive information in Terraform.
 

--- a/templates/resources/azure_peering_connection.md.tmpl
+++ b/templates/resources/azure_peering_connection.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 -> **Note:** This data source is currently in public beta.
 

--- a/templates/resources/consul_cluster.md.tmpl
+++ b/templates/resources/consul_cluster.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 -> Consul on Azure is now available in public beta. [Get started with end-to-end deployment configuration](https://learn.hashicorp.com/tutorials/cloud/consul-end-to-end-overview).
 

--- a/templates/resources/consul_cluster_root_token.md.tmpl
+++ b/templates/resources/consul_cluster_root_token.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 ~> **Security Notice:** Please see this [list of recommendations](https://www.terraform.io/docs/language/state/sensitive-data.html) for storing sensitive information in Terraform.
 

--- a/templates/resources/hvn.md.tmpl
+++ b/templates/resources/hvn.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/hvn_route.md.tmpl
+++ b/templates/resources/hvn_route.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 ~> **Migration Required:** The release of HVN Routes in v0.7.0 includes breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
 Please pin to the previous version to avoid disruption until you are ready to migrate.

--- a/templates/resources/vault_cluster.md.tmpl
+++ b/templates/resources/vault_cluster.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/vault_cluster_admin_token.md.tmpl
+++ b/templates/resources/vault_cluster_admin_token.md.tmpl
@@ -5,7 +5,7 @@ description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
-# {{.Type}} ({{.Name}})
+# {{.Name}} ({{.Type}})
 
 ~> **Security Notice:** Please see this [list of recommendations](https://www.terraform.io/docs/language/state/sensitive-data.html) for storing sensitive information in Terraform.
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Quick fix addressing:
- https://github.com/hashicorp/terraform-provider-hcp/issues/332
- inconsistent titles between our resources documented by custom templates, as opposed to the default doc plugin template

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* docs: update HVN with Azure & make resource titles consistent [GH-333]
```

### :building_construction: Acceptance tests

No test impact.