### PR TITLE
Unique Consul Cluster ID

### DIFF
--- a/.changelog/437.txt
+++ b/.changelog/437.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Enable unique clusterIDs
+Use unique clusterIDs in acceptance tests
 ```

--- a/.changelog/437.txt
+++ b/.changelog/437.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Enable unique clusterIDs
+```

--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -41,7 +41,7 @@ func setTestAccConsulClusterConfig(consulCluster string) string {
 
 	data "hcp_consul_versions" "test" {}
 
-	%[1]s
+	%s
 	
 	data "hcp_consul_cluster" "test" {
 		cluster_id = hcp_consul_cluster.test.cluster_id

--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -15,7 +15,7 @@ var consulClusterUniqueID = fmt.Sprintf("test-%s", time.Now().Format("2006010215
 
 var consulCluster = fmt.Sprintf(`
 resource "hcp_consul_cluster" "test" {
-	cluster_id         = "%[1]s"
+	cluster_id         = "%s"
 	hvn_id             = hcp_hvn.test.hvn_id
 	tier               = "development"
 	min_consul_version = data.hcp_consul_versions.test.recommended
@@ -24,7 +24,7 @@ resource "hcp_consul_cluster" "test" {
 
 var updatedConsulCluster = fmt.Sprintf(`
 resource "hcp_consul_cluster" "test" {
-	cluster_id = "%[1]s"
+	cluster_id = "%s"
 	hvn_id     = hcp_hvn.test.hvn_id
 	tier       = "standard"
 	size	   = "small"

--- a/internal/provider/resource_consul_cluster_test.go
+++ b/internal/provider/resource_consul_cluster_test.go
@@ -4,29 +4,32 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-var consulCluster = `
-resource "hcp_consul_cluster" "test" {
-	cluster_id         = "test-consul-cluster"
+var consulClusterUniqueResourceName = fmt.Sprintf("test-%s", time.Now().Format("200601021504"))
+
+var consulCluster = fmt.Sprintf(`
+resource "hcp_consul_cluster" "%[1]s" {
+	cluster_id         = "test-consul-cluster-original"
 	hvn_id             = hcp_hvn.test.hvn_id
 	tier               = "development"
 	min_consul_version = data.hcp_consul_versions.test.recommended
 }
-`
+`, consulClusterUniqueResourceName)
 
-var updatedConsulCluster = `
-resource "hcp_consul_cluster" "test" {
-	cluster_id = "test-consul-cluster"
+var updatedConsulCluster = fmt.Sprintf(`
+resource "hcp_consul_cluster" "%[1]s" {
+	cluster_id = "test-consul-cluster-updated"
 	hvn_id     = hcp_hvn.test.hvn_id
 	tier       = "standard"
 	size	   = "small"
 }
-`
+`, consulClusterUniqueResourceName)
 
 func setTestAccConsulClusterConfig(consulCluster string) string {
 	return fmt.Sprintf(`
@@ -38,24 +41,24 @@ func setTestAccConsulClusterConfig(consulCluster string) string {
 
 	data "hcp_consul_versions" "test" {}
 
-	%s
+	%[1]s
 	
-	data "hcp_consul_cluster" "test" {
-		cluster_id = hcp_consul_cluster.test.cluster_id
+	data "hcp_consul_cluster" "%[2]s" {
+		cluster_id = hcp_consul_cluster.%[2]s.cluster_id
 	}
 	
 	resource "hcp_consul_cluster_root_token" "test" {
-		cluster_id = hcp_consul_cluster.test.cluster_id
+		cluster_id = hcp_consul_cluster.%[2]s.cluster_id
 	}
-`, consulCluster)
+`, consulCluster, consulClusterUniqueResourceName)
 }
 
 // This includes tests against both the resource, the corresponding datasource,
 // and creation of the Consul cluster root token resource in order to shorten
 // testing time.
 func TestAccConsulCluster(t *testing.T) {
-	resourceName := "hcp_consul_cluster.test"
-	dataSourceName := "data.hcp_consul_cluster.test"
+	resourceName := fmt.Sprintf("hcp_consul_cluster.%s", consulClusterUniqueResourceName)
+	dataSourceName := fmt.Sprintf("data.hcp_consul_cluster.%s", consulClusterUniqueResourceName)
 	dataSourceVersionName := "data.hcp_consul_versions.test"
 	rootTokenResourceName := "hcp_consul_cluster_root_token.test"
 
@@ -69,13 +72,13 @@ func TestAccConsulCluster(t *testing.T) {
 				Config: testConfig(setTestAccConsulClusterConfig(consulCluster)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConsulClusterExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-consul-cluster-original"),
 					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
 					resource.TestCheckResourceAttr(resourceName, "tier", "DEVELOPMENT"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),
-					resource.TestCheckResourceAttr(resourceName, "datacenter", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "datacenter", "test-consul-cluster-original"),
 					resource.TestCheckResourceAttr(resourceName, "scale", "1"),
 					resource.TestCheckResourceAttr(resourceName, "consul_snapshot_interval", "24h"),
 					resource.TestCheckResourceAttr(resourceName, "consul_snapshot_retention", "30d"),
@@ -117,13 +120,13 @@ func TestAccConsulCluster(t *testing.T) {
 				Config: testConfig(setTestAccConsulClusterConfig(consulCluster)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConsulClusterExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "test-consul-cluster-original"),
 					resource.TestCheckResourceAttr(resourceName, "hvn_id", "test-hvn"),
 					resource.TestCheckResourceAttr(resourceName, "tier", "DEVELOPMENT"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-2"),
 					resource.TestCheckResourceAttr(resourceName, "public_endpoint", "false"),
-					resource.TestCheckResourceAttr(resourceName, "datacenter", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(resourceName, "datacenter", "test-consul-cluster-original"),
 					resource.TestCheckResourceAttr(resourceName, "scale", "1"),
 					resource.TestCheckResourceAttr(resourceName, "consul_snapshot_interval", "24h"),
 					resource.TestCheckResourceAttr(resourceName, "consul_snapshot_retention", "30d"),
@@ -178,7 +181,7 @@ func TestAccConsulCluster(t *testing.T) {
 			{
 				Config: testConfig(setTestAccConsulClusterConfig(consulCluster)),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(rootTokenResourceName, "cluster_id", "test-consul-cluster"),
+					resource.TestCheckResourceAttr(rootTokenResourceName, "cluster_id", "test-consul-cluster-original"),
 					resource.TestCheckResourceAttrSet(rootTokenResourceName, "accessor_id"),
 					resource.TestCheckResourceAttrSet(rootTokenResourceName, "secret_id"),
 					resource.TestCheckResourceAttrSet(rootTokenResourceName, "kubernetes_secret"),


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description
This change adds unique cluster IDs to prevent reuse of identifiers and cluster name collision on test retries.

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccConsulCluster -timeout 210m
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccConsulCluster
--- PASS: TestAccConsulCluster (1792.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	1793.055s
...
```
