### PR TITLE
Fix to just WARN about missing client configs

### DIFF
--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -181,7 +181,8 @@ func dataSourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, me
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		log.Printf("[WARN] unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		return nil
 	}
 
 	// client config found, set data source attributes
@@ -302,7 +303,7 @@ func setConsulClusterDataSourceAttributes(
 	return nil
 }
 
-// setConsulClusterClientConfigResourceData sets all resource data that's derived from client config meta
+// setConsulClusterClientConfigDataSourceAttributes sets all resource data that's derived from client config meta
 func setConsulClusterClientConfigDataSourceAttributes(
 	d *schema.ResourceData,
 	clientConfigFiles *consulmodels.HashicorpCloudConsul20210204GetClientConfigResponse,

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -394,7 +394,8 @@ func resourceConsulClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, payload.Cluster.ID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", payload.Cluster.ID, err)
+		log.Printf("[WARN] unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		return nil
 	}
 
 	if err := setConsulClusterClientConfigResourceData(d, clientConfigFiles); err != nil {
@@ -585,7 +586,8 @@ func resourceConsulClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	// get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, loc, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		log.Printf("[WARN] unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		return nil
 	}
 
 	if err := setConsulClusterClientConfigResourceData(d, clientConfigFiles); err != nil {
@@ -694,7 +696,8 @@ func resourceConsulClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	// Get the cluster's Consul client config files
 	clientConfigFiles, err := clients.GetConsulClientConfigFiles(ctx, client, cluster.Location, clusterID)
 	if err != nil {
-		return diag.Errorf("unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		log.Printf("[WARN] unable to retrieve Consul cluster (%s) client config files: %v", clusterID, err)
+		return nil
 	}
 
 	if err := setConsulClusterClientConfigResourceData(d, clientConfigFiles); err != nil {


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

This is a small change so the HCP Consul TF providers don't fail out when they fail to get client configs.. as will be the case for `FAILED` clusters. Instead, we report the failure and leave the state of the client config unchanged.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* resource_consul_cluster: only WARN on failed client config calls [GH-nnnn]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
