### PR TITLE
HVT-2807 Add cluster scaling tests for Azure

### DIFF
--- a/.changelog/465.txt
+++ b/.changelog/465.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add cluster scaling acceptance tests for Azure
+```

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -51,6 +51,9 @@ func TestAccVaultClusterAzure(t *testing.T) {
 		CloudProvider:              cloudProviderAzure,
 		Region:                     azureRegion,
 		Tier:                       "DEV",
+		UpdateTier1:                "STANDARD_SMALL",
+		UpdateTier2:                "STANDARD_MEDIUM",
+		PublicEndpoint:             "false",
 	}
 	tf := setTestAccVaultClusterConfig(t, vaultCluster, azureTestInput, azureTestInput.Tier)
 	// save so e don't have to generate this again and again
@@ -170,6 +173,7 @@ func azureTestSteps(t *testing.T, inp inputT) []resource.TestStep {
 		importResourcesInTFState(t, in),
 		tfApply(t, in),
 		testTFDataSources(t, in),
+		updateClusterTier(t, in),
 	}
 }
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
 Add cluster scaling tests for Azure

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$  TF_LOG_PATH=scale.out.text TF_LOG=TRACE TF_ACC=1 go test ./internal/... -parallel 20 -v -run=TestAccVaultClusterAzure -timeout 240m
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.436s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.325s [no tests to run]
=== RUN   TestAccVaultClusterAzure
=== PAUSE TestAccVaultClusterAzure
=== CONT  TestAccVaultClusterAzure
--- PASS: TestAccVaultClusterAzure (3479.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	3479.976s
...
```
