### PR TITLE
Updates browser login documentation

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -11,6 +11,12 @@ The HCP provider accepts client credentials, which are obtained on the creation 
 
 Service principals and service principal keys can be created in the HCP portal with an existing user account.
 
+## Authenticate using user session with browser
+
+The HCP provider supports logging in via the browser. To enable automatic browser login, you must leave client credentials unset and pin the provider to version 0.45.0 or above.
+
+Upon running `terraform apply` or `terraform plan`, your web browser will navigate to the HCP portal, where you will be prompted to login. Once logged in, you may create new or manage existing resources fully authenticated. Your session will last 24 hours before prompting you to reauthenticate.
+
 ## Create a service principal
 
 Once you have registered and logged into the HCP portal, navigate to the Access Control (IAM) page. Select the Service Principals tab and create a new service principal. Give it the role Contributor, since it will be writing resources.
@@ -32,16 +38,3 @@ provider "hcp" {
   client_secret = "service-principal-key-client-secret"
 }
 ``` 
-
-## Optional Browser Login if no client credentials configured
-
-The HCP provider supports log in via the browser if the client ID and client secret aren't configured. This feature is supported in provider version 0.45.0 and above. Enable browser login post update by first regenerating the provider in terminal with the following commands. 
-
-```
-cd terraform-provider-hcp
-make dev
-terraform init
-terraform apply
-```
-
-Your web browser then will navigate to the HCP portal, where you will be prompted to login. You may now create new or manage existing resources fully authenticated.

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -35,10 +35,15 @@ provider "hcp" {
   client_id     = "service-principal-key-client-id"
   client_secret = "service-principal-key-client-secret"
 }
-```
+``` 
 
 ## User session with browser login
 
 The HCP provider supports logging in via the browser. To enable automatic browser login, you must leave client credentials unset and pin the provider to version 0.45.0 or above.
 
 Upon running `terraform apply` or `terraform plan`, your web browser will navigate to the HCP portal, where you will be prompted to login. Once logged in, you may create new or manage existing resources fully authenticated. Your session will last 24 hours before prompting you to reauthenticate.
+
+```terraform
+// If no credentials are set, a user session can be obtained through browser login.
+provider "hcp" {}
+``` 

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -2,34 +2,32 @@
 subcategory: ""
 page_title: "Authenticate with HCP - HCP Provider"
 description: |-
-    A guide to obtaining client credentials and adding them to provider configuration.
+    A guide to obtaining HCP credentials and adding them to provider configuration.
 ---
 
-# Authenticate with HCP using service principal credentials
+# Authenticate with HCP
 
-The HCP provider accepts client credentials, which are obtained on the creation of a service principal key. 
+The HCP provider accepts client credentials, which are obtained on the creation of a service principal key.
+
+## Service principal credentials
 
 Service principals and service principal keys can be created in the HCP portal with an existing user account.
 
-## Authenticate using user session with browser
-
-The HCP provider supports logging in via the browser. To enable automatic browser login, you must leave client credentials unset and pin the provider to version 0.45.0 or above.
-
-Upon running `terraform apply` or `terraform plan`, your web browser will navigate to the HCP portal, where you will be prompted to login. Once logged in, you may create new or manage existing resources fully authenticated. Your session will last 24 hours before prompting you to reauthenticate.
-
-## Create a service principal
+### Create a service principal
 
 Once you have registered and logged into the HCP portal, navigate to the Access Control (IAM) page. Select the Service Principals tab and create a new service principal. Give it the role Contributor, since it will be writing resources.
 
-## Create a service principal key
+### Create a service principal key
 
 Once the service principal is created, navigate to its detail page by selecting its name in the list. Create a new service principal key.
 
 -> **Note:** Save the client ID and secret returned on successful key creation. The client secret will not be available after creation.
 
-## Two options to configure the provider 
+### Two options to configure the provider
 
-Save the client ID and secret as the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET. Or, configure the provider with the client ID and secret by copy-pasting the values directly into provider config.
+Save the client ID and secret as the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET.
+
+Or, configure the provider with the client ID and secret by copy-pasting the values directly into provider config.
 
 ```terraform
 // Credentials can be set explicitly or via the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET
@@ -37,4 +35,10 @@ provider "hcp" {
   client_id     = "service-principal-key-client-id"
   client_secret = "service-principal-key-client-secret"
 }
-``` 
+```
+
+## User session with browser login
+
+The HCP provider supports logging in via the browser. To enable automatic browser login, you must leave client credentials unset and pin the provider to version 0.45.0 or above.
+
+Upon running `terraform apply` or `terraform plan`, your web browser will navigate to the HCP portal, where you will be prompted to login. Once logged in, you may create new or manage existing resources fully authenticated. Your session will last 24 hours before prompting you to reauthenticate.

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -32,3 +32,16 @@ provider "hcp" {
   client_secret = "service-principal-key-client-secret"
 }
 ``` 
+
+## Optional Browser Login if no client credentials configured
+
+The HCP provider supports log in via the browser if the client ID and client secret aren't configured. This feature is supported in provider version 0.45.0 and above. Enable browser login post update by first regenerating the provider in terminal with the following commands. 
+
+```
+cd terraform-provider-hcp
+make dev
+terraform init
+terraform apply
+```
+
+Your web browser then will navigate to the HCP portal, where you will be prompted to login. You may now create new or manage existing resources fully authenticated.

--- a/examples/guides/auth/_config_no_clients.tf
+++ b/examples/guides/auth/_config_no_clients.tf
@@ -1,0 +1,2 @@
+// If no credentials are set, a user session can be obtained through browser login.
+provider "hcp" {}

--- a/templates/guides/auth.md.tmpl
+++ b/templates/guides/auth.md.tmpl
@@ -2,27 +2,39 @@
 subcategory: ""
 page_title: "Authenticate with HCP - HCP Provider"
 description: |-
-    A guide to obtaining client credentials and adding them to provider configuration.
+    A guide to obtaining HCP credentials and adding them to provider configuration.
 ---
 
-# Authenticate with HCP using service principal credentials
+# Authenticate with HCP
 
-The HCP provider accepts client credentials, which are obtained on the creation of a service principal key. 
+The HCP provider accepts client credentials, which are obtained on the creation of a service principal key.
+
+## Service principal credentials
 
 Service principals and service principal keys can be created in the HCP portal with an existing user account.
 
-## Create a service principal
+### Create a service principal
 
 Once you have registered and logged into the HCP portal, navigate to the Access Control (IAM) page. Select the Service Principals tab and create a new service principal. Give it the role Contributor, since it will be writing resources.
 
-## Create a service principal key
+### Create a service principal key
 
 Once the service principal is created, navigate to its detail page by selecting its name in the list. Create a new service principal key.
 
 -> **Note:** Save the client ID and secret returned on successful key creation. The client secret will not be available after creation.
 
-## Two options to configure the provider 
+### Two options to configure the provider
 
-Save the client ID and secret as the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET. Or, configure the provider with the client ID and secret by copy-pasting the values directly into provider config.
+Save the client ID and secret as the environment variables HCP_CLIENT_ID and HCP_CLIENT_SECRET.
+
+Or, configure the provider with the client ID and secret by copy-pasting the values directly into provider config.
 
 {{ tffile "examples/guides/auth/_config.tf" }} 
+
+## User session with browser login
+
+The HCP provider supports logging in via the browser. To enable automatic browser login, you must leave client credentials unset and pin the provider to version 0.45.0 or above.
+
+Upon running `terraform apply` or `terraform plan`, your web browser will navigate to the HCP portal, where you will be prompted to login. Once logged in, you may create new or manage existing resources fully authenticated. Your session will last 24 hours before prompting you to reauthenticate.
+
+{{ tffile "examples/guides/auth/_config_no_clients.tf" }} 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

This PR includes an amendment to the provider's public authentication docs in support of the released automatic browser login feature. This documentation update addresses a doc request brought forward in our Issues backlog.

### :link: Relevant  Links

Jira Ticket - [Documentation for the browser OIDC login support](https://hashicorp.atlassian.net/browse/HCE-602)
Github Issue - [Provider documentation for browser login](https://github.com/hashicorp/terraform-provider-hcp/issues/409)

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below. The [GH-nnnn] should match the number of your PR.
-->

```release-note
* docs: Docs update to highlight optional browser login feature [GH-412]
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
