### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ resource "hcp_aws_network_peering" "example" {
 
 // Create an HVN route that targets your HCP network peering and matches your AWS VPC's CIDR block.
 resource "hcp_hvn_route" "example" {
-  hvn_link         = hcp_hvn.hvn.self_link
+  hvn_link         = hcp_hvn.example.self_link
   hvn_route_id     = "peer-route-id"
   destination_cidr = aws_vpc.peer.cidr_block
   target_link      = hcp_aws_network_peering.example.self_link
@@ -84,6 +84,6 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 // Create a Vault cluster within the HVN.
 resource "hcp_vault_cluster" "example" {
   cluster_id = "vault-cluster"
-  hvn_id     = hcp_hvn.example_hvn.hvn_id
+  hvn_id     = hcp_hvn.example.hvn_id
 }
 ```


### PR DESCRIPTION
Fix resource names in example code.

Easy doc fix. Tested against

```
hcp = {
      source  = "hashicorp/hcp"
      version = "~> 0.39.0"
    }
```