### PR TITLE
resource/hcp_packer_channel: Fix documentation for incorrectly documented attributes

### DIFF
--- a/.changelog/462.txt
+++ b/.changelog/462.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/hcp_packer_channel: Fix documentation for incorrectly documented attributes
+```

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -73,7 +73,7 @@ resource "hcp_packer_channel" "staging" {
 
 ### Required
 
-- `bucket_name` (String) The slug of the HCP Packer Registry image bucket where the channel should be managed in.
+- `bucket_name` (String) The slug of the HCP Packer Registry image bucket where the channel should be created in.
 - `name` (String) The name of the channel being managed.
 
 ### Optional
@@ -83,12 +83,12 @@ resource "hcp_packer_channel" "staging" {
 
 ### Read-Only
 
-- `author_id` (String) The author of the channel.
-- `created_at` (String) Creation time of this build.
+- `author_id` (String) The author of this channel.
+- `created_at` (String) The creation time of this channel.
 - `id` (String) The ID of this resource.
-- `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
-- `project_id` (String) The ID of the project this HCP Packer registry is located in.
-- `updated_at` (String) The author of the channel.
+- `organization_id` (String) The ID of the HCP organization where this channel is located in.
+- `project_id` (String) The ID of the HCP project where this channel is located in.
+- `updated_at` (String) The time this channel was last updated.
 
 <a id="nestedblock--iteration"></a>
 ### Nested Schema for `iteration`

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -44,7 +44,7 @@ func resourcePackerChannel() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			"bucket_name": {
-				Description:      "The slug of the HCP Packer Registry image bucket where the channel should be managed in.",
+				Description:      "The slug of the HCP Packer Registry image bucket where the channel should be created in.",
 				Type:             schema.TypeString,
 				ForceNew:         true,
 				Required:         true,
@@ -84,27 +84,27 @@ func resourcePackerChannel() *schema.Resource {
 			},
 			// Computed Values
 			"author_id": {
-				Description: "The author of the channel.",
+				Description: "The author of this channel.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"created_at": {
-				Description: "Creation time of this build.",
+				Description: "The creation time of this channel.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"organization_id": {
-				Description: "The ID of the organization this HCP Packer registry is located in.",
+				Description: "The ID of the HCP organization where this channel is located in.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"project_id": {
-				Description: "The ID of the project this HCP Packer registry is located in.",
+				Description: "The ID of the HCP project where this channel is located in.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
 			"updated_at": {
-				Description: "The author of the channel.",
+				Description: "The time this channel was last updated.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
A few of the output attributes were incorrectly documented. This change updates the documentation to reflect the channel resource under management.


### :building_construction: Acceptance tests

N/A - only documentation changes within this pull request.


Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
TF_ACC=1 go test ./internal/... -v -run=TestAcc_*Packer -timeout 210m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.188s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.224s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.275s [no tests to run]
=== RUN   TestAccPackerChannel
--- PASS: TestAccPackerChannel (15.04s)
=== RUN   TestAccPackerChannel_AssignedIteration
--- PASS: TestAccPackerChannel_AssignedIteration (9.55s)
=== RUN   TestAccPackerChannel_UpdateAssignedIteration
--- PASS: TestAccPackerChannel_UpdateAssignedIteration (14.91s)
=== RUN   TestAccPackerChannel_UpdateAssignedIterationWithFingerprint
--- PASS: TestAccPackerChannel_UpdateAssignedIterationWithFingerprint (7.59s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   47.390s
```
