### PR TITLE
Replace ReadContext with ReadWithoutTimeout

### DIFF
--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -114,7 +114,7 @@ func dataSourceAwsNetworkPeeringRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if waitForActive && peering.State != networkmodels.HashicorpCloudNetwork20200907PeeringStateACTIVE {
-		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnID, loc, d.Timeout(schema.TimeoutRead))
+		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnID, loc, peeringCreateTimeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -13,8 +13,8 @@ import (
 
 func dataSourceAwsNetworkPeering() *schema.Resource {
 	return &schema.Resource{
-		Description: "The AWS network peering data source provides information about an existing network peering between an HVN and a peer AWS VPC.",
-		ReadContext: dataSourceAwsNetworkPeeringRead,
+		Description:        "The AWS network peering data source provides information about an existing network peering between an HVN and a peer AWS VPC.",
+		ReadWithoutTimeout: dataSourceAwsNetworkPeeringRead,
 		Timeouts: &schema.ResourceTimeout{
 			Read: &peeringCreateTimeout,
 		},

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -13,8 +13,8 @@ import (
 
 func dataSourceAzurePeeringConnection() *schema.Resource {
 	return &schema.Resource{
-		Description: "The Azure peering connection data source provides information about a peering connection between an HVN and a peer Azure VNet.",
-		ReadContext: dataSourceAzurePeeringConnectionRead,
+		Description:        "The Azure peering connection data source provides information about a peering connection between an HVN and a peer Azure VNet.",
+		ReadWithoutTimeout: dataSourceAzurePeeringConnectionRead,
 		Timeouts: &schema.ResourceTimeout{
 			Read: &peeringCreateTimeout,
 		},

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -129,7 +129,7 @@ func dataSourceAzurePeeringConnectionRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if waitForActive && peering.State != networkmodels.HashicorpCloudNetwork20200907PeeringStateACTIVE {
-		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnLink.ID, loc, d.Timeout(schema.TimeoutRead))
+		peering, err = clients.WaitForPeeringToBeActive(ctx, client, peering.ID, hvnLink.ID, loc, peeringCreateTimeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/provider/resource_azure_peering_connection_test.go
+++ b/internal/provider/resource_azure_peering_connection_test.go
@@ -122,13 +122,13 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
 					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
-					resource.TestCheckResourceAttrSet(resourceName, "azure_peering_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
+					// Note: azure_peering_id is not set until the peering is accepted after creation.
 				),
 			},
 			// Tests import


### PR DESCRIPTION
### :hammer_and_wrench: Description

Temporary fix to address an issue where timeouts aren't applied to a Data Source read. Relates to https://github.com/hashicorp/terraform-plugin-sdk/issues/1038

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* {azure data source}: {Replace ReadContext with ReadWithoutTimeout in the Azure and AWS peering connection} [GH-389]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:


```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
