### PR TITLE
hcp_packer_image channel attribute support

### DIFF
--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -2,12 +2,12 @@
 page_title: "Data Source hcp_packer_image - terraform-provider-hcp"
 subcategory: ""
 description: |-
-  The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id.
+  The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id or a channel.
 ---
 
 # hcp_packer_image (Data Source)
 
-The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id.
+The Packer Image data source iteration gets the most recent iteration (or build) of an image, given an iteration id or a channel.
 
 ## Example Usage
 
@@ -38,11 +38,12 @@ output "packer-registry-ubuntu" {
 
 - `bucket_name` (String) The slug of the HCP Packer Registry image bucket to pull from.
 - `cloud_provider` (String) Name of the cloud provider this image is stored-in.
-- `iteration_id` (String) HCP ID of this image.
 - `region` (String) Region this image is stored in, if any.
 
 ### Optional
 
+- `channel` (String) The channel that points to the version of the image being retrieved. Either this or `iteration_id` must be specified. Note: will incur a billable request
+- `iteration_id` (String) The iteration from which to get the image. Either this or `channel` must be specified.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/data-sources/packer_image.md
+++ b/docs/data-sources/packer_image.md
@@ -11,6 +11,27 @@ The Packer Image data source iteration gets the most recent iteration (or build)
 
 ## Example Usage
 
+### Single image sourcing
+
+```terraform
+data "hcp_packer_image" "baz" {
+  bucket_name    = "hardened-ubuntu-16-04"
+  cloud_provider = "aws"
+  channel        = "production"
+  region         = "us-east-1"
+}
+
+output "packer-registry-ubuntu-east-1" {
+  value = data.hcp_packer_image.baz.cloud_image_id
+}
+```
+
+~> **Note:** The `channel` attribute in this data source may incur a billable request to HCP Packer. This attribute is intended for convenience when using a single image. When sourcing multiple images from a single iteration, the `hcp_packer_iteration` data source is the alternative for querying a channel just once.
+
+~> **Note:** This data source only returns the first found image's metadata filtered by the given schema values, from the returned list of images associated with the specified iteration. Therefore, if multiple images exist in the same region, it will only pick one of them. If that's the case, you may consider separating your builds into different buckets.
+
+### Multiple image sourcing from a single iteration
+
 ```terraform
 data "hcp_packer_iteration" "hardened-source" {
   bucket_name = "hardened-ubuntu-16-04"
@@ -24,8 +45,19 @@ data "hcp_packer_image" "foo" {
   region         = "us-east-1"
 }
 
-output "packer-registry-ubuntu" {
+data "hcp_packer_image" "bar" {
+  bucket_name    = "hardened-ubuntu-16-04"
+  cloud_provider = "aws"
+  iteration_id   = data.hcp_packer_iteration.hardened-source.ulid
+  region         = "us-west-1"
+}
+
+output "packer-registry-ubuntu-east-1" {
   value = data.hcp_packer_image.foo.cloud_image_id
+}
+
+output "packer-registry-ubuntu-west-1" {
+  value = data.hcp_packer_image.bar.cloud_image_id
 }
 ```
 

--- a/examples/data-sources/hcp_packer_image/data-source-alt.tf
+++ b/examples/data-sources/hcp_packer_image/data-source-alt.tf
@@ -1,0 +1,10 @@
+data "hcp_packer_image" "baz" {
+  bucket_name    = "hardened-ubuntu-16-04"
+  cloud_provider = "aws"
+  channel        = "production"
+  region         = "us-east-1"
+}
+
+output "packer-registry-ubuntu-east-1" {
+  value = data.hcp_packer_image.baz.cloud_image_id
+}

--- a/examples/data-sources/hcp_packer_image/data-source.tf
+++ b/examples/data-sources/hcp_packer_image/data-source.tf
@@ -10,6 +10,17 @@ data "hcp_packer_image" "foo" {
   region         = "us-east-1"
 }
 
-output "packer-registry-ubuntu" {
+data "hcp_packer_image" "bar" {
+  bucket_name    = "hardened-ubuntu-16-04"
+  cloud_provider = "aws"
+  iteration_id   = data.hcp_packer_iteration.hardened-source.ulid
+  region         = "us-west-1"
+}
+
+output "packer-registry-ubuntu-east-1" {
   value = data.hcp_packer_image.foo.cloud_image_id
+}
+
+output "packer-registry-ubuntu-west-1" {
+  value = data.hcp_packer_image.bar.cloud_image_id
 }

--- a/templates/data-sources/packer_image.md.tmpl
+++ b/templates/data-sources/packer_image.md.tmpl
@@ -11,6 +11,16 @@ description: |-
 
 ## Example Usage
 
+### Single image sourcing
+
+{{ tffile "examples/data-sources/hcp_packer_image/data-source-alt.tf" }}
+
+~> **Note:** The `channel` attribute in this data source may incur a billable request to HCP Packer. This attribute is intended for convenience when using a single image. When sourcing multiple images from a single iteration, the `hcp_packer_iteration` data source is the alternative for querying a channel just once.
+
+~> **Note:** This data source only returns the first found image's metadata filtered by the given schema values, from the returned list of images associated with the specified iteration. Therefore, if multiple images exist in the same region, it will only pick one of them. If that's the case, you may consider separating your builds into different buckets.
+
+### Multiple image sourcing from a single iteration
+
 {{ tffile "examples/data-sources/hcp_packer_image/data-source.tf" }}
 
 ~> **Note:** This data source only returns the first found image's metadata filtered by the given schema values, from the returned list of images associated with the specified iteration. Therefore, if multiple images exist in the same region, it will only pick one of them. If that's the case, you may consider separating your builds into different buckets.


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add a new channel attribute to the `hcp_packer_image` data source, so a user can fetch the latest image directly, without having to specify a companion `hcp_packer_iteration` data source to fetch the build ID from.

### :ship: Release Note

```release-note
* datasource/hcp_packer_image: allow `channel` attribute to get an image [GH-339]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAcc_dataSourcePackerImage_chan'
==> Checking that code complies with gofmt requirements...
./scripts/gofmtcheck.sh: line 5: gofmt: command not found
TF_ACC=1 go test ./internal/... -v -run=TestAcc_dataSourcePackerImage_chan -timeout 210m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAcc_dataSourcePackerImage_channelAndIterationIDReject
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (0.08s)
=== RUN   TestAcc_dataSourcePackerImage_channelAccept
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (3.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	4.026s
```
