### PR TITLE
Add note on Vault Cluster about Tier field and Admins

### DIFF
--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -56,7 +56,7 @@ resource "hcp_vault_cluster" "example" {
 - `paths_filter` (List of String) The performance replication [paths filter](https://learn.hashicorp.com/tutorials/vault/paths-filter). Applies to performance replication secondaries only and operates in "deny" mode only.
 - `primary_link` (String) The `self_link` of the HCP Vault Plus tier cluster which is the primary in the performance replication setup with this HCP Vault Plus tier cluster. If not specified, it is a standalone Plus tier HCP Vault cluster.
 - `public_endpoint` (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
-- `tier` (String) Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://cloud.hashicorp.com/pricing/vault).
+- `tier` (String) Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://cloud.hashicorp.com/pricing/vault). Changing a cluster's size or tier is only available to admins. See [Scale a cluster](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/vault-scaling).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -63,7 +63,7 @@ func resourceVaultCluster() *schema.Resource {
 			},
 			// Optional fields
 			"tier": {
-				Description:      "Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://cloud.hashicorp.com/pricing/vault).",
+				Description:      "Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://cloud.hashicorp.com/pricing/vault). Changing a cluster's size or tier is only available to admins. See [Scale a cluster](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/vault-scaling).",
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add a note in the vault cluster resource that explains resizing a vault cluster is a feature only available to admin users.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):

```release-note
* docs: Add note in vault resource that only admins can modify cluster tier and size. [GH-nnnn]
```

### :building_construction: Preview

<img width="933" alt="Screen Shot 2022-09-30 at 4 23 26 PM" src="https://user-images.githubusercontent.com/15036233/193350617-4af2a72c-8323-4b5d-bb37-15b1029cd418.png">
