### PR TITLE
Release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.48.0 (November 9, 2022)
+
+IMPROVEMENTS:
+
+* provider: Bump `github.com/stretchr/testify` from 1.8.0 to 1.8.1 ([GH-408](https://github.com/hashicorp/terraform-provider-hcp/pull/408))
+* provider: Auto detect latest Consul patch version ([GH-406](https://github.com/hashicorp/terraform-provider-hcp/pull/406))
+
 ## 0.47.0 (October 21, 2022)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.47.0"
+      version = "~> 0.48.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.47.0"
+      version = "~> 0.48.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Release 0.48.0

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccConsulCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/... -v -run=TestAccConsulCluster -timeout 210m
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.737s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.207s [no tests to run]
=== RUN   TestAccConsulCluster
--- PASS: TestAccConsulCluster (1806.45s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   1806.870s
```
