### PR TITLE
Release 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.49.0 (November 16, 2022)
+
+IMPROVEMENTS:
+
+* provider: Bump `github.com/hashicorp/terraform-plugin-sdk/v2` from 2.24.0 to 2.24.1 ([GH-415](https://github.com/hashicorp/terraform-provider-hcp/pull/415))
+* provider: Bump `github.com/hashicorp/hcp-sdk-go` from 0.23.0 to 0.24.0 ([GH-413](https://github.com/hashicorp/terraform-provider-hcp/pull/413))
+* docs: Update the tutorial links ([GH-414](https://github.com/hashicorp/terraform-provider-hcp/pull/414))
+* docs: Updates browser login documentation ([GH-412](https://github.com/hashicorp/terraform-provider-hcp/pull/412))
+
 ## 0.48.0 (November 9, 2022)
 
 IMPROVEMENTS:
@@ -58,7 +67,7 @@ FEATURES:
 IMPROVEMENTS:
 
 * provider: Bump version of Go to 1.18.5 in `.go-version` ([GH-374](https://github.com/hashicorp/terraform-provider-hcp/pull/374))
-*provider: Bump `google.golang.org/grpc` from 1.48.0 to 1.49.0 ([GH-379](https://github.com/hashicorp/terraform-provider-hcp/pull/379))
+* provider: Bump `google.golang.org/grpc` from 1.48.0 to 1.49.0 ([GH-379](https://github.com/hashicorp/terraform-provider-hcp/pull/379))
 
 FIXES:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.48.0"
+      version = "~> 0.49.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.48.0"
+      version = "~> 0.49.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

This preps the release of 0.49.0, consisting of documentation updates and dependency bumps.

Testing:
```
--- PASS: TestAcc_dataSourcePacker (8.26s)
--- PASS: TestAcc_dataSourcePacker_revokedIteration (11.03s)
--- PASS: TestAcc_dataSourcePackerImage (7.02s)
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (9.77s)
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (3.18s)
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (5.58s)
--- PASS: TestAcc_dataSourcePackerIteration (5.31s)
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (11.06s)

--- PASS: TestAccTGWAttachment (760.50s)
--- PASS: TestAccHvnRoute (781.40s)
--- PASS: TestAccAwsHvnOnly (130.40s)
--- PASS: TestAccAzureHvnOnly (419.06s)
--- PASS: TestAccHvnPeeringConnection (305.20s)
--- PASS: TestAccAwsPeering (767.33s)

--- PASS: TestAccBoundaryCluster (191.11s)

--- PASS: TestAccConsulCluster (1819.58s)
--- PASS: TestAccConsulSnapshot (1002.36s)

--- PASS: TestAccAzurePeeringConnection (1114.95s)