### PR TITLE
Add project ID to AWS network peering

### DIFF
--- a/docs/data-sources/aws_network_peering.md
+++ b/docs/data-sources/aws_network_peering.md
@@ -30,6 +30,7 @@ data "hcp_aws_network_peering" "test" {
 
 ### Optional
 
+- `project_id` (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `wait_for_active_state` (Boolean) If `true`, Terraform will wait for the network peering to reach an `ACTIVE` state before continuing. Default `false`.
 
@@ -42,7 +43,6 @@ data "hcp_aws_network_peering" "test" {
 - `peer_account_id` (String) The account ID of the peer VPC in AWS.
 - `peer_vpc_id` (String) The ID of the peer VPC in AWS.
 - `peer_vpc_region` (String) The region of the peer VPC in AWS.
-- `project_id` (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - `provider_peering_id` (String) The peering connection ID used by AWS.
 - `self_link` (String) A unique URL identifying the network peering.
 - `state` (String) The state of the network peering.

--- a/docs/resources/aws_network_peering.md
+++ b/docs/resources/aws_network_peering.md
@@ -66,6 +66,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 
 ### Optional
 
+- `project_id` (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -74,7 +75,6 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 - `expires_at` (String) The time after which the network peering will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.
 - `id` (String) The ID of this resource.
 - `organization_id` (String) The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.
-- `project_id` (String) The ID of the HCP project where the network peering is located. Always matches the HVN's project.
 - `provider_peering_id` (String) The peering connection ID used by AWS.
 - `self_link` (String) A unique URL identifying the network peering.
 - `state` (String) The state of the network peering.

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -13,6 +13,7 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
@@ -70,14 +71,18 @@ func resourceAwsNetworkPeering() *schema.Resource {
 					return strings.EqualFold(old, new)
 				},
 			},
+			// Optional inputs
+			"project_id": {
+				Description:  "The ID of the HCP project where the network peering is located. Always matches the HVN's project.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+				Computed:     true,
+			},
 			// Computed outputs
 			"organization_id": {
 				Description: "The ID of the HCP organization where the network peering is located. Always matches the HVN's organization.",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
-			"project_id": {
-				Description: "The ID of the HCP project where the network peering is located. Always matches the HVN's project.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -126,9 +131,14 @@ func resourceAwsNetworkPeeringCreate(ctx context.Context, d *schema.ResourceData
 	peerVpcID := d.Get("peer_vpc_id").(string)
 	peerVpcRegion := d.Get("peer_vpc_region").(string)
 
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 
 	// Check for an existing HVN


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

This code includes changes to allow associated project ID to be optionally read from either the provider config or AWS network peering's config directly. Primary test coverage for helpers used and changes made were tested using the steps in GH-460 - [Add project ID to HVN](https://github.com/hashicorp/terraform-provider-hcp/pull/460).

Jira 🎟️ :

[Add project_id to AWS peering](https://hashicorp.atlassian.net/jira/software/c/projects/HCE/boards/550?selectedIssue=HCE-778)

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=AwsPeering'    
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=AwsPeering -timeout 210m -parallel=10
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccAwsPeering
--- PASS: TestAccAwsPeering (700.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	701.250s

...
```
