### PR TITLE
Update Revocation Acceptance test case to clean up on exit

### DIFF
--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -305,7 +305,7 @@ func upsertBuild(t *testing.T, bucketSlug, fingerprint, iterationID string) {
 				},
 				{
 					ImageID: "ami-43",
-					Region:  "us-east-1",
+					Region:  "us-east-2",
 				},
 			},
 			Labels: map[string]string{"test-key": "test-value"},

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -162,18 +162,16 @@ func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
 		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			deleteChannel(t, acctestUbuntuImageBucket, acctestImageChannel, true)
+			deleteIteration(t, acctestUbuntuImageBucket, fingerprint, true)
+			deleteBucket(t, acctestUbuntuImageBucket, true)
+			return nil
+		},
 		Steps: []resource.TestStep{
-			// testing that getting a revoked iteration fails properly
 			{
 				PlanOnly: true,
 				PreConfig: func() {
-					// CheckDestroy doesn't get called when the test fails and doesn't
-					// produce any tf state. In this case we destroy any existing resource
-					// before creating them.
-					deleteChannel(t, acctestUbuntuImageBucket, acctestImageChannel, false)
-					deleteIteration(t, acctestUbuntuImageBucket, fingerprint, false)
-					deleteBucket(t, acctestUbuntuImageBucket, false)
-
 					upsertRegistry(t)
 					upsertBucket(t, acctestUbuntuImageBucket)
 					upsertIteration(t, acctestUbuntuImageBucket, fingerprint)
@@ -192,7 +190,7 @@ func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 				Config: testConfig(testAccPackerImageUbuntuProduction),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "revoke_at", revokeAt.String()),
-					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "cloud_image_id", "error_revoked"),
+					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "cloud_image_id", "ami-42"),
 				),
 			},
 		},


### PR DESCRIPTION
Previously, the revocation acceptance test would error because the data
source was configured to error when querying for a revoked image. That
logic has since been removed, and no longer errors. Instead the
attribute revoked_at is set to a valid revocation date, and the cloud
image id is set to the value stored in HCP Packer. This change updates
the test to reflect the new expected behavior and adds a clean step on
CheckDestroy to ensure no test images are left in the registry under
test.

<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  make testacc TESTARGS='-run=Packer'
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (9.75s)
=== RUN   TestAcc_dataSourcePacker_revokedIteration
--- PASS: TestAcc_dataSourcePacker_revokedIteration (13.88s)
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (7.60s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (11.12s)
=== RUN   TestAcc_dataSourcePackerImage_channelAndIterationIDReject
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (3.76s)
=== RUN   TestAcc_dataSourcePackerImage_channelAccept
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (6.41s)
=== RUN   TestAcc_dataSourcePackerIteration
--- PASS: TestAcc_dataSourcePackerIteration (5.79s)
=== RUN   TestAcc_dataSourcePackerIteration_revokedIteration
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (12.25s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   70.855s

...
```
