### PR TITLE
resource/hcp_packer_channel: Label resource as public beta

### DIFF
--- a/.changelog/457.txt
+++ b/.changelog/457.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+resource/hcp_packer_channel: Label resource as public beta
+```

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -7,6 +7,8 @@ description: |-
 
 # hcp_packer_channel (Resource)
 
+-> **Note:** This resource is currently in public beta.
+
 The Packer Channel resource allows you to manage image bucket channels within an active HCP Packer Registry.
 
 ## Example Usage

--- a/templates/resources/packer_channel.md.tmpl
+++ b/templates/resources/packer_channel.md.tmpl
@@ -7,6 +7,8 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
+-> **Note:** This resource is currently in public beta.
+
 {{ .Description | trimspace }}
 
 ## Example Usage


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

The hcp_packer_channel is being released as a beta to allow for user feedback. This change adds the public beta call out within the resource documentation. 

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests
 
N/A

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
