### PR TITLE
Update hcp sdk

### DIFF
--- a/.changelog/510.txt
+++ b/.changelog/510.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update `hcp-sdk-go`
+```

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcp-sdk-go v0.37.0
+	github.com/hashicorp/hcp-sdk-go v0.45.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/stretchr/testify v1.8.2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcp-sdk-go v0.45.0
+	github.com/hashicorp/hcp-sdk-go v0.46.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/hashicorp/hcl/v2 v2.16.1 h1:BwuxEMD/tsYgbhIW7UuI3crjovf3MzuFWiVgiv57i
 github.com/hashicorp/hcl/v2 v2.16.1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/hcp-sdk-go v0.45.0 h1:1E6d5Kay0A8iI/PnZX1ixT+5wgyKmMZk9NIhN8C5/9s=
 github.com/hashicorp/hcp-sdk-go v0.45.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
+github.com/hashicorp/hcp-sdk-go v0.46.0 h1:LXKVJDb7QNoqMJt5/sLZwv1Wd4o1dVP3E9K30Sk0nks=
+github.com/hashicorp/hcp-sdk-go v0.46.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/hashicorp/hc-install v0.5.0 h1:D9bl4KayIYKEeJ4vUDe9L5huqxZXczKaykSRcm
 github.com/hashicorp/hc-install v0.5.0/go.mod h1:JyzMfbzfSBSjoDCRPna1vi/24BEDxFaCPfdHtM5SCdo=
 github.com/hashicorp/hcl/v2 v2.16.1 h1:BwuxEMD/tsYgbhIW7UuI3crjovf3MzuFWiVgiv57iHg=
 github.com/hashicorp/hcl/v2 v2.16.1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
-github.com/hashicorp/hcp-sdk-go v0.37.0 h1:CP2sdNMksK/Xf6EqSF6FDYdA2JVmlJjq4snuFWlC3DE=
-github.com/hashicorp/hcp-sdk-go v0.37.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
+github.com/hashicorp/hcp-sdk-go v0.45.0 h1:1E6d5Kay0A8iI/PnZX1ixT+5wgyKmMZk9NIhN8C5/9s=
+github.com/hashicorp/hcp-sdk-go v0.45.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjlaclkx3eErU=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,6 @@ github.com/hashicorp/hc-install v0.5.0 h1:D9bl4KayIYKEeJ4vUDe9L5huqxZXczKaykSRcm
 github.com/hashicorp/hc-install v0.5.0/go.mod h1:JyzMfbzfSBSjoDCRPna1vi/24BEDxFaCPfdHtM5SCdo=
 github.com/hashicorp/hcl/v2 v2.16.1 h1:BwuxEMD/tsYgbhIW7UuI3crjovf3MzuFWiVgiv57iHg=
 github.com/hashicorp/hcl/v2 v2.16.1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
-github.com/hashicorp/hcp-sdk-go v0.45.0 h1:1E6d5Kay0A8iI/PnZX1ixT+5wgyKmMZk9NIhN8C5/9s=
-github.com/hashicorp/hcp-sdk-go v0.45.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
 github.com/hashicorp/hcp-sdk-go v0.46.0 h1:LXKVJDb7QNoqMJt5/sLZwv1Wd4o1dVP3E9K30Sk0nks=
 github.com/hashicorp/hcp-sdk-go v0.46.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -126,12 +126,16 @@ func UpdateVaultClusterPublicIps(ctx context.Context, client *Client, loc *share
 func UpdateVaultMajorVersionUpgradeConfig(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string,
 	config *vaultmodels.HashicorpCloudVault20201125MajorVersionUpgradeConfig) (vaultmodels.HashicorpCloudVault20201125UpdateMajorVersionUpgradeConfigResponse, error) {
 
+	region := &sharedmodels.HashicorpCloudLocationRegion{}
+	if loc.Region != nil {
+		region = loc.Region
+	}
 	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
 		OrganizationID: loc.OrganizationID,
 		ProjectID:      loc.ProjectID,
 		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
-			Provider: loc.Region.Provider,
-			Region:   loc.Region.Region,
+			Provider: region.Provider,
+			Region:   region.Region,
 		},
 	}
 	request := &vaultmodels.HashicorpCloudVault20201125UpdateMajorVersionUpgradeConfigRequest{

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -93,6 +93,14 @@ func CreateVaultClusterAdminToken(ctx context.Context, client *Client, loc *shar
 func UpdateVaultClusterPublicIps(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	clusterID string, enablePublicIps bool) (*vaultmodels.HashicorpCloudVault20201125UpdatePublicIpsResponse, error) {
 
+	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
+		OrganizationID: loc.OrganizationID,
+		ProjectID:      loc.ProjectID,
+		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
+			Provider: loc.Region.Provider,
+			Region:   loc.Region.Region,
+		},
+	}
 	updateParams := vault_service.NewUpdatePublicIpsParams()
 	updateParams.Context = ctx
 	updateParams.ClusterID = clusterID
@@ -102,7 +110,7 @@ func UpdateVaultClusterPublicIps(ctx context.Context, client *Client, loc *share
 		// ClusterID and Location are repeated because the values above are required to populate the URL,
 		// and the values below are required in the API request body
 		ClusterID:       clusterID,
-		Location:        loc,
+		Location:        locInternal,
 		EnablePublicIps: enablePublicIps,
 	}
 
@@ -118,11 +126,19 @@ func UpdateVaultClusterPublicIps(ctx context.Context, client *Client, loc *share
 func UpdateVaultMajorVersionUpgradeConfig(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string,
 	config *vaultmodels.HashicorpCloudVault20201125MajorVersionUpgradeConfig) (vaultmodels.HashicorpCloudVault20201125UpdateMajorVersionUpgradeConfigResponse, error) {
 
+	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
+		OrganizationID: loc.OrganizationID,
+		ProjectID:      loc.ProjectID,
+		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
+			Provider: loc.Region.Provider,
+			Region:   loc.Region.Region,
+		},
+	}
 	request := &vaultmodels.HashicorpCloudVault20201125UpdateMajorVersionUpgradeConfigRequest{
 		// ClusterID and Location are repeated because the values above are required to populate the URL,
 		// and the values below are required in the API request body
 		ClusterID:   clusterID,
-		Location:    loc,
+		Location:    locInternal,
 		UpgradeType: config.UpgradeType,
 	}
 	if config.MaintenanceWindow != nil {
@@ -167,6 +183,14 @@ func UpdateVaultClusterConfig(ctx context.Context, client *Client, loc *sharedmo
 		config.AuditLogExportConfig = auditLog
 		updateMaskPaths = append(updateMaskPaths, "config.audit_log_export_config")
 	}
+	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
+		OrganizationID: loc.OrganizationID,
+		ProjectID:      loc.ProjectID,
+		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
+			Provider: loc.Region.Provider,
+			Region:   loc.Region.Region,
+		},
+	}
 	updateParams := vault_service.NewUpdateParams()
 	updateParams.Context = ctx
 	updateParams.ClusterID = clusterID
@@ -177,7 +201,7 @@ func UpdateVaultClusterConfig(ctx context.Context, client *Client, loc *sharedmo
 		// ClusterID and Location are repeated because the values above are required to populate the URL,
 		// and the values below are required in the API request body
 		ID:       clusterID,
-		Location: loc,
+		Location: locInternal,
 		// NOTE: if this function is ever modified to update more than just the tier,
 		// the tier must ALWAYS be specified, since the 0-value is valid and will not
 		// be ignored.
@@ -196,6 +220,14 @@ func UpdateVaultClusterConfig(ctx context.Context, client *Client, loc *sharedmo
 func UpdateVaultPathsFilter(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
 	clusterID string, params vaultmodels.HashicorpCloudVault20201125ClusterPerformanceReplicationPathsFilter) (*vaultmodels.HashicorpCloudVault20201125UpdatePathsFilterResponse, error) {
 
+	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
+		OrganizationID: loc.OrganizationID,
+		ProjectID:      loc.ProjectID,
+		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
+			Provider: loc.Region.Provider,
+			Region:   loc.Region.Region,
+		},
+	}
 	updateParams := vault_service.NewUpdatePathsFilterParams()
 	updateParams.Context = ctx
 	updateParams.ClusterID = clusterID
@@ -205,7 +237,7 @@ func UpdateVaultPathsFilter(ctx context.Context, client *Client, loc *sharedmode
 		// ClusterID and Location are repeated because the values above are required to populate the URL,
 		// and the values below are required in the API request body
 		ClusterID: clusterID,
-		Location:  loc,
+		Location:  locInternal,
 		Mode:      params.Mode,
 		Paths:     params.Paths,
 	}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Update `hcp-go-sdk` to the latest version. Found breaking change with the vault API and applied client side updates to remediate the issues.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-hcp git:(update-hcp-sdk) ✗ make testacc TESTARGS='-run=TestAccVaultClusterAWS'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultClusterAWS -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccVaultClusterAWS
=== PAUSE TestAccVaultClusterAWS
=== CONT  TestAccVaultClusterAWS
--- PASS: TestAccVaultClusterAWS (3372.04s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   3373.094s
➜  terraform-provider-hcp git:(update-hcp-sdk) ✗ make testacc TESTARGS='-run=TestAccVaultClusterAzure'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultClusterAzure -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccVaultClusterAzure
=== PAUSE TestAccVaultClusterAzure
=== CONT  TestAccVaultClusterAzure
--- PASS: TestAccVaultClusterAzure (3470.10s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   3471.011s
➜  terraform-provider-hcp git:(update-hcp-sdk) ✗ 
```
