### PR TITLE
TCE-1655: Retry failed GET organization and project requests

### DIFF
--- a/internal/clients/retry_request.go
+++ b/internal/clients/retry_request.go
@@ -1,0 +1,70 @@
+package clients
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/client/project_service"
+)
+
+const (
+	retryCount   = 10
+	retryDelay   = 10
+	counterStart = 1
+)
+
+var errorCodesToRetry = [...]int{502, 503, 504}
+
+// Helper to check what requests to retry based on the response HTTP code
+func shouldRetryErrorCode(errorCode int, errorCodesToRetry []int) bool {
+	for i := range errorCodesToRetry {
+		if errorCodesToRetry[i] == errorCode {
+			return true
+		}
+	}
+	return false
+}
+
+// Wraps the OrganizationServiceList function in a loop that supports retrying the GET request
+func RetryOrganizationServiceList(client *Client, params *organization_service.OrganizationServiceListParams) (*organization_service.OrganizationServiceListOK, error) {
+	resp, err := client.Organization.OrganizationServiceList(params, nil)
+
+	counter := counterStart
+	for err != nil && shouldRetryErrorCode(err.(*organization_service.OrganizationServiceListDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+
+		resp, err = client.Organization.OrganizationServiceList(params, nil)
+		if err == nil {
+			break
+		}
+		// Avoid wasting time if we're not going to retry next loop cycle
+		if (counter + 1) != retryCount {
+			fmt.Printf("Error trying to get list of organizations. Retrying in %d seconds...", retryDelay*counter)
+			time.Sleep(time.Duration(retryDelay*counter) * time.Second)
+		}
+		counter++
+	}
+
+	return resp, err
+}
+
+// Wraps the ProjectServiceList function in a loop that supports retrying the GET request
+func RetryProjectServiceList(client *Client, params *project_service.ProjectServiceListParams) (*project_service.ProjectServiceListOK, error) {
+	resp, err := client.Project.ProjectServiceList(params, nil)
+
+	counter := counterStart
+	for err != nil && shouldRetryErrorCode(err.(*project_service.ProjectServiceListDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+		resp, err = client.Project.ProjectServiceList(params, nil)
+		if err == nil {
+			break
+		}
+		// Avoid wasting time if we're not going to retry next loop cycle
+		if (counter + 1) != retryCount {
+			fmt.Printf("Error trying to get list of projects. Retrying in %d seconds...", retryDelay*counter)
+			time.Sleep(time.Duration(retryDelay*counter) * time.Second)
+		}
+		counter++
+	}
+
+	return resp, err
+}

--- a/internal/clients/retry_request_test.go
+++ b/internal/clients/retry_request_test.go
@@ -1,0 +1,17 @@
+package clients
+
+import "testing"
+
+func TestShouldRetryErrorCode(t *testing.T) {
+	errorCodesToRetry := []int{502, 503, 504}
+
+	shouldFail := shouldRetryErrorCode(200, errorCodesToRetry[:])
+	if shouldFail != false {
+		t.Errorf("shouldRetryErrorCode(200, []int{502, 503, 504}[:]) = %v; want false", shouldFail)
+	}
+
+	shouldSucceed := shouldRetryErrorCode(503, errorCodesToRetry[:])
+	if shouldSucceed != true {
+		t.Errorf("shouldRetryErrorCode(503, []int{502, 503, 504}[:]) = %v; want true", shouldSucceed)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/client/organization_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/preview/2019-12-10/client/project_service"
@@ -17,6 +18,14 @@ import (
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/version"
 )
+
+const (
+	retryCount   = 10
+	retryDelay   = 10
+	counterStart = 1
+)
+
+var errorCodesToRetry = [...]int{502, 503, 504}
 
 func New() func() *schema.Provider {
 	return func() *schema.Provider {
@@ -123,13 +132,66 @@ func configure(p *schema.Provider) func(context.Context, *schema.ResourceData) (
 	}
 }
 
+// Helper to check what requests to retry based on the response HTTP code
+func shouldRetryErrorCode(errorCode int, errorCodesToRetry []int) bool {
+	for i := range errorCodesToRetry {
+		if errorCodesToRetry[i] == errorCode {
+			return true
+		}
+	}
+	return false
+}
+
+// Wraps the OrganizationServiceList function in a loop that supports retrying the GET request
+func retryOrganizationServiceList(client *clients.Client, params *organization_service.OrganizationServiceListParams) (*organization_service.OrganizationServiceListOK, error) {
+	resp, err := client.Organization.OrganizationServiceList(params, nil)
+
+	counter := counterStart
+	for err != nil && shouldRetryErrorCode(err.(*organization_service.OrganizationServiceListDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+
+		resp, err = client.Organization.OrganizationServiceList(params, nil)
+		if err == nil {
+			break
+		}
+		// Avoid wasting time if we're not going to retry next loop cycle
+		if (counter + 1) != retryCount {
+			fmt.Printf("Error trying to get list of organizations. Retrying in %d seconds...", retryDelay*counter)
+			time.Sleep(time.Duration(retryDelay*counter) * time.Second)
+		}
+		counter++
+	}
+
+	return resp, err
+}
+
+// Wraps the ProjectServiceList function in a loop that supports retrying the GET request
+func retryProjectServiceList(client *clients.Client, params *project_service.ProjectServiceListParams) (*project_service.ProjectServiceListOK, error) {
+	resp, err := client.Project.ProjectServiceList(params, nil)
+
+	counter := counterStart
+	for err != nil && shouldRetryErrorCode(err.(*project_service.ProjectServiceListDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+		resp, err = client.Project.ProjectServiceList(params, nil)
+		if err == nil {
+			break
+		}
+		// Avoid wasting time if we're not going to retry next loop cycle
+		if (counter + 1) != retryCount {
+			fmt.Printf("Error trying to get list of projects. Retrying in %d seconds...", retryDelay*counter)
+			time.Sleep(time.Duration(retryDelay*counter) * time.Second)
+		}
+		counter++
+	}
+
+	return resp, err
+}
+
 // getProjectFromCredentials uses the configured client credentials to
 // fetch the associated organization and returns that organization's
 // single project.
 func getProjectFromCredentials(ctx context.Context, client *clients.Client) (*models.HashicorpCloudResourcemanagerProject, error) {
 	// Get the organization ID.
 	listOrgParams := organization_service.NewOrganizationServiceListParams()
-	listOrgResp, err := client.Organization.OrganizationServiceList(listOrgParams, nil)
+	listOrgResp, err := retryOrganizationServiceList(client, listOrgParams)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch organization list: %v", err)
 	}
@@ -144,7 +206,7 @@ func getProjectFromCredentials(ctx context.Context, client *clients.Client) (*mo
 	listProjParams.ScopeID = &orgID
 	scopeType := string(models.HashicorpCloudResourcemanagerResourceIDResourceTypeORGANIZATION)
 	listProjParams.ScopeType = &scopeType
-	listProjResp, err := client.Project.ProjectServiceList(listProjParams, nil)
+	listProjResp, err := retryProjectServiceList(client, listProjParams)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch project id: %v", err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -105,17 +105,3 @@ provider "hcp" {}`)
 	c = append(c, res...)
 	return strings.Join(c, "\n")
 }
-
-func TestShouldRetryErrorCode(t *testing.T) {
-	errorCodesToRetry := []int{502, 503, 504}
-
-	shouldFail := shouldRetryErrorCode(200, errorCodesToRetry[:])
-	if shouldFail != false {
-		t.Errorf("shouldRetryErrorCode(200, []int{502, 503, 504}[:]) = %v; want false", shouldFail)
-	}
-
-	shouldSucceed := shouldRetryErrorCode(503, errorCodesToRetry[:])
-	if shouldSucceed != true {
-		t.Errorf("shouldRetryErrorCode(503, []int{502, 503, 504}[:]) = %v; want true", shouldSucceed)
-	}
-}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -105,3 +105,17 @@ provider "hcp" {}`)
 	c = append(c, res...)
 	return strings.Join(c, "\n")
 }
+
+func TestShouldRetryErrorCode(t *testing.T) {
+	errorCodesToRetry := []int{502, 503, 504}
+
+	shouldFail := shouldRetryErrorCode(200, errorCodesToRetry[:])
+	if shouldFail != false {
+		t.Errorf("shouldRetryErrorCode(200, []int{502, 503, 504}[:]) = %v; want false", shouldFail)
+	}
+
+	shouldSucceed := shouldRetryErrorCode(503, errorCodesToRetry[:])
+	if shouldSucceed != true {
+		t.Errorf("shouldRetryErrorCode(503, []int{502, 503, 504}[:]) = %v; want true", shouldSucceed)
+	}
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

From time to time, the GET requests for fetching the organization and project will return a 502 or 504 which can cause E2E pipelines to fail. This PR addresses the issue by adding in some retry logic so if the 502s or 504s are temporary, we don't have to stop the whole pipeline in order to retry.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* all: Add retry logic to the get organization and get project endpoints [GH-nnnn]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestShouldRetryErrorCode'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestShouldRetryErrorCode -timeout 210m
?       github.com/hashicorp/terraform-provider-hcp/internal/clients    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.223s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.143s [no tests to run]
=== RUN   TestShouldRetryErrorCode
--- PASS: TestShouldRetryErrorCode (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   0.314s
...
```
