### PR TITLE
[HPR-859] Update resource schema to use a single iteration block

### DIFF
--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -24,7 +24,7 @@ To create, or update an existing, channel with an assigned iteration.
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
-  iteration_assignment {
+  iteration {
     id = "iteration-id"
   }
 }
@@ -33,7 +33,7 @@ resource "hcp_packer_channel" "staging" {
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
-  iteration_assignment {
+  iteration {
     fingerprint = "fingerprint-associated-to-iteration"
   }
 }
@@ -42,7 +42,7 @@ resource "hcp_packer_channel" "staging" {
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
-  iteration_assignment {
+  iteration {
     // incremental_version is the version number assigned to a completed iteration.
     incremental_version = 1
   }
@@ -59,7 +59,7 @@ data "hcp_packer_image_iteration" "latest" {
 resource "hcp_packer_channel" "staging" {
   name        = staging
   bucket_name = alpine
-  iteration_assignment {
+  iteration {
     id = data.hcp_packer_image_iteration.latest.id
   }
 }
@@ -76,7 +76,7 @@ resource "hcp_packer_channel" "staging" {
 
 ### Optional
 
-- `iteration_assignment` (Block List, Max: 1) The iteration assignment information that will be used to assign a completed iteration to the channel. (see [below for nested schema](#nestedblock--iteration_assignment))
+- `iteration` (Block List, Max: 1) The iteration assigned to the channel. (see [below for nested schema](#nestedblock--iteration))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -84,19 +84,18 @@ resource "hcp_packer_channel" "staging" {
 - `author_id` (String) The author of the channel.
 - `created_at` (String) Creation time of this build.
 - `id` (String) The ID of this resource.
-- `iteration` (List of Object) The iteration assigned to the channel. (see [below for nested schema](#nestedatt--iteration))
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `project_id` (String) The ID of the project this HCP Packer registry is located in.
 - `updated_at` (String) The author of the channel.
 
-<a id="nestedblock--iteration_assignment"></a>
-### Nested Schema for `iteration_assignment`
+<a id="nestedblock--iteration"></a>
+### Nested Schema for `iteration`
 
 Optional:
 
-- `fingerprint` (String) The fingerprint of the iteration to assign to the channel.
-- `id` (String) The id of the iteration to assign to the channel.
-- `incremental_version` (Number) The incremental_version of the iteration to assign to the channel.
+- `fingerprint` (String) The fingerprint of the iteration assigned to the channel.
+- `id` (String) The ID of the iteration assigned to the channel.
+- `incremental_version` (Number) The incremental_version of the iteration assigned to the channel.
 
 
 <a id="nestedblock--timeouts"></a>
@@ -108,16 +107,6 @@ Optional:
 - `default` (String)
 - `delete` (String)
 - `update` (String)
-
-
-<a id="nestedatt--iteration"></a>
-### Nested Schema for `iteration`
-
-Read-Only:
-
-- `fingerprint` (String)
-- `id` (String)
-- `incremental_version` (Number)
 
 ## Import
 

--- a/examples/resources/hcp_packer_channel/resource_assignment.tf
+++ b/examples/resources/hcp_packer_channel/resource_assignment.tf
@@ -1,7 +1,7 @@
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
-  iteration_assignment {
+  iteration {
     id = "iteration-id"
   }
 }
@@ -10,7 +10,7 @@ resource "hcp_packer_channel" "staging" {
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
-  iteration_assignment {
+  iteration {
     fingerprint = "fingerprint-associated-to-iteration"
   }
 }
@@ -19,7 +19,7 @@ resource "hcp_packer_channel" "staging" {
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
-  iteration_assignment {
+  iteration {
     // incremental_version is the version number assigned to a completed iteration.
     incremental_version = 1
   }

--- a/examples/resources/hcp_packer_channel/resource_using_latest_channel.tf
+++ b/examples/resources/hcp_packer_channel/resource_using_latest_channel.tf
@@ -6,7 +6,7 @@ data "hcp_packer_image_iteration" "latest" {
 resource "hcp_packer_channel" "staging" {
   name        = staging
   bucket_name = alpine
-  iteration_assignment {
+  iteration {
     id = data.hcp_packer_image_iteration.latest.id
   }
 }

--- a/internal/clients/packer.go
+++ b/internal/clients/packer.go
@@ -48,30 +48,23 @@ func GetIterationFromID(ctx context.Context, client *Client, loc *sharedmodels.H
 	return it.Payload.Iteration, nil
 }
 
-// ChannelIterationAssignment assigns an iteration by its ID, fingerprint, or version to a channel
-type ChannelIterationAssignment struct {
-	IterationID                 string
-	IterationFingerprint        string
-	IterationIncrementalVersion int
-}
-
 // CreateBucketChannel creates a channel on the named bucket.
 func CreateBucketChannel(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, bucketSlug string, channelSlug string,
-	assignment *ChannelIterationAssignment) (*packermodels.HashicorpCloudPackerChannel, error) {
+	iteration *packermodels.HashicorpCloudPackerIteration) (*packermodels.HashicorpCloudPackerChannel, error) {
 	params := packer_service.NewPackerServiceCreateChannelParamsWithContext(ctx)
 	params.LocationOrganizationID = loc.OrganizationID
 	params.LocationProjectID = loc.ProjectID
 	params.BucketSlug = bucketSlug
 	params.Body.Slug = channelSlug
 
-	if assignment != nil {
+	if iteration != nil {
 		switch {
-		case assignment.IterationID != "":
-			params.Body.IterationID = assignment.IterationID
-		case assignment.IterationFingerprint != "":
-			params.Body.Fingerprint = assignment.IterationFingerprint
-		case assignment.IterationIncrementalVersion > 0:
-			params.Body.IncrementalVersion = int32(assignment.IterationIncrementalVersion)
+		case iteration.ID != "":
+			params.Body.IterationID = iteration.ID
+		case iteration.Fingerprint != "":
+			params.Body.Fingerprint = iteration.Fingerprint
+		case iteration.IncrementalVersion > 0:
+			params.Body.IncrementalVersion = iteration.IncrementalVersion
 		}
 	}
 
@@ -86,21 +79,21 @@ func CreateBucketChannel(ctx context.Context, client *Client, loc *sharedmodels.
 
 // UpdateBucketChannel updates the named channel.
 func UpdateBucketChannel(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, bucketSlug string, channelSlug string,
-	assignment *ChannelIterationAssignment) (*packermodels.HashicorpCloudPackerChannel, error) {
+	iteration *packermodels.HashicorpCloudPackerIteration) (*packermodels.HashicorpCloudPackerChannel, error) {
 	params := packer_service.NewPackerServiceUpdateChannelParamsWithContext(ctx)
 	params.LocationOrganizationID = loc.OrganizationID
 	params.LocationProjectID = loc.ProjectID
 	params.BucketSlug = bucketSlug
 	params.Slug = channelSlug
 
-	if assignment != nil {
+	if iteration != nil {
 		switch {
-		case assignment.IterationID != "":
-			params.Body.IterationID = assignment.IterationID
-		case assignment.IterationFingerprint != "":
-			params.Body.Fingerprint = assignment.IterationFingerprint
-		case assignment.IterationIncrementalVersion > 0:
-			params.Body.IncrementalVersion = int32(assignment.IterationIncrementalVersion)
+		case iteration.ID != "":
+			params.Body.IterationID = iteration.ID
+		case iteration.Fingerprint != "":
+			params.Body.Fingerprint = iteration.Fingerprint
+		case iteration.IncrementalVersion > 0:
+			params.Body.IncrementalVersion = iteration.IncrementalVersion
 		}
 	}
 

--- a/internal/provider/resource_packer_channel_test.go
+++ b/internal/provider/resource_packer_channel_test.go
@@ -83,7 +83,6 @@ func TestAccPackerChannel_AssignedIteration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", acctestAlpineBucket),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "iteration_assignment.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.incremental_version"),
 					resource.TestCheckResourceAttr(resourceName, "iteration.0.fingerprint", "channel-assigned-iteration"),
@@ -140,7 +139,8 @@ func TestAccPackerChannel_UpdateAssignedIteration(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", acctestAlpineBucket),
 					resource.TestCheckResourceAttr(resourceName, "name", acctestProductionChannel),
-					resource.TestCheckResourceAttrSet(resourceName, "iteration_assignment.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "iteration.0.fingerprint", "channel-update-it1"),
 				),
 			},
 			{
@@ -159,7 +159,6 @@ func TestAccPackerChannel_UpdateAssignedIteration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", acctestAlpineBucket),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "iteration_assignment.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.incremental_version"),
 					resource.TestCheckResourceAttr(resourceName, "iteration.0.fingerprint", "channel-update-it2"),
@@ -199,10 +198,9 @@ func TestAccPackerChannel_UpdateAssignedIterationWithFingerprint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", acctestAlpineBucket),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "iteration_assignment.0.fingerprint"),
+					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "iteration.0.incremental_version"),
-					resource.TestCheckResourceAttr(resourceName, "iteration.0.fingerprint", fingerprint),
 					resource.TestCheckResourceAttr(resourceName, "name", acctestProductionChannel),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
@@ -228,7 +226,7 @@ var testAccPackerChannelAssignedLatestIteration = func(bucketName, channelName s
 	resource "hcp_packer_channel" "production" {
 		name = %[1]q
 		bucket_name  = %[2]q
-		iteration_assignment {
+		iteration {
 		  id = data.hcp_packer_image_iteration.test.id
 		}
 	}`, channelName, bucketName)
@@ -239,7 +237,7 @@ var testAccPackerChannelIterationFingerprint = func(bucketName, channelName, fin
 	resource "hcp_packer_channel" "production" {
 		bucket_name  = %q
 		name = %q
-		iteration_assignment {
+		iteration {
 		  fingerprint = %q
 		}
 	}`, bucketName, channelName, fingerprint)


### PR DESCRIPTION

<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
The current implementation relies on the use of an extra iteration_assignment block to denote what iteration to assign to a channel. Instead of defining a separate block this change uses the single iteration block to denote the state of a channel. Modifying the iteration block will trigger the respective updates to the state of a channel. Removing the iteration block will remove the assigned iteration from the channel.

Potentially Supersedes #435 
### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccPackerChannel'

...
```
