### PR TITLE
HPR-1168: Resolve plan failures for hcp_packer_channel when deleted out-of-band

### DIFF
--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -128,12 +128,15 @@ func resourcePackerChannelRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	channelName := d.Get("name").(string)
+
+	log.Printf("[INFO] Reading HCP Packer channel (%s) [bucket_name=%s, project_id=%s, organization_id=%s]", channelName, bucketName, loc.ProjectID, loc.OrganizationID)
+
 	resp, err := clients.ListBucketChannels(ctx, client, loc, bucketName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	channelName := d.Get("name").(string)
 	var channel packermodels.HashicorpCloudPackerChannel
 	for _, c := range resp.Channels {
 		if c.Slug == channelName {
@@ -143,7 +146,7 @@ func resourcePackerChannelRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	if channel.ID == "" {
 		log.Printf(
-			"[WARN] no HCP Packer chanel found with (name %q) (bucket_name %q) (project_id %q)",
+			"[WARN] HCP Packer chanel with (name %q) (bucket_name %q) (project_id %q) not found, removing from state.",
 			channelName, bucketName, loc.ProjectID,
 		)
 		d.SetId("")

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -142,7 +142,12 @@ func resourcePackerChannelRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 	if channel.ID == "" {
-		return diag.Errorf("Unable to find channel in bucket %s named %s.", bucketName, channelName)
+		log.Printf(
+			"[WARN] no HCP Packer chanel found with (name %q) (bucket_name %q) (project_id %q)",
+			channelName, bucketName, loc.ProjectID,
+		)
+		d.SetId("")
+		return nil
 	}
 	return setPackerChannelResourceData(d, &channel)
 }


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Current Channel Read code throws a Diagnostic error when the channel is not found. 

Changed to log a warning, and mark the resource as deleted externally. Terraform will generate a plan to re-create the resource on `apply`, or a no-op plan to save the external state change on `destroy`.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$make testacc TESTARGS='-run=TestAcc.*PackerChannel.*'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAcc.*PackerChannel.* -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccPackerChannel
--- PASS: TestAccPackerChannel (8.93s)
=== RUN   TestAccPackerChannel_AssignedIteration
--- PASS: TestAccPackerChannel_AssignedIteration (8.34s)
=== RUN   TestAccPackerChannel_UpdateAssignedIteration
--- PASS: TestAccPackerChannel_UpdateAssignedIteration (12.96s)
=== RUN   TestAccPackerChannel_UpdateAssignedIterationWithFingerprint
--- PASS: TestAccPackerChannel_UpdateAssignedIterationWithFingerprint (6.57s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   37.153s
```
