### PR TITLE
do not fail acceptance test when provider returns a warning

### DIFF
--- a/.changelog/448.txt
+++ b/.changelog/448.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Do not exit acceptance test when provider returns a warning
+```

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -91,7 +91,12 @@ func testAccPreCheck(t *testing.T, requiredCreds map[string]bool) {
 
 		err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 		if err != nil {
-			t.Fatal(err)
+			if err[0].Severity == 1 {
+				// Severity 1 = Warning, which can be ignored during test
+				return
+			}
+
+			t.Fatalf("unexpected error, exiting test: %#v", err)
 		}
 	})
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Quick fix. During the Preconfig step (prior to `plan` or `apply`), the HCP provider checks the HCP status page and returns a warning if there is any degraded performance or outage. The acceptance tests were exiting on any error during the preconfig step, so it was failing on the status page warnings. This PR checks the `Severity` of the returned error (type `Diagnostic`) and allows tests to proceed despite any warnings.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=Packer'

--- PASS: TestAcc_dataSourcePacker (7.36s)
--- PASS: TestAcc_dataSourcePacker_revokedIteration (9.72s)
--- PASS: TestAcc_dataSourcePackerImage (6.20s)
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (8.97s)
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (2.35s)
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (4.64s)
--- PASS: TestAcc_dataSourcePackerIteration (4.27s)
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (9.83s)
--- PASS: TestAccPackerChannel (7.19s)
--- PASS: TestAccPackerChannel_AssignedIteration (6.43s)
--- PASS: TestAccPackerChannel_UpdateAssignedIteration (9.97s)
--- PASS: TestAccPackerChannel_UpdateAssignedIterationWithFingerprint (4.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	82.386s
```
