### PR TITLE
HCE-345: Allow Project ID on Terraform Import

### DIFF
--- a/internal/provider/peering.go
+++ b/internal/provider/peering.go
@@ -7,15 +7,13 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
 var peeringDefaultTimeout = time.Minute * 1
 var peeringCreateTimeout = time.Minute * 35
 var peeringDeleteTimeout = time.Minute * 35
 
-func parsePeeringResourceID(resourceID string, client *clients.Client) (projectID, hvnID, peeringID string, err error) {
+func parsePeeringResourceID(resourceID, clientProjectID string) (projectID, hvnID, peeringID string, err error) {
 	idParts := strings.SplitN(resourceID, ":", 3)
 
 	if len(idParts) == 3 { // {project_id}:{hvn_id}:{peering_id}
@@ -23,11 +21,11 @@ func parsePeeringResourceID(resourceID string, client *clients.Client) (projectI
 			return "", "", "", fmt.Errorf("unexpected format of ID (%q), expected {project_id}:{hvn_id}:{peering_id}", resourceID)
 		}
 		return idParts[0], idParts[1], idParts[2], nil
-	} else if len(idParts) == 2 { //{hvn_id}:{peering_id}
+	} else if len(idParts) == 2 { // {hvn_id}:{peering_id}
 		if idParts[0] == "" || idParts[1] == "" {
 			return "", "", "", fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{peering_id}", resourceID)
 		}
-		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		projectID, err = GetProjectID(projectID, clientProjectID)
 		if err != nil {
 			return "", "", "", fmt.Errorf("unable to retrieve project ID: %v", err)
 		}

--- a/internal/provider/peering.go
+++ b/internal/provider/peering.go
@@ -7,16 +7,32 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
 var peeringDefaultTimeout = time.Minute * 1
 var peeringCreateTimeout = time.Minute * 35
 var peeringDeleteTimeout = time.Minute * 35
 
-func parsePeeringResourceID(id string) (hvnID, peeringID string, err error) {
-	idParts := strings.SplitN(id, ":", 2)
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		return "", "", fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{peering_id}", id)
+func parsePeeringResourceID(resourceID string, client *clients.Client) (projectID, hvnID, peeringID string, err error) {
+	idParts := strings.SplitN(resourceID, ":", 3)
+
+	if len(idParts) == 3 { // {project_id}:{hvn_id}:{peering_id}
+		if idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+			return "", "", "", fmt.Errorf("unexpected format of ID (%q), expected {project_id}:{hvn_id}:{peering_id}", resourceID)
+		}
+		return idParts[0], idParts[1], idParts[2], nil
+	} else if len(idParts) == 2 { //{hvn_id}:{peering_id}
+		if idParts[0] == "" || idParts[1] == "" {
+			return "", "", "", fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{peering_id}", resourceID)
+		}
+		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		if err != nil {
+			return "", "", "", fmt.Errorf("unable to retrieve project ID: %v", err)
+		}
+		return projectID, idParts[0], idParts[1], nil
+	} else {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{peering_id} or {project_id}:{hvn_id}:{peering_id}", resourceID)
 	}
-	return idParts[0], idParts[1], nil
 }

--- a/internal/provider/peering_test.go
+++ b/internal/provider/peering_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func Test_parsePeeringResourceID(t *testing.T) {
+	defaultProjectID := "e20ad934-b88a-4897-a58e-d8318dd43cc3"
 	tests := map[string]struct {
 		input             string
 		expectedHvnID     string
 		expectedPeeringID string
+		expectedProjectID string
 		hasErr            bool
 	}{
 		"invalid ID format": {
@@ -38,12 +40,19 @@ func Test_parsePeeringResourceID(t *testing.T) {
 			input:             "my-hvn-id:my-peering-id",
 			expectedHvnID:     "my-hvn-id",
 			expectedPeeringID: "my-peering-id",
+			expectedProjectID: defaultProjectID,
+		},
+		"valid ID format with project ID": {
+			input:             "ca69d5ff-68c1-4b40-b4fe-b0a1fa80382c:my-hvn-id:my-peering-id",
+			expectedHvnID:     "my-hvn-id",
+			expectedPeeringID: "my-peering-id",
+			expectedProjectID: "ca69d5ff-68c1-4b40-b4fe-b0a1fa80382c",
 		},
 	}
 	for n, tc := range tests {
 		t.Run(n, func(*testing.T) {
 			r := require.New(t)
-			hvnID, peeringID, err := parsePeeringResourceID(tc.input)
+			projectID, hvnID, peeringID, err := parsePeeringResourceID(tc.input, defaultProjectID)
 
 			if tc.hasErr {
 				r.Error(err)
@@ -52,6 +61,7 @@ func Test_parsePeeringResourceID(t *testing.T) {
 			}
 			r.Equal(tc.expectedHvnID, hvnID)
 			r.Equal(tc.expectedPeeringID, peeringID)
+			r.Equal(tc.expectedProjectID, projectID)
 
 		})
 	}

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -357,7 +357,7 @@ func resourceAwsNetworkPeeringImport(ctx context.Context, d *schema.ResourceData
 	//   terraform import hcp_aws_network_peering.test {hvn_id}:{peering_id}
 
 	client := meta.(*clients.Client)
-	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client)
+	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client.Config.ProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -353,7 +353,7 @@ func resourceAwsTransitGatewayAttachmentImport(ctx context.Context, d *schema.Re
 		hvnID = idParts[1]
 		tgwAttID = idParts[2]
 		resourceShareArn = idParts[3]
-	} else if len(idParts) == 3 { //{hvn_id}:{transit_gateway_attachment_id}:{resource_share_arn}
+	} else if len(idParts) == 3 { // {hvn_id}:{transit_gateway_attachment_id}:{resource_share_arn}
 		if idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
 			return nil, fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{transit_gateway_attachment_id}:{resource_share_arn}", d.Id())
 		}

--- a/internal/provider/resource_azure_peering_connection.go
+++ b/internal/provider/resource_azure_peering_connection.go
@@ -378,7 +378,7 @@ func resourceAzurePeeringConnectionImport(ctx context.Context, d *schema.Resourc
 	//   terraform import hcp_azure_peering_connection.test {hvn_id}:{peering_id}
 
 	client := meta.(*clients.Client)
-	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client)
+	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client.Config.ProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -257,16 +257,12 @@ func resourceBoundaryClusterImport(ctx context.Context, d *schema.ResourceData, 
 	clusterID := ""
 	var err error
 
-	if strings.Contains(d.Id(), ":") {
+	if strings.Contains(d.Id(), ":") { // {project_id}:{boundary_cluster_id}
 		idParts := strings.SplitN(d.Id(), ":", 2)
-		// Get the Cluster ID from the input
 		clusterID = idParts[1]
-		// Get the Project ID from the input
 		projectID = idParts[0]
-	} else {
-		// Get the Cluster ID from the input
+	} else { // {boundary_cluster_id}
 		clusterID = d.Id()
-		// Get the Project ID from the helper function
 		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -5,7 +5,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	boundarymodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-boundary-service/preview/2021-12-21/models"
@@ -244,11 +246,35 @@ func resourceBoundaryClusterDelete(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceBoundaryClusterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client)
+	// with multi-projects, import arguments must become dynamic:
+	// use explicit project ID with terraform import:
+	//   terraform import hcp_boundary_cluster.test f709ec73-55d4-46d8-897d-816ebba28778:test-boundary-cluster
+	// use default project ID from provider:
+	//   terraform import hcp_boundary_cluster.test test-boundary-cluster
 
-	clusterID := d.Id()
+	client := meta.(*clients.Client)
+	projectID := ""
+	clusterID := ""
+	var err error
+
+	if strings.Contains(d.Id(), ":") {
+		idParts := strings.SplitN(d.Id(), ":", 2)
+		// Get the Cluster ID from the input
+		clusterID = idParts[1]
+		// Get the Project ID from the input
+		projectID = idParts[0]
+	} else {
+		// Get the Cluster ID from the input
+		clusterID = d.Id()
+		// Get the Project ID from the helper function
+		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)
+		}
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		ProjectID: client.Config.ProjectID,
+		ProjectID: projectID,
 	}
 
 	link := newLink(loc, BoundaryClusterResourceType, clusterID)

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -839,16 +839,12 @@ func resourceConsulClusterImport(ctx context.Context, d *schema.ResourceData, me
 	clusterID := ""
 	var err error
 
-	if strings.Contains(d.Id(), ":") {
+	if strings.Contains(d.Id(), ":") { // {project_id}:{consul_cluster_id}
 		idParts := strings.SplitN(d.Id(), ":", 2)
-		// Get the Cluster ID from the input
 		clusterID = idParts[1]
-		// Get the Project ID from the input
 		projectID = idParts[0]
-	} else {
-		// Get the Cluster ID from the input
+	} else { // {consul_cluster_id}
 		clusterID = d.Id()
-		// Get the Project ID from the helper function
 		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -828,11 +828,35 @@ func resourceConsulClusterDelete(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceConsulClusterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client)
+	// with multi-projects, import arguments must become dynamic:
+	// use explicit project ID with terraform import:
+	//   terraform import hcp_consul_cluster.test f709ec73-55d4-46d8-897d-816ebba28778:test-consul-cluster
+	// use default project ID from provider:
+	//   terraform import hcp_consul_cluster.test test-consul-cluster
 
-	clusterID := d.Id()
+	client := meta.(*clients.Client)
+	projectID := ""
+	clusterID := ""
+	var err error
+
+	if strings.Contains(d.Id(), ":") {
+		idParts := strings.SplitN(d.Id(), ":", 2)
+		// Get the Cluster ID from the input
+		clusterID = idParts[1]
+		// Get the Project ID from the input
+		projectID = idParts[0]
+	} else {
+		// Get the Cluster ID from the input
+		clusterID = d.Id()
+		// Get the Project ID from the helper function
+		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)
+		}
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		ProjectID: client.Config.ProjectID,
+		ProjectID: projectID,
 	}
 
 	link := newLink(loc, ConsulClusterResourceType, clusterID)

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -335,16 +335,12 @@ func resourceHvnImport(ctx context.Context, d *schema.ResourceData, meta interfa
 	hvnID := ""
 	var err error
 
-	if strings.Contains(d.Id(), ":") {
+	if strings.Contains(d.Id(), ":") { // {project_id}:{hvn_id}
 		idParts := strings.SplitN(d.Id(), ":", 2)
-		// Get the HVN ID from the input
 		hvnID = idParts[1]
-		// Get the Project ID from the input
 		projectID = idParts[0]
-	} else {
-		// Get the HVN ID from the input
+	} else { // {hvn_id}
 		hvnID = d.Id()
-		// Get the Project ID from the helper function
 		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -269,14 +269,20 @@ func resourceHvnPeeringConnectionDelete(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceHvnPeeringConnectionImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// with multi-projects, import arguments must become dynamic:
+	// use explicit project ID with terraform import:
+	//   terraform import hcp_hvn_peering_connection.test {project_id}:{hvn_id}:{peering_id}
+	// use default project ID from provider:
+	//   terraform import hcp_hvn_peering_connection.test {hvn_id}:{peering_id}
+
 	client := meta.(*clients.Client)
-	hvnID, peeringID, err := parsePeeringResourceID(d.Id())
+	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client)
 	if err != nil {
 		return nil, err
 	}
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		ProjectID: client.Config.ProjectID,
+		ProjectID: projectID,
 	}
 
 	link := newLink(loc, PeeringResourceType, peeringID)

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -276,7 +276,7 @@ func resourceHvnPeeringConnectionImport(ctx context.Context, d *schema.ResourceD
 	//   terraform import hcp_hvn_peering_connection.test {hvn_id}:{peering_id}
 
 	client := meta.(*clients.Client)
-	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client)
+	projectID, hvnID, peeringID, err := parsePeeringResourceID(d.Id(), client.Config.ProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -323,7 +323,7 @@ func resourceHVNRouteImport(ctx context.Context, d *schema.ResourceData, meta in
 		projectID = idParts[0]
 		hvnID = idParts[1]
 		routeID = idParts[2]
-	} else if len(idParts) == 2 { //{hvn_id}:{hvn_route_id}
+	} else if len(idParts) == 2 { // {hvn_id}:{hvn_route_id}
 		if idParts[0] == "" || idParts[1] == "" {
 			return nil, fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{hvn_route_id}", d.Id())
 		}

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -298,8 +298,16 @@ func setHVNRouteResourceData(d *schema.ResourceData, route *networkmodels.Hashic
 // resourceHVNRouteImport implements the logic necessary to import an
 // un-tracked (by Terraform) HVN route resource into Terraform state.
 func resourceHVNRouteImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client)
+	// with multi-projects, import arguments must become dynamic:
+	// use explicit project ID with terraform import:
+	//   terraform import hcp_hvn_route.test {project_id}:{hvn_id}:{hvn_route_id}
+	// use default project ID from provider:
+	//   terraform import hcp_hvn_route.test {hvn_id}:{hvn_route_id}
 
+	client := meta.(*clients.Client)
+	projectID := ""
+	hvnID := ""
+	routeID := ""
 	var err error
 	// Updates the source channel to include data about the module used.
 	client, err = client.UpdateSourceChannel(d)
@@ -307,14 +315,30 @@ func resourceHVNRouteImport(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[DEBUG] Failed to update analytics with module name (%s)", err)
 	}
 
-	idParts := strings.SplitN(d.Id(), ":", 2)
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		return nil, fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{hvn_route_id}", d.Id())
+	idParts := strings.SplitN(d.Id(), ":", 3)
+	if len(idParts) == 3 { // {project_id}:{hvn_id}:{hvn_route_id}
+		if idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+			return nil, fmt.Errorf("unexpected format of ID (%q), expected {project_id}:{hvn_id}:{hvn_route_id}", d.Id())
+		}
+		projectID = idParts[0]
+		hvnID = idParts[1]
+		routeID = idParts[2]
+	} else if len(idParts) == 2 { //{hvn_id}:{hvn_route_id}
+		if idParts[0] == "" || idParts[1] == "" {
+			return nil, fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{hvn_route_id}", d.Id())
+		}
+		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)
+		}
+		hvnID = idParts[0]
+		routeID = idParts[1]
+	} else {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected {hvn_id}:{hvn_route_id} or {project_id}:{hvn_id}:{hvn_route_id}", d.Id())
 	}
-	hvnID := idParts[0]
-	routeID := idParts[1]
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		ProjectID: client.Config.ProjectID,
+		ProjectID: projectID,
 	}
 
 	routeLink := newLink(loc, HVNRouteResourceType, routeID)

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -294,7 +294,7 @@ func resourcePackerChannelImport(ctx context.Context, d *schema.ResourceData, me
 		projectID = idParts[0]
 		bucketName = idParts[1]
 		channelName = idParts[2]
-	} else if len(idParts) == 2 { //{bucket_name}:{channel_name}
+	} else if len(idParts) == 2 { // {bucket_name}:{channel_name}
 		if idParts[0] == "" || idParts[1] == "" {
 			return nil, fmt.Errorf("unexpected format of ID (%q), expected {bucket_name}:{channel_name}", d.Id())
 		}

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -269,8 +269,16 @@ func resourcePackerChannelDelete(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourcePackerChannelImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client)
+	// with multi-projects, import arguments must become dynamic:
+	// use explicit project ID with terraform import:
+	//   terraform import hcp_packer_channel.test {project_id}:{bucket_name}:{channel_name}
+	// use default project ID from provider:
+	//   terraform import hcp_packer_channel.test {bucket_name}:{channel_name}
 
+	client := meta.(*clients.Client)
+	bucketName := ""
+	channelName := ""
+	projectID := ""
 	var err error
 	// Updates the source channel to include data about the module used.
 	client, err = client.UpdateSourceChannel(d)
@@ -278,17 +286,31 @@ func resourcePackerChannelImport(ctx context.Context, d *schema.ResourceData, me
 		log.Printf("[DEBUG] Failed to update analytics with module name (%s)", err)
 	}
 
-	idParts := strings.SplitN(d.Id(), ":", 2)
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		return nil, fmt.Errorf("unexpected format of ID (%q), expected {bucket_name}:{channel_name}", d.Id())
+	idParts := strings.SplitN(d.Id(), ":", 3)
+	if len(idParts) == 3 { // {project_id}:{bucket_name}:{channel_name}
+		if idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+			return nil, fmt.Errorf("unexpected format of ID (%q), expected {project_id}:{bucket_name}:{channel_name}", d.Id())
+		}
+		projectID = idParts[0]
+		bucketName = idParts[1]
+		channelName = idParts[2]
+	} else if len(idParts) == 2 { //{bucket_name}:{channel_name}
+		if idParts[0] == "" || idParts[1] == "" {
+			return nil, fmt.Errorf("unexpected format of ID (%q), expected {bucket_name}:{channel_name}", d.Id())
+		}
+		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)
+		}
+		bucketName = idParts[0]
+		channelName = idParts[1]
+	} else {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected {bucket_name}:{channel_name} or {project_id}:{bucket_name}:{channel_name}", d.Id())
 	}
-
-	bucketName := idParts[0]
-	channelName := idParts[1]
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 	if err := setLocationData(d, loc); err != nil {
 		return nil, err

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -1067,11 +1067,35 @@ func flattenMajorVersionUpgradeConfig(config *vaultmodels.HashicorpCloudVault202
 }
 
 func resourceVaultClusterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client)
+	// with multi-projects, import arguments must become dynamic:
+	// use explicit project ID with terraform import:
+	//   terraform import hcp_vault_cluster.test f709ec73-55d4-46d8-897d-816ebba28778:test-vault-cluster
+	// use default project ID from provider:
+	//   terraform import hcp_vault_cluster.test test-vault-cluster
 
-	clusterID := d.Id()
+	client := meta.(*clients.Client)
+	projectID := ""
+	clusterID := ""
+	var err error
+
+	if strings.Contains(d.Id(), ":") {
+		idParts := strings.SplitN(d.Id(), ":", 2)
+		// Get the Cluster ID from the input
+		clusterID = idParts[1]
+		// Get the Project ID from the input
+		projectID = idParts[0]
+	} else {
+		// Get the Cluster ID from the input
+		clusterID = d.Id()
+		// Get the Project ID from the helper function
+		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)
+		}
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		ProjectID: client.Config.ProjectID,
+		ProjectID: projectID,
 	}
 
 	link := newLink(loc, VaultClusterResourceType, clusterID)

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -1078,16 +1078,12 @@ func resourceVaultClusterImport(ctx context.Context, d *schema.ResourceData, met
 	clusterID := ""
 	var err error
 
-	if strings.Contains(d.Id(), ":") {
+	if strings.Contains(d.Id(), ":") { // {project_id}:{vault_cluster_id}
 		idParts := strings.SplitN(d.Id(), ":", 2)
-		// Get the Cluster ID from the input
 		clusterID = idParts[1]
-		// Get the Project ID from the input
 		projectID = idParts[0]
-	} else {
-		// Get the Cluster ID from the input
+	} else { // {vault_cluster_id}
 		clusterID = d.Id()
-		// Get the Project ID from the helper function
 		projectID, err = GetProjectID(projectID, client.Config.ProjectID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve project ID: %v", err)


### PR DESCRIPTION
### :hammer_and_wrench: Description

Allow Project IDs to be explicitly set when importing resources.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsHvnOnly'
--- PASS: TestAccAwsHvnOnly (139.13s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   139.477s
...
```
