### PR TITLE
Prep 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
+## 0.34.0 (June 30, 2022)
+
+IMPROVEMENTS:
+
+* docs: Refactor documentation for `hcp_hvn` resource ([337](https://github.com/hashicorp/terraform-provider-hcp/pull/337))
+
+FIXES:
+
+* resource/consul: Store cluster+snapshot state ([326](https://github.com/hashicorp/terraform-provider-hcp/pull/326))
+* resource/vault: keep failed clusters, export state ([331](https://github.com/hashicorp/terraform-provider-hcp/pull/331))
+* resource/hvn: keep failed networks/peerings, export state ([331](https://github.com/hashicorp/terraform-provider-hcp/pull/331))
+
 ## 0.33.0 (June 22, 2022)
 
 IMPROVEMENTS:
+
 * datasource/hcp_packer_image: Include `revoke_at` in the data source output ([330](https://github.com/hashicorp/terraform-provider-hcp/pull/330))
 * datasource/hcp_packer_iteration: Include `revoke_at` in the data source output ([330](https://github.com/hashicorp/terraform-provider-hcp/pull/330))
 * datasource/hcp_packer_image_iteration: Include `revoke_at` in the data source output ([330](https://github.com/hashicorp/terraform-provider-hcp/pull/330))

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.33.0"
+      version = "~> 0.34.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.33.0"
+      version = "~> 0.34.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Prepares v0.34.0, which includes a networking doc clarification and the introduction of tracked `state` to our resources! Previously, failed resources were automatically removed from terraform state— leaving behind orphaned resources. Now, by tracking `state`, the provider will be better able to recover from failed resource creation.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc

--- PASS: TestAccAwsPeering (722.57s)
--- PASS: TestAccTGWAttachment (770.96s)
--- PASS: TestAccHvnPeeringConnection (308.54s)
--- PASS: TestAccHvnRoute (947.37s)
--- PASS: TestAccAwsHvnOnly (165.44s)
--- PASS: TestAccAzureHvnOnly (298.79s)

--- PASS: TestAccConsulCluster (1592.92s)
--- PASS: TestAccConsulSnapshot (867.65s)

--- PASS: TestAccVaultCluster (3255.63s)
```

⚠️ NOTE: the Azure peering test result has been timing out consistently. This is a known issue that we are investigating.
