### PR TITLE
fix Azure peering acc test variables

### DIFF
--- a/internal/provider/resource_azure_peering_connection_test.go
+++ b/internal/provider/resource_azure_peering_connection_test.go
@@ -33,8 +33,8 @@ resource "hcp_azure_peering_connection" "peering" {
   hvn_link                 = hcp_hvn.test.self_link
   peering_id               = "%[1]s"
   peer_vnet_name           = azurerm_virtual_network.vnet.name
-  peer_subscription_id     = "subscription-uuid"
-  peer_tenant_id           = "tenant-uuid"
+  peer_subscription_id     = "%[2]s"
+  peer_tenant_id           = "%[3]s"
   peer_resource_group_name = azurerm_resource_group.rg.name
   peer_vnet_region         = "eastus"
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixes a test that wasn't using configured Azure IDs.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
FIXES:
* resource/azure_peering: fix acceptance test [GH-nnnn]
```

### :building_construction: Acceptance tests

This test is still having timeout issues - investigation is ongoing. 
