### PR TITLE
Prevent FAILED peerings from failing deletes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ website/node_modules
 .env*
 
 website/vendor
+vendor
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/contributing/writing-tests.md
+++ b/contributing/writing-tests.md
@@ -69,7 +69,7 @@ For advanced developers, the acceptance testing framework accepts some additiona
 
 ## Writing an Acceptance Test
 
-Terraform has a framework for writing acceptance tests which minimises the
+Terraform has a framework for writing acceptance tests which minimizes the
 amount of boilerplate code necessary to use common testing patterns. The entry
 point to the framework is the `resource.Test()` function.
 

--- a/internal/clients/peering.go
+++ b/internal/clients/peering.go
@@ -99,5 +99,8 @@ var WaitForPeeringToBeAccepted = waitForPeeringToBe(peeringState{
 // WaitForPeeringToBeActive will poll the GET peering endpoint until the state is ACTIVE, ctx is canceled, or an error occurs.
 var WaitForPeeringToBeActive = waitForPeeringToBe(peeringState{
 	Target:  PeeringStateActive,
-	Pending: []string{PeeringStateCreating, PeeringStatePendingAcceptance, PeeringStateAccepted},
+	Pending: WaitForPeeringToBeActivePendingStates,
 })
+
+// WaitForPeeringToBeActivePendingStates are those from which we'd expect an ACTIVE state to be possible.
+var WaitForPeeringToBeActivePendingStates = []string{PeeringStateCreating, PeeringStatePendingAcceptance, PeeringStateAccepted}

--- a/internal/provider/resource_aws_network_peering_test.go
+++ b/internal/provider/resource_aws_network_peering_test.go
@@ -84,7 +84,7 @@ func TestAccAwsPeering(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": true, "azure": false}) },
 		ProviderFactories: providerFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
-			"aws": {VersionConstraint: "~> 2.64.0"},
+			"aws": {VersionConstraint: "~> 4.0.0"},
 		},
 		CheckDestroy: testAccCheckHvnPeeringDestroy,
 

--- a/internal/provider/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment_test.go
@@ -109,7 +109,7 @@ func TestAccTGWAttachment(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": true, "azure": false}) },
 		ProviderFactories: providerFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
-			"aws": {VersionConstraint: "~> 2.64.0"},
+			"aws": {VersionConstraint: "~> 4.0.0"},
 		},
 		CheckDestroy: testAccCheckTGWAttachmentDestroy,
 

--- a/internal/provider/resource_hvn_route_test.go
+++ b/internal/provider/resource_hvn_route_test.go
@@ -83,7 +83,7 @@ func TestAccHvnRoute(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": true, "azure": false}) },
 		ProviderFactories: providerFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
-			"aws": {VersionConstraint: "~> 2.64.0"},
+			"aws": {VersionConstraint: "~> 4.0.0"},
 		},
 		CheckDestroy: testAccCheckHvnRouteDestroy,
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* {affected resource | docs | all}: {Brief description of change} [GH-nnnn]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
