### PR TITLE
HCP Boundary maintenance window config

### DIFF
--- a/.changelog/500.txt
+++ b/.changelog/500.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Adds `maintenenace_window_config` to the `hcp_boundary_cluster` resource to manage the timeframe for cluster upgrades.
+```

--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -51,9 +51,9 @@ Optional:
 
 Read-Only:
 
-- `maintenance_window_day` (String)
-- `maintenance_window_end` (Number)
-- `maintenance_window_start` (Number)
+- `day` (String)
+- `end` (Number)
+- `start` (Number)
 - `upgrade_type` (String)
 
 

--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -35,6 +35,7 @@ data "hcp_boundary_cluster" "example" {
 - `cluster_url` (String) A unique URL identifying the Boundary cluster.
 - `created_at` (String) The time that the Boundary cluster was created.
 - `id` (String) The ID of this resource.
+- `maintenance_window_config` (List of Object) (see [below for nested schema](#nestedatt--maintenance_window_config))
 - `state` (String) The state of the Boundary cluster.
 
 <a id="nestedblock--timeouts"></a>
@@ -43,5 +44,16 @@ data "hcp_boundary_cluster" "example" {
 Optional:
 
 - `default` (String)
+
+
+<a id="nestedatt--maintenance_window_config"></a>
+### Nested Schema for `maintenance_window_config`
+
+Read-Only:
+
+- `maintenance_window_day` (String)
+- `maintenance_window_end` (Number)
+- `maintenance_window_start` (Number)
+- `upgrade_type` (String)
 
 

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -17,6 +17,12 @@ resource "hcp_boundary_cluster" "example" {
   cluster_id = "boundary-cluster"
   username   = "test-user"
   password   = "Password123!"
+  maintenance_window_config {
+    maintenance_window_day   = "TUESDAY"
+    maintenance_window_start = 2
+    maintenance_window_end   = 12
+    upgrade_type             = "SCHEDULED"
+  }
 }
 ```
 
@@ -32,6 +38,7 @@ resource "hcp_boundary_cluster" "example" {
 ### Optional
 
 - `project_id` (String) The ID of the HCP project where the Boundary cluster is located.
+- `maintenance_window_config` (Block List, Max: 1) The maintenance window configuration for when cluster upgrades can take place. (see [below for nested schema](#nestedblock--maintenance_window_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -40,6 +47,17 @@ resource "hcp_boundary_cluster" "example" {
 - `created_at` (String) The time that the Boundary cluster was created.
 - `id` (String) The ID of this resource.
 - `state` (String) The state of the Boundary cluster.
+
+<a id="nestedblock--maintenance_window_config"></a>
+### Nested Schema for `maintenance_window_config`
+
+Optional:
+
+- `maintenance_window_day` (String) The maintenance day of the week for scheduled upgrades. Valid options for maintenance window day - `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY`, `SATURDAY`, `SUNDAY`
+- `maintenance_window_end` (Number) The end time which upgrades can be performed. Valid options for maintenance_window_end - 0 to 23 (inclusive)
+- `maintenance_window_start` (Number) The start time which upgrades can be performed. Valid options for maintenance_window_start - 0 to 23 (inclusive)
+- `upgrade_type` (String) The upgrade type for the cluster. Valid options for upgrade type - `AUTOMATIC`, `SCHEDULED`
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -18,10 +18,10 @@ resource "hcp_boundary_cluster" "example" {
   username   = "test-user"
   password   = "Password123!"
   maintenance_window_config {
-    maintenance_window_day   = "TUESDAY"
-    maintenance_window_start = 2
-    maintenance_window_end   = 12
-    upgrade_type             = "SCHEDULED"
+    day          = "TUESDAY"
+    start        = 2
+    end          = 12
+    upgrade_type = "SCHEDULED"
   }
 }
 ```
@@ -37,8 +37,8 @@ resource "hcp_boundary_cluster" "example" {
 
 ### Optional
 
-- `project_id` (String) The ID of the HCP project where the Boundary cluster is located.
 - `maintenance_window_config` (Block List, Max: 1) The maintenance window configuration for when cluster upgrades can take place. (see [below for nested schema](#nestedblock--maintenance_window_config))
+- `project_id` (String) The ID of the HCP project where the Boundary cluster is located.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -53,9 +53,9 @@ resource "hcp_boundary_cluster" "example" {
 
 Optional:
 
-- `maintenance_window_day` (String) The maintenance day of the week for scheduled upgrades. Valid options for maintenance window day - `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY`, `SATURDAY`, `SUNDAY`
-- `maintenance_window_end` (Number) The end time which upgrades can be performed. Valid options for maintenance_window_end - 0 to 23 (inclusive)
-- `maintenance_window_start` (Number) The start time which upgrades can be performed. Valid options for maintenance_window_start - 0 to 23 (inclusive)
+- `day` (String) The maintenance day of the week for scheduled upgrades. Valid options for maintenance window day - `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY`, `SATURDAY`, `SUNDAY`
+- `end` (Number) The end time which upgrades can be performed. Valid options for end - 0 to 24 (inclusive)
+- `start` (Number) The start time which upgrades can be performed. Valid options for start - 0 to 24 (inclusive)
 - `upgrade_type` (String) The upgrade type for the cluster. Valid options for upgrade type - `AUTOMATIC`, `SCHEDULED`
 
 

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -54,8 +54,8 @@ resource "hcp_boundary_cluster" "example" {
 Optional:
 
 - `day` (String) The maintenance day of the week for scheduled upgrades. Valid options for maintenance window day - `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY`, `SATURDAY`, `SUNDAY`
-- `end` (Number) The end time which upgrades can be performed. Valid options for end - 0 to 24 (inclusive)
-- `start` (Number) The start time which upgrades can be performed. Valid options for start - 0 to 24 (inclusive)
+- `end` (Number) The end time which upgrades can be performed. Uses 24H clock. Valid options include - 1 to 24 (inclusive)
+- `start` (Number) The start time which upgrades can be performed. Uses 24H clock. Valid options include - 0 to 23 (inclusive)
 - `upgrade_type` (String) The upgrade type for the cluster. Valid options for upgrade type - `AUTOMATIC`, `SCHEDULED`
 
 

--- a/examples/resources/hcp_boundary_cluster/resource.tf
+++ b/examples/resources/hcp_boundary_cluster/resource.tf
@@ -2,4 +2,10 @@ resource "hcp_boundary_cluster" "example" {
   cluster_id = "boundary-cluster"
   username   = "test-user"
   password   = "Password123!"
+  maintenance_window_config {
+    day          = "TUESDAY"
+    start        = 2
+    end          = 12
+    upgrade_type = "SCHEDULED"
+  }
 }

--- a/internal/clients/boundary_cluster.go
+++ b/internal/clients/boundary_cluster.go
@@ -67,3 +67,50 @@ func DeleteBoundaryCluster(ctx context.Context, client *Client, loc *sharedmodel
 
 	return deleteResp.Payload, nil
 }
+
+// SetBoundaryClusterMaintenanceWindow updates the maintenance window configuration for a Boundary cluster.
+func SetBoundaryClusterMaintenanceWindow(
+	ctx context.Context,
+	client *Client,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	boundaryClusterID string,
+	mwUpdateRequest *boundarymodels.HashicorpCloudBoundary20211221MaintenanceWindowUpdateRequest,
+) (*boundarymodels.HashicorpCloudBoundary20211221MaintenanceWindowUpdateResponse, error) {
+
+	params := boundary_service.NewMaintenanceWindowUpdateParams()
+	params.Context = ctx
+	params.Body = mwUpdateRequest
+
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+	params.ClusterID = boundaryClusterID
+
+	resp, err := client.Boundary.MaintenanceWindowUpdate(params, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload, nil
+}
+
+// GetBoundaryClusterMaintenanceWindow gets the maintenance window configuration for a Boundary cluster.
+func GetBoundaryClusterMaintenanceWindow(
+	ctx context.Context,
+	client *Client,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	boundaryClusterID string,
+) (*boundarymodels.HashicorpCloudBoundary20211221UpgradeType, *boundarymodels.HashicorpCloudBoundary20211221MaintenanceWindow, error) {
+
+	params := boundary_service.NewMaintenanceWindowGetParams()
+	params.Context = ctx
+	params.ClusterID = boundaryClusterID
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+
+	resp, err := client.Boundary.MaintenanceWindowGet(params, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return resp.Payload.UpgradeType, resp.Payload.MaintenanceWindow, nil
+}

--- a/internal/provider/data_source_boundary_cluster.go
+++ b/internal/provider/data_source_boundary_cluster.go
@@ -53,6 +53,34 @@ func dataSourceBoundaryCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"maintenance_window_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"upgrade_type": {
+							Description: "The upgrade type for the cluster",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"day": {
+							Description: "The day of the week for scheduled updates",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"start": {
+							Description: "The start time for the maintenance window",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
+						"end": {
+							Description: "The end time for the maintenance window",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -89,8 +117,13 @@ func dataSourceBoundaryClusterRead(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(url)
 
+	clusterUpgradeType, clusterMW, err := clients.GetBoundaryClusterMaintenanceWindow(ctx, client, loc, clusterID)
+	if err != nil {
+		return diag.Errorf("unable to fetch maintenenace window Boundary cluster (%s): %v", clusterID, err)
+	}
+
 	// cluster found, update resource data
-	if err := setBoundaryClusterResourceData(d, cluster); err != nil {
+	if err := setBoundaryClusterResourceData(d, cluster, clusterUpgradeType, clusterMW); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -507,11 +507,11 @@ func getBoundaryClusterMaintainanceWindowConfig(d *schema.ResourceData) (*bounda
 		mwDayElem = boundaryClusterDayOfWeekPrefix + mwDayElem
 	}
 	mwDay := boundarymodels.HashicorpCloudBoundary20211221MaintenanceWindowDayOfWeek(mwDayElem)
-	mwStart := mwConfigElems["start"].(int32)
-	mwEnd := mwConfigElems["end"].(int32)
+	mwStart := mwConfigElems["start"].(int)
+	mwEnd := mwConfigElems["end"].(int)
 	maintenanceWindow.DayOfWeek = &mwDay
-	maintenanceWindow.Start = mwStart
-	maintenanceWindow.End = mwEnd
+	maintenanceWindow.Start = int32(mwStart)
+	maintenanceWindow.End = int32(mwEnd)
 
 	if upgradeType == boundarymodels.HashicorpCloudBoundary20211221UpgradeTypeUPGRADETYPESCHEDULED {
 		if mwDay == "" {

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -126,7 +126,7 @@ func resourceBoundaryCluster() *schema.Resource {
 							RequiredWith: []string{"maintenance_window_config.0.start"},
 						},
 						"start": {
-							Description:  "The start time which upgrades can be performed. Valid options for start - 0 to 24 (inclusive)",
+							Description:  "The start time which upgrades can be performed. Uses 24H clock. Valid options include - 0 to 23 (inclusive)",
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 23),
@@ -136,10 +136,10 @@ func resourceBoundaryCluster() *schema.Resource {
 							RequiredWith: []string{"maintenance_window_config.0.day"},
 						},
 						"end": {
-							Description:  "The end time which upgrades can be performed. Valid options for end - 0 to 24 (inclusive)",
+							Description:  "The end time which upgrades can be performed. Uses 24H clock. Valid options include - 1 to 24 (inclusive)",
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 23),
+							ValidateFunc: validation.IntBetween(1, 24),
 							DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
 								return strings.EqualFold(old, new)
 							},

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -327,9 +327,9 @@ func resourceVaultClusterCreate(ctx context.Context, d *schema.ResourceData, met
 	if diagErr != nil {
 		return diagErr
 	}
-	mvuConfig, error := getMajorVersionUpgradeConfig(d)
+	mvuConfig, diagErr := getMajorVersionUpgradeConfig(d)
 	if diagErr != nil {
-		return error
+		return diagErr
 	}
 
 	// Use the hvn to get provider and region.


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Extends the HCP Boundary cluster resource to support maintenance window configuration. The maintenance window configuration sets the period when cluster upgrades to take place.

HCP Boundary admins can configure either `automatic` or `scheduled` upgrade type. `Scheduled` are customer specified and require a day of the week, start and end hours.

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-hcp git:(uruemu/ICU-8995) ✗ make testacc TESTARGS='-run=TestAccBoundaryCluster'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccBoundaryCluster -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccBoundaryCluster
--- PASS: TestAccBoundaryCluster (138.21s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   138.574s

...
```
