### PR TITLE
Increase `hcp_consul_cluster` delete timeout to 35 min

### DIFF
--- a/.changelog/427.txt
+++ b/.changelog/427.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Increase `hcp_consul_cluster` create timeout to 35 minutes
+```

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -28,7 +28,7 @@ var createUpdateConsulClusterTimeout = time.Minute * 35
 
 // deleteTimeout is the amount of time that can elapse
 // before a cluster delete operation should timeout.
-var deleteConsulClusterTimeout = time.Minute * 25
+var deleteConsulClusterTimeout = time.Minute * 35
 
 // resourceConsulCluster represents an HCP Consul cluster.
 func resourceConsulCluster() *schema.Resource {


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

In our E2E testing, we see Consul cluster delete times occasionally a bit above 25 minutes. Those clusters delete successfully, but the TF provider errors out on context cancellation. This increases the timeout from 25 minutes to 35 minutes, matching the Create timeout we already have.

### :building_construction: Acceptance tests

I have not ran acceptance testing because this only increases the delete timeout value to match the existing create timeout, no other behavior changed.

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
