### PR TITLE
HCE-721: Fix Dependabot Name

### DIFF
--- a/.github/workflows/create-dependabot-changelog.yml
+++ b/.github/workflows/create-dependabot-changelog.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   create_changelog:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot'}}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]'}}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### :hammer_and_wrench: Description

Adjust the name of `dependabot` to the correct one: `dependabot[bot]`

This was confirmed with the GitHub API:
```
> gh api /repos/hashicorp/terraform-provider-hcp/pulls/431 --method GET
```
```json
{
  "url": "https://api.github.com/repos/hashicorp/terraform-provider-hcp/pulls/431",
  "id": 1164098932,
  "node_id": "PR_kwDOE4g6Vc5FYr10",
  "html_url": "https://github.com/hashicorp/terraform-provider-hcp/pull/431",
  "diff_url": "https://github.com/hashicorp/terraform-provider-hcp/pull/431.diff",
  "patch_url": "https://github.com/hashicorp/terraform-provider-hcp/pull/431.patch",
  "issue_url": "https://api.github.com/repos/hashicorp/terraform-provider-hcp/issues/431",
  "number": 431,
  "state": "open",
  "locked": false,
  "title": "Bump github.com/hashicorp/hcp-sdk-go from 0.28.0 to 0.29.0",
  "user": {
    "login": "dependabot[bot]",
    "id": 49699333,
    "node_id": "MDM6Qm90NDk2OTkzMzM=",
    "avatar_url": "https://avatars.githubusercontent.com/in/29110?v=4",
...
```