### PR TITLE
IFACE-1880: Enable RFC 6598 CIDR Range for HVN Route

### DIFF
--- a/.changelog/515.txt
+++ b/.changelog/515.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Update HVN Route validation for `destination_cidr` attribute to allow RFC6598 CIDR range.
+```

--- a/docs/resources/hvn_route.md
+++ b/docs/resources/hvn_route.md
@@ -12,6 +12,9 @@ Please pin to the previous version to avoid disruption until you are ready to mi
 
 The HVN route resource allows you to manage an HVN route.
 
+-> **Note:** The `destination_cidr` value must be an IPv4 CIDR block within the [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918) private address space (10.*.*.*, 192.168.*.*, 172.[16-31].*.*) **or**
+the [RFC6598](https://datatracker.ietf.org/doc/html/rfc6598) shared address space (100.64.*.*).
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/hvn_route.md
+++ b/docs/resources/hvn_route.md
@@ -10,10 +10,10 @@ description: |-
 ~> **Migration Required:** The release of HVN Routes in v0.7.0 includes breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
 Please pin to the previous version to avoid disruption until you are ready to migrate.
 
-The HVN route resource allows you to manage an HVN route.
-
 -> **Note:** The `destination_cidr` value must be an IPv4 CIDR block within the [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918) private address space (10.*.*.*, 192.168.*.*, 172.[16-31].*.*) **or**
 the [RFC6598](https://datatracker.ietf.org/doc/html/rfc6598) shared address space (100.64.*.*).
+
+The HVN route resource allows you to manage an HVN route.
 
 ## Example Usage
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -80,7 +80,7 @@ func resourceHvn() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validateCIDRBlock,
+				ValidateDiagFunc: validateCIDRBlockHVN,
 				Computed:         true,
 			},
 			"project_id": {

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -59,7 +59,7 @@ func resourceHvnRoute() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: validateCIDRBlock,
+				ValidateDiagFunc: validateCIDRBlockHVNRoute,
 			},
 			"target_link": {
 				Description: "A unique URL identifying the target of the HVN route. Examples of the target: [`aws_network_peering`](aws_network_peering.md), [`aws_transit_gateway_attachment`](aws_transit_gateway_attachment.md)",

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -536,257 +536,274 @@ func Test_validateVaultPathsFilter(t *testing.T) {
 }
 
 func Test_validateCIDRBlock(t *testing.T) {
-	tcs := map[string]struct {
+	type testCase struct {
 		input    string
 		networks []net.IPNet
 		expected diag.Diagnostics
-	}{
-		"blank input string": {
-			input: "",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid cidr notation": {
-			input: "192.168.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid characters": {
-			input: "someString",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"valid cidr block": {
-			input:    "10.0.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 2": {
-			input:    "10.255.255.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"invalid cidr notation 2": {
-			input: "10.256.0.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid cidr notation 3": {
-			input: "10.0.256.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid characters 2": {
-			input: "10.255.255asdfasdfaqsd.250",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"valid cidr block 3": {
-			input:    "192.168.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 4": {
-			input:    "192.168.255.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"invalid cidr notation 4": {
-			input: "192.168.256.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "unable to parse string as CIDR notation IP address",
-					Detail:        "unable to parse string as CIDR notation IP address",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern": {
-			input: "192.0.0.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"valid cidr block 5": {
-			input:    "172.16.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 6": {
-			input:    "172.17.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 7": {
-			input:    "172.18.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 8": {
-			input:    "172.30.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 9": {
-			input:    "172.20.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"valid cidr block 10": {
-			input:    "172.31.0.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
-		"invalid pattern 2": {
-			input: "172.15.0.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern 3": {
-			input: "172.32.0.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern 4": {
-			input: "172.192.0.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern 5": {
-			input: "172.255.0.0/24",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern 6": {
-			input: "10.0.0.0/7",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern 7": {
-			input: "192.168.0.0/15",
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid pattern and invalid range": {
-			input:    "87.70.141.1/22",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
-					AttributePath: nil,
-				},
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "invalid CIDR range start 87.70.141.1, should have been 87.70.140.0",
-					Detail:        "invalid CIDR range start 87.70.141.1, should have been 87.70.140.0",
-					AttributePath: nil,
-				},
-			},
-		},
-		"invalid range": {
-			input:    "192.168.255.255/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics{
-				diag.Diagnostic{
-					Severity:      diag.Error,
-					Summary:       "invalid CIDR range start 192.168.255.255, should have been 192.168.255.0",
-					Detail:        "invalid CIDR range start 192.168.255.255, should have been 192.168.255.0",
-					AttributePath: nil,
-				},
-			},
-		},
-		"valid cidr block 11": {
-			input:    "172.25.16.0/24",
-			networks: RFC1918Networks,
-			expected: diag.Diagnostics(nil),
-		},
 	}
 
-	for n, tc := range tcs {
-		t.Run(n, func(t *testing.T) {
-			r := require.New(t)
-			result := validateCIDRBlock(tc.input, nil, tc.networks)
-			r.Equal(tc.expected, result)
-		})
-	}
+	t.Run("Formatting", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"blank input string": {
+				input: "",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid cidr notation": {
+				input: "192.168.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid characters": {
+				input: "someString",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid cidr notation 2": {
+				input: "10.256.0.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid cidr notation 3": {
+				input: "10.0.256.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid characters 2": {
+				input: "10.255.255asdfasdfaqsd.250",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid cidr notation 4": {
+				input: "192.168.256.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "unable to parse string as CIDR notation IP address",
+						Detail:        "unable to parse string as CIDR notation IP address",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern": {
+				input: "192.0.0.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern 2": {
+				input: "172.15.0.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern 3": {
+				input: "172.32.0.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern 4": {
+				input: "172.192.0.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern 5": {
+				input: "172.255.0.0/24",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern 6": {
+				input: "10.0.0.0/7",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern 7": {
+				input: "192.168.0.0/15",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid pattern and invalid range": {
+				input:    "87.70.141.1/22",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "invalid CIDR range start 87.70.141.1, should have been 87.70.140.0",
+						Detail:        "invalid CIDR range start 87.70.141.1, should have been 87.70.140.0",
+						AttributePath: nil,
+					},
+				},
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlock(tc.input, nil, tc.networks)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("By Range", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"valid cidr block": {
+				input:    "10.0.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 2": {
+				input:    "10.255.255.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 3": {
+				input:    "192.168.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 4": {
+				input:    "192.168.255.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 5": {
+				input:    "172.16.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 6": {
+				input:    "172.17.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 7": {
+				input:    "172.18.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 8": {
+				input:    "172.30.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 9": {
+				input:    "172.20.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 10": {
+				input:    "172.31.0.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"valid cidr block 11": {
+				input:    "172.25.16.0/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics(nil),
+			},
+			"invalid range": {
+				input:    "192.168.255.255/24",
+				networks: RFC1918Networks,
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "invalid CIDR range start 192.168.255.255, should have been 192.168.255.0",
+						Detail:        "invalid CIDR range start 192.168.255.255, should have been 192.168.255.0",
+						AttributePath: nil,
+					},
+				},
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlock(tc.input, nil, tc.networks)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
 }

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -807,3 +807,266 @@ func Test_validateCIDRBlock(t *testing.T) {
 		}
 	})
 }
+
+func Test_validateCIDRBlockHVN(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected diag.Diagnostics
+	}
+
+	t.Run("Range 10.0.0.0/8", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"valid 1": {
+				input:    "10.255.255.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 2": {
+				input:    "10.100.80.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 3": {
+				input:    "10.40.80.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 4": {
+				input:    "10.40.0.0/16",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 5": {
+				input:    "10.70.4.2/32",
+				expected: diag.Diagnostics(nil),
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVN(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("Range 172.16.0.0/12", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"valid 1": {
+				input:    "172.31.255.250/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 2": {
+				input:    "172.16.0.2/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 3": {
+				input:    "172.30.0.0/16",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 4": {
+				input:    "172.30.255.255/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 5": {
+				input:    "172.16.255.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVN(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("Range 192.168.0.0/16", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"valid 1": {
+				input:    "192.168.10.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 2": {
+				input:    "192.168.255.255/32",
+				expected: diag.Diagnostics(nil),
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVN(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"invalid range 1": {
+				input: "170.16.0.0/16",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid range 2": {
+				input: "170.16.10.8/16",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "invalid CIDR range start 170.16.10.8, should have been 170.16.0.0",
+						Detail:        "invalid CIDR range start 170.16.10.8, should have been 170.16.0.0",
+						AttributePath: nil,
+					},
+				},
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVN(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+}
+
+func Test_validateCIDRBlockHVNRoute(t *testing.T) {
+	type testCase struct {
+		input    string
+		expected diag.Diagnostics
+	}
+
+	t.Run("Range RFC1918", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"valid 1": {
+				input:    "10.255.255.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 2": {
+				input:    "10.100.80.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 3": {
+				input:    "10.40.80.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 4": {
+				input:    "10.40.0.0/16",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 5": {
+				input:    "10.70.4.2/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 6": {
+				input:    "172.31.255.250/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 7": {
+				input:    "172.16.0.2/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 8": {
+				input:    "172.30.0.0/16",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 9": {
+				input:    "172.30.255.255/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 10": {
+				input:    "172.16.255.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 11": {
+				input:    "192.168.10.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 12": {
+				input:    "192.168.255.255/32",
+				expected: diag.Diagnostics(nil),
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVNRoute(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("Range RFC6598", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"valid 1": {
+				input:    "100.64.0.1/32",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 2": {
+				input:    "100.64.10.0/24",
+				expected: diag.Diagnostics(nil),
+			},
+			"valid 3": {
+				input:    "100.64.255.254/32",
+				expected: diag.Diagnostics(nil),
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVNRoute(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		tcs := map[string]testCase{
+			"invalid range 1": {
+				input: "100.64.0.0/16",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+			"invalid range 2": {
+				input: "100.65.0.0/16",
+				expected: diag.Diagnostics{
+					diag.Diagnostic{
+						Severity:      diag.Error,
+						Summary:       "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						Detail:        "must match pattern of 10.*.*.* with prefix greater than /8,or 172.[16-31].*.* with prefix greater than /12, or 192.168.*.* with prefix greater than /16; where * is any number from [0-255]",
+						AttributePath: nil,
+					},
+				},
+			},
+		}
+
+		for n, tc := range tcs {
+			t.Run(n, func(t *testing.T) {
+				r := require.New(t)
+				result := validateCIDRBlockHVN(tc.input, nil)
+				r.Equal(tc.expected, result)
+			})
+		}
+	})
+}

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -537,6 +538,7 @@ func Test_validateVaultPathsFilter(t *testing.T) {
 func Test_validateCIDRBlock(t *testing.T) {
 	tcs := map[string]struct {
 		input    string
+		networks []net.IPNet
 		expected diag.Diagnostics
 	}{
 		"blank input string": {
@@ -574,10 +576,12 @@ func Test_validateCIDRBlock(t *testing.T) {
 		},
 		"valid cidr block": {
 			input:    "10.0.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 2": {
 			input:    "10.255.255.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"invalid cidr notation 2": {
@@ -615,10 +619,12 @@ func Test_validateCIDRBlock(t *testing.T) {
 		},
 		"valid cidr block 3": {
 			input:    "192.168.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 4": {
 			input:    "192.168.255.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"invalid cidr notation 4": {
@@ -645,26 +651,32 @@ func Test_validateCIDRBlock(t *testing.T) {
 		},
 		"valid cidr block 5": {
 			input:    "172.16.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 6": {
 			input:    "172.17.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 7": {
 			input:    "172.18.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 8": {
 			input:    "172.30.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 9": {
 			input:    "172.20.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"valid cidr block 10": {
 			input:    "172.31.0.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 		"invalid pattern 2": {
@@ -734,7 +746,8 @@ func Test_validateCIDRBlock(t *testing.T) {
 			},
 		},
 		"invalid pattern and invalid range": {
-			input: "87.70.141.1/22",
+			input:    "87.70.141.1/22",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,
@@ -751,7 +764,8 @@ func Test_validateCIDRBlock(t *testing.T) {
 			},
 		},
 		"invalid range": {
-			input: "192.168.255.255/24",
+			input:    "192.168.255.255/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,
@@ -763,6 +777,7 @@ func Test_validateCIDRBlock(t *testing.T) {
 		},
 		"valid cidr block 11": {
 			input:    "172.25.16.0/24",
+			networks: RFC1918Networks,
 			expected: diag.Diagnostics(nil),
 		},
 	}
@@ -770,7 +785,7 @@ func Test_validateCIDRBlock(t *testing.T) {
 	for n, tc := range tcs {
 		t.Run(n, func(t *testing.T) {
 			r := require.New(t)
-			result := validateCIDRBlock(tc.input, nil)
+			result := validateCIDRBlock(tc.input, nil, tc.networks)
 			r.Equal(tc.expected, result)
 		})
 	}

--- a/templates/resources/hvn_route.md.tmpl
+++ b/templates/resources/hvn_route.md.tmpl
@@ -10,6 +10,9 @@ description: |-
 ~> **Migration Required:** The release of HVN Routes in v0.7.0 includes breaking changes that affect `hcp_aws_network_peering` and `hcp_aws_transit_gateway_attachment`. [This guide](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/hvn-route-migration-guide) walks through how to migrate to the new resource syntax.
 Please pin to the previous version to avoid disruption until you are ready to migrate.
 
+-> **Note:** The `destination_cidr` value must be an IPv4 CIDR block within the [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918) private address space (10.*.*.*, 192.168.*.*, 172.[16-31].*.*) **or**
+the [RFC6598](https://datatracker.ietf.org/doc/html/rfc6598) shared address space (100.64.*.*).
+
 {{ .Description | trimspace }}
 
 ## Example Usage


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
* The network service has been updated to allow creation of HVN routes to [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598#section-7). We need to support this functionality through the `hcp_hvn_route` resource as well.
* This change updates the validation used on the `destination_cidr` attribute of the `hcp_hvn_route` resource to allow the additional network range (`100.64.0.0/10`)

### Related
* https://github.com/hashicorp/cloud-network/pull/1122
* https://github.com/hashicorp/cloud-ui/pull/6159

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
