### PR TITLE
Prep 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.42.0 (August 24, 2022)
+
+IMPROVEMENTS:
+
+* provider: Bump version of Go to 1.18.5 in `.go-version` ([GH-374](https://github.com/hashicorp/terraform-provider-hcp/pull/374))
+*provider: Bump `google.golang.org/grpc` from 1.48.0 to 1.49.0 ([GH-379](https://github.com/hashicorp/terraform-provider-hcp/pull/379))
+
+FIXES:
+
+* all: Prevents the app from crashing when a `*url.Error` is received while retrying HTTP requests. ([GH-376](https://github.com/hashicorp/terraform-provider-hcp/pull/376))
+
 ## 0.41.0 (August 18, 2022)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.41.0"
+      version = "~> 0.42.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.41.0"
+      version = "~> 0.42.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Preps the release of 0.42.0, which includes a critical fix to a panic that was happening in our retry helpers.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsHvnOnly'

--- PASS: TestAccAwsHvnOnly (146.62s)
PASS
```
