### PR TITLE
HCE-716: differentiate acceptance test IDs

### DIFF
--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	acctestAlpineBucket      = fmt.Sprintf("alpine-acctest-%s", time.Now().Format("200601021504"))
-	acctestUbuntuBucket      = fmt.Sprintf("ubuntu-acctest-%s", time.Now().Format("200601021504"))
+	acctestAlpineBucket      = fmt.Sprintf("alpine-acc-%s", time.Now().Format("200601021504"))
+	acctestUbuntuBucket      = fmt.Sprintf("ubuntu-acc-%s", time.Now().Format("200601021504"))
 	acctestProductionChannel = "production"
 )
 

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -19,9 +19,9 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-const (
-	acctestAlpineBucket      = "alpine-acctest"
-	acctestUbuntuBucket      = "ubuntu-acctest"
+var (
+	acctestAlpineBucket      = fmt.Sprintf("alpine-acctest-%s", time.Now().Format("200601021504"))
+	acctestUbuntuBucket      = fmt.Sprintf("ubuntu-acctest-%s", time.Now().Format("200601021504"))
 	acctestProductionChannel = "production"
 )
 

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-const (
-	acctestImageBucket       = "alpine-acctest-imagetest"
-	acctestUbuntuImageBucket = "ubuntu-acctest-imagetest"
-	acctestArchImageBucket   = "arch-acctest-imagetest"
+var (
+	acctestImageBucket       = fmt.Sprintf("alpine-acctest-imagetest-%s", time.Now().Format("200601021504"))
+	acctestUbuntuImageBucket = fmt.Sprintf("ubuntu-acctest-imagetest-%s", time.Now().Format("200601021504"))
+	acctestArchImageBucket   = fmt.Sprintf("arch-acctest-imagetest-%s", time.Now().Format("200601021504"))
 	acctestImageChannel      = "production-image-test"
 	componentType            = "amazon-ebs.example"
 )

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	acctestImageBucket       = fmt.Sprintf("alpine-acctest-imagetest-%s", time.Now().Format("200601021504"))
-	acctestUbuntuImageBucket = fmt.Sprintf("ubuntu-acctest-imagetest-%s", time.Now().Format("200601021504"))
-	acctestArchImageBucket   = fmt.Sprintf("arch-acctest-imagetest-%s", time.Now().Format("200601021504"))
+	acctestImageBucket       = fmt.Sprintf("alpine-acc-imagetest-%s", time.Now().Format("200601021504"))
+	acctestUbuntuImageBucket = fmt.Sprintf("ubuntu-acc-imagetest-%s", time.Now().Format("200601021504"))
+	acctestArchImageBucket   = fmt.Sprintf("arch-acc-imagetest-%s", time.Now().Format("200601021504"))
 	acctestImageChannel      = "production-image-test"
 	componentType            = "amazon-ebs.example"
 )

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	acctestIterationBucket       = fmt.Sprintf("alpine-acctest-itertest-%s", time.Now().Format("200601021504"))
-	acctestIterationUbuntuBucket = fmt.Sprintf("ubuntu-acctest-itertest-%s", time.Now().Format("200601021504"))
+	acctestIterationBucket       = fmt.Sprintf("alpine-acc-itertest-%s", time.Now().Format("200601021504"))
+	acctestIterationUbuntuBucket = fmt.Sprintf("ubuntu-acc-itertest-%s", time.Now().Format("200601021504"))
 	acctestIterationChannel      = "production-iter-test"
 )
 

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-const (
-	acctestIterationBucket       = "alpine-acctest-itertest"
-	acctestIterationUbuntuBucket = "ubuntu-acctest-itertest"
+var (
+	acctestIterationBucket       = fmt.Sprintf("alpine-acctest-itertest-%s", time.Now().Format("200601021504"))
+	acctestIterationUbuntuBucket = fmt.Sprintf("ubuntu-acctest-itertest-%s", time.Now().Format("200601021504"))
 	acctestIterationChannel      = "production-iter-test"
 )
 

--- a/internal/provider/resource_aws_network_peering_test.go
+++ b/internal/provider/resource_aws_network_peering_test.go
@@ -111,9 +111,18 @@ func TestAccAwsPeering(t *testing.T) {
 			// Testing that we can import HVN route created in the previous step and that the
 			// resource terraform state will be exactly the same
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateId:     "test-hvn:test-peering",
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+
+					hvnID := s.RootModule().Resources["hcp_hvn.test"].Primary.Attributes["hvn_id"]
+					peerID := rs.Primary.Attributes["peering_id"]
+					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
+				},
 				ImportStateVerify: true,
 			},
 			// Testing running Terraform Apply for already known resource

--- a/internal/provider/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment_test.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -14,14 +14,14 @@ import (
 
 var (
 	// using unique names for AWS resource to make debugging easier
-	tgwAttUniqueAWSName        = fmt.Sprintf("hcp-tf-provider-test-%d", rand.Intn(99999))
+	tgwAttUniqueAWSName        = fmt.Sprintf("hcp-provider-test-%s", time.Now().Format("200601021504"))
 	testAccTGWAttachmentConfig = fmt.Sprintf(`
 provider "aws" {
   region = "us-west-2"
 }
 
 resource "hcp_hvn" "test" {
-  hvn_id         = "test-hvn"
+  hvn_id         = "%[1]s"
   cloud_provider = "aws"
   region         = "us-west-2"
   cidr_block     = "172.25.16.0/20"
@@ -62,7 +62,7 @@ resource "hcp_aws_transit_gateway_attachment" "example" {
   ]
 
   hvn_id                        = hcp_hvn.test.hvn_id
-  transit_gateway_attachment_id = "example-tgw-attachment"
+  transit_gateway_attachment_id = "%[1]s"
   transit_gateway_id            = aws_ec2_transit_gateway.example.id
   resource_share_arn            = aws_ram_resource_share.example.arn
 }
@@ -77,7 +77,7 @@ data "hcp_aws_transit_gateway_attachment" "example" {
 // The route depends on the data source, rather than the resource, to ensure the TGW is in an Active state.
 resource "hcp_hvn_route" "route" {
  hvn_link         = hcp_hvn.test.self_link
- hvn_route_id     = "hvn-to-tgw-attachment"
+ hvn_route_id     = "%[1]s"
  destination_cidr = aws_vpc.example.cidr_block
  target_link      = data.hcp_aws_transit_gateway_attachment.example.self_link
 }
@@ -119,8 +119,8 @@ func TestAccTGWAttachment(t *testing.T) {
 				Config: testConfig(testAccTGWAttachmentConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTGWAttachmentExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", "example-tgw-attachment"),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", tgwAttUniqueAWSName),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", tgwAttUniqueAWSName),
 					resource.TestCheckResourceAttrSet(resourceName, "transit_gateway_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_transit_gateway_attachment_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
@@ -128,7 +128,7 @@ func TestAccTGWAttachment(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					testLink(resourceName, "self_link", "example-tgw-attachment", TgwAttachmentResourceType, "hcp_hvn.test"),
+					testLink(resourceName, "self_link", tgwAttUniqueAWSName, TgwAttachmentResourceType, "hcp_hvn.test"),
 				),
 			},
 			// Testing that we can import TGW attachment created in the previous step and that the
@@ -151,8 +151,8 @@ func TestAccTGWAttachment(t *testing.T) {
 				Config: testConfig(testAccTGWAttachmentConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTGWAttachmentExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", "example-tgw-attachment"),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", tgwAttUniqueAWSName),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", tgwAttUniqueAWSName),
 					resource.TestCheckResourceAttrSet(resourceName, "transit_gateway_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_transit_gateway_attachment_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
@@ -160,7 +160,7 @@ func TestAccTGWAttachment(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					testLink(resourceName, "self_link", "example-tgw-attachment", TgwAttachmentResourceType, "hcp_hvn.test"),
+					testLink(resourceName, "self_link", tgwAttUniqueAWSName, TgwAttachmentResourceType, "hcp_hvn.test"),
 				),
 			},
 		},

--- a/internal/provider/resource_azure_peering_connection_test.go
+++ b/internal/provider/resource_azure_peering_connection_test.go
@@ -133,9 +133,18 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 			},
 			// Tests import
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateId:     uniqueAzurePeeringTestID + ":" + uniqueAzurePeeringTestID,
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+
+					hvnID := s.RootModule().Resources["hcp_hvn.test"].Primary.Attributes["hvn_id"]
+					peerID := rs.Primary.Attributes["peering_id"]
+					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
+				},
 				ImportStateVerify: true,
 			},
 			// Tests read

--- a/internal/provider/resource_azure_peering_connection_test.go
+++ b/internal/provider/resource_azure_peering_connection_test.go
@@ -3,9 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	uniqueAzurePeeringTestID  = fmt.Sprintf("hcp-tf-provider-test-%d", rand.Intn(99999))
+	uniqueAzurePeeringTestID  = fmt.Sprintf("hcp-provider-test-%s", time.Now().Format("200601021504"))
 	subscriptionID            = os.Getenv("AZURE_SUBSCRIPTION_ID")
 	tenantID                  = os.Getenv("AZURE_TENANT_ID")
 	testAccAzurePeeringConfig = fmt.Sprintf(`

--- a/internal/provider/resource_boundary_cluster_test.go
+++ b/internal/provider/resource_boundary_cluster_test.go
@@ -4,19 +4,22 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-const boundaryCluster = `
+var boundaryUniqueID = fmt.Sprintf("hcp-provider-test-%s", time.Now().Format("200601021504"))
+
+var boundaryCluster = fmt.Sprintf(`
 resource hcp_boundary_cluster "test" {
-	cluster_id = "test-boundary-cluster"
+	cluster_id = "%[1]s"
 	username = "test-user"
 	password = "password123!"
 }
-`
+`, boundaryUniqueID)
 
 func setTestAccBoundaryClusterConfig(boundaryCluster string) string {
 	return fmt.Sprintf(`
@@ -42,7 +45,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 				Config: testConfig(setTestAccBoundaryClusterConfig(boundaryCluster)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBoundaryClusterExists(boundaryClusterResourceName),
-					resource.TestCheckResourceAttr(boundaryClusterResourceName, "cluster_id", "test-boundary-cluster"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "cluster_id", boundaryUniqueID),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "cluster_url"),
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
@@ -69,7 +72,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 				Config: testConfig(setTestAccBoundaryClusterConfig(boundaryCluster)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBoundaryClusterExists(boundaryClusterResourceName),
-					resource.TestCheckResourceAttr(boundaryClusterResourceName, "cluster_id", "test-boundary-cluster"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "cluster_id", boundaryUniqueID),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "cluster_url"),
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),

--- a/internal/provider/resource_hvn_peering_connection_test.go
+++ b/internal/provider/resource_hvn_peering_connection_test.go
@@ -4,22 +4,28 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-var testAccHvnPeeringConnectionConfig = `
+var (
+	hvn1UniqueID = fmt.Sprintf("hcp-provider-test-%s-1", time.Now().Format("200601021504"))
+	hvn2UniqueID = fmt.Sprintf("hcp-provider-test-%s-2", time.Now().Format("200601021504"))
+)
+
+var testAccHvnPeeringConnectionConfig = fmt.Sprintf(`
 resource "hcp_hvn" "test_1" {
-	hvn_id         = "test-1"
+	hvn_id         = "%[1]s"
 	cloud_provider = "aws"
 	region         = "us-west-2"
 	cidr_block     = "172.25.16.0/20"
 }
 
 resource "hcp_hvn" "test_2" {
-	hvn_id         = "test-2"
+	hvn_id         = "%[2]s"
 	cloud_provider = "aws"
 	region         = "us-west-2"
 	cidr_block     = "172.18.16.0/20"
@@ -35,7 +41,7 @@ data "hcp_hvn_peering_connection" "test" {
 	hvn_1      = hcp_hvn_peering_connection.test.hvn_1
 	hvn_2      = hcp_hvn_peering_connection.test.hvn_2
 }
-`
+`, hvn1UniqueID, hvn2UniqueID)
 
 // This includes tests against both the resource and the corresponding datasource
 // to shorten testing time
@@ -59,8 +65,8 @@ func TestAccHvnPeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "hvn_1", "test-1", HvnResourceType, resourceName),
-					testLink(resourceName, "hvn_2", "test-2", HvnResourceType, resourceName),
+					testLink(resourceName, "hvn_1", hvn1UniqueID, HvnResourceType, resourceName),
+					testLink(resourceName, "hvn_2", hvn2UniqueID, HvnResourceType, resourceName),
 				),
 			},
 			// Tests import
@@ -90,8 +96,8 @@ func TestAccHvnPeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "hvn_1", "test-1", HvnResourceType, resourceName),
-					testLink(resourceName, "hvn_2", "test-2", HvnResourceType, resourceName),
+					testLink(resourceName, "hvn_1", hvn1UniqueID, HvnResourceType, resourceName),
+					testLink(resourceName, "hvn_2", hvn2UniqueID, HvnResourceType, resourceName),
 				),
 			},
 			// Tests datasource
@@ -104,8 +110,8 @@ func TestAccHvnPeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "expires_at", dataSourceName, "expires_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "state", dataSourceName, "state"),
-					testLink(dataSourceName, "hvn_1", "test-1", HvnResourceType, dataSourceName),
-					testLink(dataSourceName, "hvn_2", "test-2", HvnResourceType, dataSourceName),
+					testLink(dataSourceName, "hvn_1", hvn1UniqueID, HvnResourceType, dataSourceName),
+					testLink(dataSourceName, "hvn_2", hvn2UniqueID, HvnResourceType, dataSourceName),
 				),
 			},
 		},

--- a/internal/provider/resource_hvn_route_test.go
+++ b/internal/provider/resource_hvn_route_test.go
@@ -103,9 +103,18 @@ func TestAccHvnRoute(t *testing.T) {
 			// Testing that we can import HVN route created in the previous step and that the
 			// resource terraform state will be exactly the same
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateId:     "test-hvn:peering-route",
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+
+					hvnID := s.RootModule().Resources["hcp_hvn.test"].Primary.Attributes["hvn_id"]
+					routeID := rs.Primary.Attributes["hvn_route_id"]
+					return fmt.Sprintf("%s:%s", hvnID, routeID), nil
+				},
 				ImportStateVerify: true,
 			},
 			// Testing running Terraform Apply for already known resource

--- a/internal/provider/resource_hvn_route_test.go
+++ b/internal/provider/resource_hvn_route_test.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -13,15 +13,15 @@ import (
 )
 
 var (
-	// using unique names for AWS resource to make debugging easier
-	hvnRouteUniqueAWSName = fmt.Sprintf("hcp-tf-provider-test-%d", rand.Intn(99999))
+	// using unique names for resources to make debugging easier
+	hvnRouteUniqueAWSName = fmt.Sprintf("hcp-provider-test-%s", time.Now().Format("200601021504"))
 	testAccHvnRouteConfig = fmt.Sprintf(`
 provider "aws" {
   region = "us-west-2"
 }
 
 resource "hcp_hvn" "test" {
-	hvn_id         = "test-hvn"
+	hvn_id         = "%[1]s"
 	cloud_provider = "aws"
 	region         = "us-west-2"
 }
@@ -34,7 +34,7 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "hcp_aws_network_peering" "peering" {	
-  peering_id      = "hcp-tf-provider-test"
+  peering_id      = "%[1]s"
   hvn_id          = hcp_hvn.test.hvn_id
   peer_account_id = aws_vpc.vpc.owner_id
   peer_vpc_id     = aws_vpc.vpc.id
@@ -50,7 +50,7 @@ data "hcp_aws_network_peering" "peering" {
 
 // The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
 resource "hcp_hvn_route" "route" {
-  hvn_route_id = "peering-route"
+  hvn_route_id = "%[1]s"
   hvn_link = hcp_hvn.test.self_link
   destination_cidr = "172.31.0.0/16"
   target_link = data.hcp_aws_network_peering.peering.self_link
@@ -93,11 +93,11 @@ func TestAccHvnRoute(t *testing.T) {
 				Config: testConfig(testAccHvnRouteConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHvnRouteExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_route_id", "peering-route"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_route_id", hvnRouteUniqueAWSName),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr", "172.31.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
-					testLink(resourceName, "self_link", "peering-route", HVNRouteResourceType, "hcp_hvn.test"),
-					testLink(resourceName, "target_link", "hcp-tf-provider-test", PeeringResourceType, "hcp_hvn.test"),
+					testLink(resourceName, "self_link", hvnRouteUniqueAWSName, HVNRouteResourceType, "hcp_hvn.test"),
+					testLink(resourceName, "target_link", hvnRouteUniqueAWSName, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
 			// Testing that we can import HVN route created in the previous step and that the
@@ -113,11 +113,11 @@ func TestAccHvnRoute(t *testing.T) {
 				Config: testConfig(testAccHvnRouteConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHvnRouteExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_route_id", "peering-route"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_route_id", hvnRouteUniqueAWSName),
 					resource.TestCheckResourceAttr(resourceName, "destination_cidr", "172.31.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
-					testLink(resourceName, "self_link", "peering-route", HVNRouteResourceType, "hcp_hvn.test"),
-					testLink(resourceName, "target_link", "hcp-tf-provider-test", PeeringResourceType, "hcp_hvn.test"),
+					testLink(resourceName, "self_link", hvnRouteUniqueAWSName, HVNRouteResourceType, "hcp_hvn.test"),
+					testLink(resourceName, "target_link", hvnRouteUniqueAWSName, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
 		},

--- a/internal/provider/resource_hvn_test.go
+++ b/internal/provider/resource_hvn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,9 +13,13 @@ import (
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-var testAccAwsHvnConfig = `
+var (
+	hvnUniqueID = fmt.Sprintf("hcp-provider-test-%s", time.Now().Format("200601021504"))
+)
+
+var testAccAwsHvnConfig = fmt.Sprintf(`
 resource "hcp_hvn" "test" {
-	hvn_id         = "test-hvn"
+	hvn_id         = "%[1]s"
 	cloud_provider = "aws"
 	region         = "us-west-2"
 }
@@ -22,12 +27,12 @@ resource "hcp_hvn" "test" {
 data "hcp_hvn" "test" {
 	hvn_id = hcp_hvn.test.hvn_id
 }
-`
+`, hvnUniqueID)
 
 // Currently in public beta
-var testAccAzureHvnConfig = `
+var testAccAzureHvnConfig = fmt.Sprintf(`
 resource "hcp_hvn" "test" {
-	hvn_id         = "test-hvn"
+	hvn_id         = "%[1]s"
 	cloud_provider = "azure"
 	region         = "eastus"
 }
@@ -35,7 +40,7 @@ resource "hcp_hvn" "test" {
 data "hcp_hvn" "test" {
 	hvn_id = hcp_hvn.test.hvn_id
 }
-`
+`, hvnUniqueID)
 
 // This includes tests against both the resource and the corresponding datasource
 // to shorten testing time.
@@ -53,7 +58,7 @@ func TestAccAwsHvnOnly(t *testing.T) {
 				Config: testConfig(testAccAwsHvnConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHvnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", hvnUniqueID),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
@@ -62,7 +67,7 @@ func TestAccAwsHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+					testLink(resourceName, "self_link", hvnUniqueID, HvnResourceType, resourceName),
 				),
 			},
 			// Tests import
@@ -84,7 +89,7 @@ func TestAccAwsHvnOnly(t *testing.T) {
 				Config: testConfig(testAccAwsHvnConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHvnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", hvnUniqueID),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
@@ -93,7 +98,7 @@ func TestAccAwsHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_account_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+					testLink(resourceName, "self_link", hvnUniqueID, HvnResourceType, resourceName),
 				),
 			},
 			// Tests datasource
@@ -131,7 +136,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 				Config: testConfig(testAccAzureHvnConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHvnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", hvnUniqueID),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "azure"),
 					resource.TestCheckResourceAttr(resourceName, "region", "eastus"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
@@ -139,7 +144,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+					testLink(resourceName, "self_link", hvnUniqueID, HvnResourceType, resourceName),
 				),
 			},
 			// Tests import
@@ -161,7 +166,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 				Config: testConfig(testAccAzureHvnConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHvnExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
+					resource.TestCheckResourceAttr(resourceName, "hvn_id", hvnUniqueID),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "azure"),
 					resource.TestCheckResourceAttr(resourceName, "region", "eastus"),
 					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
@@ -169,7 +174,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", "test-hvn", HvnResourceType, resourceName),
+					testLink(resourceName, "self_link", hvnUniqueID, HvnResourceType, resourceName),
 				),
 			},
 			// Tests datasource


### PR DESCRIPTION
### :hammer_and_wrench: Description

To help with test cleanup in case of unexpected panics.

EDIT: Reverted the Consul change due to consistent creation timeout failures. Reaching out to Consul team to find out the issue.

### :building_construction: Acceptance tests

Output from acceptance testing:

```
$ make testacc

# Packer tests
--- PASS: TestAcc_dataSourcePacker (13.14s)
--- PASS: TestAcc_dataSourcePacker_revokedIteration (11.51s)
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (7.85s)
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (5.79s)
--- PASS: TestAcc_dataSourcePackerIteration (5.48s)
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (11.06s)

# Networking tests
--- PASS: TestAccHvnPeeringConnection (305.60s)
--- PASS: TestAccAzureHvnOnly (281.41s)
--- PASS: TestAccAwsHvnOnly (113.52s)
--- PASS: TestAccHvnRoute (706.42s)
--- PASS: TestAccHvnPeeringConnection (326.27s)
--- PASS: TestAccAwsPeering (710.01s)
--- PASS: TestAccAzurePeeringConnection (1155.92s)

# Boundary test
--- PASS: TestAccBoundaryCluster (178.35s)

```
