### PR TITLE
Allow `prerelease` E2E bypass

### DIFF
--- a/.changelog/520.txt
+++ b/.changelog/520.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update prerelease github action workflow to allow bypassing end-to-end tests via input variable.
+```

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,6 +1,6 @@
 name: Prerelease
 
-on: 
+on:
   # Run Every Wednesday at 12:00 AM UTC
   schedule:
     - cron: '0 0 * * 3'
@@ -16,7 +16,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          ref: main
+          # fetch-depth: 0
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
       - name: Setup Go
@@ -54,39 +55,39 @@ jobs:
           name: Test Coverage
           path: coverage.html
 
-      - name: Run E2E Tests
-        env:
-          HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
-          HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
-          HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
-          HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
-          HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
-          HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
+      # - name: Run E2E Tests
+      #   env:
+      #     HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
+      #     HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
+      #     HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+      #     HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+      #     HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
+      #     HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
 
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-          AWS_REGION: us-west-1
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+      #     AWS_REGION: us-west-1
 
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      #     AZURE_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      #     AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
-          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-        run: |
-          AWS_OUTPUT=$(aws sts assume-role --role-arn $AWS_ROLE_ARN --role-session-name e2e-test --duration-seconds 43200)
-          export AWS_ACCESS_KEY_ID=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.AccessKeyId) 
-          export AWS_SECRET_ACCESS_KEY=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SecretAccessKey) 
-          export AWS_SESSION_TOKEN=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SessionToken) 
-          make testacc-ci
+      #     ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      #     ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      #     ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+      #     ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      #   run: |
+      #     AWS_OUTPUT=$(aws sts assume-role --role-arn $AWS_ROLE_ARN --role-session-name e2e-test --duration-seconds 43200)
+      #     export AWS_ACCESS_KEY_ID=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.AccessKeyId)
+      #     export AWS_SECRET_ACCESS_KEY=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SecretAccessKey)
+      #     export AWS_SESSION_TOKEN=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SessionToken)
+      #     make testacc-ci
 
-      - name: Upload E2E Coverage Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Coverage
-          path: coverage-e2e.html
+      # - name: Upload E2E Coverage Artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: Test Coverage
+      #     path: coverage-e2e.html
 
       - name: Release New Version
         env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -88,6 +88,7 @@ jobs:
           make testacc-ci
 
       - name: Upload E2E Coverage Artifact
+        if: ${{ !inputs.skip-e2e }}
         uses: actions/upload-artifact@v3
         with:
           name: Test Coverage

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          ref: main
           fetch-depth: 0
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -60,7 +60,7 @@ jobs:
           path: coverage.html
 
       - name: Run E2E Tests
-        if ${{ !inputs.skip-e2e }}
+        if: ${{ !inputs.skip-e2e }}
         env:
           HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
           HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * 3'
   workflow_dispatch:
+    inputs:
+      skip-e2e:
+        type: boolean
+        default: false
 
 permissions: write-all
 
@@ -17,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
-          # fetch-depth: 0
+          fetch-depth: 0
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
       - name: Setup Go
@@ -55,39 +59,40 @@ jobs:
           name: Test Coverage
           path: coverage.html
 
-      # - name: Run E2E Tests
-      #   env:
-      #     HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
-      #     HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
-      #     HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
-      #     HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
-      #     HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
-      #     HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
+      - name: Run E2E Tests
+        if ${{ !inputs.skip-e2e }}
+        env:
+          HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
+          HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
+          HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+          HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+          HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
+          HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
 
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-      #     AWS_REGION: us-west-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          AWS_REGION: us-west-1
 
-      #     AZURE_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      #     AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
-      #     ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      #     ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-      #     ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      #     ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-      #   run: |
-      #     AWS_OUTPUT=$(aws sts assume-role --role-arn $AWS_ROLE_ARN --role-session-name e2e-test --duration-seconds 43200)
-      #     export AWS_ACCESS_KEY_ID=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.AccessKeyId)
-      #     export AWS_SECRET_ACCESS_KEY=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SecretAccessKey)
-      #     export AWS_SESSION_TOKEN=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SessionToken)
-      #     make testacc-ci
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+        run: |
+          AWS_OUTPUT=$(aws sts assume-role --role-arn $AWS_ROLE_ARN --role-session-name e2e-test --duration-seconds 43200)
+          export AWS_ACCESS_KEY_ID=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.AccessKeyId)
+          export AWS_SECRET_ACCESS_KEY=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SecretAccessKey)
+          export AWS_SESSION_TOKEN=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SessionToken)
+          make testacc-ci
 
-      # - name: Upload E2E Coverage Artifact
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: Test Coverage
-      #     path: coverage-e2e.html
+      - name: Upload E2E Coverage Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Coverage
+          path: coverage-e2e.html
 
       - name: Release New Version
         env:


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

* Due to ongoing [E2E failures](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/5138483891/jobs/9247870935) (incident related), we are unable to create a new release of the provider.
* This PR adds an input to the workflow_dispatch trigger to allow bypassing the e2e steps. The E2Es are run by default, switching `skip-e2e: true` will bypass the tests.

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
