### PR TITLE
Log peering wait errors, use ReadTimeout in peering Data Sources

### DIFF
--- a/docs/data-sources/aws_network_peering.md
+++ b/docs/data-sources/aws_network_peering.md
@@ -52,6 +52,6 @@ data "hcp_aws_network_peering" "test" {
 
 Optional:
 
-- `default` (String)
+- `read` (String)
 
 

--- a/docs/data-sources/azure_peering_connection.md
+++ b/docs/data-sources/azure_peering_connection.md
@@ -57,3 +57,4 @@ data "hcp_azure_peering_connection" "test" {
 Optional:
 
 - `default` (String)
+- `read` (String)

--- a/docs/data-sources/azure_peering_connection.md
+++ b/docs/data-sources/azure_peering_connection.md
@@ -56,5 +56,4 @@ data "hcp_azure_peering_connection" "test" {
 
 Optional:
 
-- `default` (String)
 - `read` (String)

--- a/internal/clients/peering.go
+++ b/internal/clients/peering.go
@@ -76,7 +76,7 @@ func waitForPeeringToBe(ps peeringState) WaitFor {
 
 		result, err := stateChangeConfig.WaitForStateContext(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("error waiting for peering connection (%s) to become '%s'", peeringID, ps.Target)
+			return nil, fmt.Errorf("error waiting for peering connection (%s) to become '%s': %v", peeringID, ps.Target, err)
 		}
 
 		return result.(*networkmodels.HashicorpCloudNetwork20200907Peering), nil

--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -16,7 +16,7 @@ func dataSourceAwsNetworkPeering() *schema.Resource {
 		Description: "The AWS network peering data source provides information about an existing network peering between an HVN and a peer AWS VPC.",
 		ReadContext: dataSourceAwsNetworkPeeringRead,
 		Timeouts: &schema.ResourceTimeout{
-			Default: &peeringCreateTimeout,
+			Read: &peeringCreateTimeout,
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs
@@ -114,7 +114,7 @@ func dataSourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if waitForActive && peering.State != networkmodels.HashicorpCloudNetwork20200907PeeringStateACTIVE {
-		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnID, loc, peeringCreateTimeout)
+		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnID, loc, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -16,8 +16,7 @@ func dataSourceAzurePeeringConnection() *schema.Resource {
 		Description: "The Azure peering connection data source provides information about a peering connection between an HVN and a peer Azure VNet.",
 		ReadContext: dataSourceAzurePeeringConnectionRead,
 		Timeouts: &schema.ResourceTimeout{
-			Default: &peeringCreateTimeout,
-			Read:    &peeringCreateTimeout,
+			Read: &peeringCreateTimeout,
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -17,6 +17,7 @@ func dataSourceAzurePeeringConnection() *schema.Resource {
 		ReadContext: dataSourceAzurePeeringConnectionRead,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &peeringCreateTimeout,
+			Read:    &peeringCreateTimeout,
 		},
 		Schema: map[string]*schema.Schema{
 			// Required inputs
@@ -129,7 +130,7 @@ func dataSourceAzurePeeringConnectionRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if waitForActive && peering.State != networkmodels.HashicorpCloudNetwork20200907PeeringStateACTIVE {
-		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnLink.ID, loc, peeringCreateTimeout)
+		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnLink.ID, loc, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Occasionally we get what look like timeouts while waiting on Azure peerings to flip to ACTIVE:

```
TestE2E_BasicAzure 2022-07-29T17:56:40Z logger.go:66: module.hcp_peering.data.hcp_azure_peering_connection.peering: Still reading... [19m50s elapsed]
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66: 
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66: Error: error waiting for peering connection (azure-e2e-68625cad-peer) to become 'ACTIVE'
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66: 
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66:   with module.hcp_peering.data.hcp_azure_peering_connection.peering,
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66:   on .terraform/modules/hcp_peering/main.tf line 117, in data "hcp_azure_peering_connection" "peering":
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66:  117: data "hcp_azure_peering_connection" "peering" {
TestE2E_BasicAzure 2022-07-29T17:56:50Z logger.go:66: 
TestE2E_BasicAzure 2022-07-29T17:56:50Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1; 
Error: error waiting for peering connection (azure-e2e-68625cad-peer) to become 'ACTIVE'

  with module.hcp_peering.data.hcp_azure_peering_connection.peering,
  on .terraform/modules/hcp_peering/main.tf line 117, in data "hcp_azure_peering_connection" "peering":
 117: data "hcp_azure_peering_connection" "peering" {
}
```

This repeatedly happens right at 20 minutes, which is the [default timeout](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts#default-timeouts-and-deadline-exceeded-errors). That doesn't make a lot of sense, be we ourselves set the Timeout to 35 minutes in multiple places. The changes in this PR are to 1. try to log failures seen waiting on the peering state transition and 2. set the Read timeout to 35 minutes explicitly (vs using just `Timeouts.Default`).

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* data_source_azure_peering_connection: log failed peering wait errors [GH-363]
```

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
