### PR TITLE
cited doc fix for issue #387

### DIFF
--- a/docs/guides/peering.md
+++ b/docs/guides/peering.md
@@ -65,7 +65,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 // Create an HVN route that targets your HCP network peering and matches your AWS VPC's CIDR block.
 // The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
 resource "hcp_hvn_route" "example" {
-  hvn_link         = hcp_hvn.hvn.self_link
+  hvn_link         = hcp_hvn.example.self_link
   hvn_route_id     = var.route_id
   destination_cidr = aws_vpc.peer.cidr_block
   target_link      = data.hcp_aws_network_peering.example.self_link

--- a/examples/guides/peering/main.tf
+++ b/examples/guides/peering/main.tf
@@ -47,7 +47,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 // Create an HVN route that targets your HCP network peering and matches your AWS VPC's CIDR block.
 // The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
 resource "hcp_hvn_route" "example" {
-  hvn_link         = hcp_hvn.hvn.self_link
+  hvn_link         = hcp_hvn.example.self_link
   hvn_route_id     = var.route_id
   destination_cidr = aws_vpc.peer.cidr_block
   target_link      = data.hcp_aws_network_peering.example.self_link


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* docs : Update docs for hcp_hvn_route resource [GH-388]
```

### :building_construction: Acceptance tests

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccAwsHvnOnly -timeout 210m
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccAwsHvnOnly
--- PASS: TestAccAwsHvnOnly (128.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	(cached)
```
