### PR TITLE
Refactor hcp hvn docs

### DIFF
--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -17,9 +17,9 @@ We recommend the following when selecting the CIDR block of an HVN:
 
 - The CIDR block value must end between /16 and /25.
 
-- If the CIDR block values for your HVN and VPCs overlap, then you will not be able to establish a connection. Ensure that any VPCs you plan to connect do not have overlapping values.
+- If the CIDR block values for your HCP HVN and your cloud provider’s virtual network overlap you will not be able to establish a connection. The following are default CIDR block values to be aware of: HCP HVN (172.25.16.0/20), AWS VPC (172.31.0.0/16), and Azure VNet (172.29.0.0/24). Avoid creating overlapping networks.
 
-- The default HVN CIDR block value does not overlap with the default CIDR block value for AWS VPCs (172.31.0.0/16). However, if you are planning to use this HVN in production, we recommend adding a custom value instead of using the default.
+- If you’re creating a HVN for use in production it's recommended that you specify a CIDR block value that does not overlap with the other HVNs already created in your organization. You will not be able to connect two HVNs with overlapping CIDR block values.
 
 ## Example Usage
 

--- a/templates/resources/hvn.md.tmpl
+++ b/templates/resources/hvn.md.tmpl
@@ -17,9 +17,9 @@ We recommend the following when selecting the CIDR block of an HVN:
 
 - The CIDR block value must end between /16 and /25.
 
-- If the CIDR block values for your HVN and VPCs overlap, then you will not be able to establish a connection. Ensure that any VPCs you plan to connect do not have overlapping values.
+- If the CIDR block values for your HCP HVN and your cloud provider’s virtual network overlap you will not be able to establish a connection. The following are default CIDR block values to be aware of: HCP HVN (172.25.16.0/20), AWS VPC (172.31.0.0/16), and Azure VNet (172.29.0.0/24). Avoid creating overlapping networks.
 
-- The default HVN CIDR block value does not overlap with the default CIDR block value for AWS VPCs (172.31.0.0/16). However, if you are planning to use this HVN in production, we recommend adding a custom value instead of using the default.
+- If you’re creating a HVN for use in production it's recommended that you specify a CIDR block value that does not overlap with the other HVNs already created in your organization. You will not be able to connect two HVNs with overlapping CIDR block values.
 
 ## Example Usage
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

- The `hcp_hvn` documentation was AWS VPC specific. These changes make them more generic to support multiple cloud providers.
- We also explained why you should specify production HVN CIDR block values.

### :ship: Release Note

```release-note
* docs: Refactor documentation for `hcp_hvn` resource [GH-337]
```

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality? No
- [x] Have you added an acceptance test for the functionality being added? No
- [x] Have you run the acceptance tests on this branch? No

Closes #337 
