### PR TITLE
[HPR-1139] Remove beta label from HCP Packer channel resource

### DIFF
--- a/.changelog/513.txt
+++ b/.changelog/513.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+HCP Packer Channel Resource is no longer in beta
+```

--- a/.changelog/513.txt
+++ b/.changelog/513.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-HCP Packer Channel Resource is no longer in beta
+Documentation: HCP Packer Channel Resource is no longer in beta
 ```

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_packer_channel (Resource)
 
--> **Note:** This resource is currently in public beta.
-
 The Packer Channel resource allows you to manage image bucket channels within an active HCP Packer Registry.
 
 ## Example Usage

--- a/templates/resources/packer_channel.md.tmpl
+++ b/templates/resources/packer_channel.md.tmpl
@@ -7,8 +7,6 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** This resource is currently in public beta.
-
 {{ .Description | trimspace }}
 
 ## Example Usage


### PR DESCRIPTION
### :hammer_and_wrench: Description

This resource is no longer in beta

### :building_construction: Acceptance tests

I did not run acceptance tests on this change since it is only a docs change