### PR TITLE
Prep 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.36.0 (July 13,2022)
+
+IMPROVEMENTS:
+
+* provider: Bump google.golang.org/grpc from 1.47.0 to 1.48.0 ([#351](https://github.com/hashicorp/terraform-provider-hcp/pull/351)) 
+* provider: Bump `github.com/hashicorp/terraform-plugin-docs` from 0.12.0 to 0.13.0 ([#350](https://github.com/hashicorp/terraform-provider-hcp/pull/350))
+* datasource/hcp_packer_image: Add `component_type` optional argument ([#347](https://github.com/hashicorp/terraform-provider-hcp/pull/347))
+
 ## 0.35.0 (July 07,2022)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.35.0"
+      version = "~> 0.36.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.35.0"
+      version = "~> 0.36.0"
     }
   }
 }


### PR DESCRIPTION

### :building_construction: Acceptance tests

Output from acceptance testing:
```
$  make testacc TESTARGS='-run=TestAccAwsHvnOnly'

TF_ACC=1 go test ./internal/... -v -run=TestAccAwsHvnOnly -timeout 210m
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccAwsHvnOnly
--- PASS: TestAccAwsHvnOnly (153.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	(cached)
...
```
