### PR TITLE
HCE-721 Add Auto Changelog for Dependabot

### DIFF
--- a/.changelog/429.txt
+++ b/.changelog/429.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Enable automatic changelog creation for dependabot PRs.
+```

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "pr/no-changelog"
 
   # Maintain dependencies for Go modules
   - package-ecosystem: "gomod"
@@ -15,3 +17,5 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: "daily"
+    labels:
+      - "pr/no-changelog"

--- a/.github/workflows/create-dependabot-changelog.yml
+++ b/.github/workflows/create-dependabot-changelog.yml
@@ -1,0 +1,37 @@
+# Auto generate a changelog entry if the PR was opened by dependabot.
+---
+name: Create Changelog for Dependabot
+
+on:
+  pull_request:
+    types: 
+      - opened
+
+jobs:
+  create_changelog:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot'}}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+
+      - name: Configure git
+        env:
+          TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+        run: |
+            git config --global advice.detachedHead false
+            git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+            git config user.name "github-actions"
+            git config user.email "hashicorp-cloud@hashicorp.com"
+      - name: Create Changelog
+        run: |
+          echo "This is a Dependabot PR. Creating changelog entry on its behalf."
+          touch .changelog/${{ github.event.pull_request.number }}.txt
+          printf '```release-note:improvement%s\n' >> .changelog/${{ github.event.pull_request.number }}.txt
+          printf '${{ github.event.pull_request.title }}%s\n' >> .changelog/${{ github.event.pull_request.number }}.txt
+          printf '```%s\n' >> .changelog/${{ github.event.pull_request.number }}.txt
+          git add .
+          git commit -m "Added changelog entry"
+          git push


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add a GitHub action that will create a changelog entry for dependabot PRs. This will also disable the changelog check for dependabot PRs by adding the pr/no-changelog label.

### :link: External Links

Proof of concept: https://github.com/hashicorp/cloud-tooling-automation-spike/pull/18