### PR TITLE
HPR-1177: Assigned iteration should not be forced to be null when no iteration block is present

### DIFF
--- a/.changelog/521.txt
+++ b/.changelog/521.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Resolve unintended removal of assigned iteration when iteration block is not present on `hcp_packer_channel`
+```

--- a/.changelog/521.txt
+++ b/.changelog/521.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Resolve unintended removal of assigned iteration when iteration block is not present on `hcp_packer_channel`
+Resolve unintended removal of assigned iteration when `iteration` block is not present on `hcp_packer_channel`
 ```

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -46,7 +46,7 @@ resource "hcp_packer_channel" "staging" {
 }
 ```
 
-Using the latest channel to create a new channel the latest complete iteration assigned.
+Using the latest channel to create a new channel with the latest complete iteration assigned.
 ```terraform
 data "hcp_packer_image_iteration" "latest" {
   bucket_name = "alpine"

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -25,10 +25,10 @@ resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
   iteration {
-    // Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
+    # Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
     id = "01H1SF9NWAK8AP25PAWDBGZ1YD"
-    // fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
-    // incremental_version = 1
+    # fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
+    # incremental_version = 1
   }
 }
 

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -19,7 +19,7 @@ resource "hcp_packer_channel" "staging" {
 }
 ```
 
-To create a channel with a Terraform-managed iteration.
+To create a channel with iteration assignment managed by Terraform.
 ```terraform
 resource "hcp_packer_channel" "staging" {
   name        = "staging"

--- a/docs/resources/packer_channel.md
+++ b/docs/resources/packer_channel.md
@@ -11,7 +11,7 @@ The Packer Channel resource allows you to manage image bucket channels within an
 
 ## Example Usage
 
-To create a channel with no assigned iteration.
+To create a channel.
 ```terraform
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
@@ -19,37 +19,34 @@ resource "hcp_packer_channel" "staging" {
 }
 ```
 
-To create, or update an existing, channel with an assigned iteration.
+To create a channel with a Terraform-managed iteration.
 ```terraform
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
   iteration {
-    id = "iteration-id"
+    // Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
+    id = "01H1SF9NWAK8AP25PAWDBGZ1YD"
+    // fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
+    // incremental_version = 1
   }
 }
 
-# Update assigned iteration using an iteration fingerprint
+# To configure a channel to have no assigned iteration, use a "zero value".
+# The zero value for `id` and `fingerprint` is `""`; for `incremental_version`, it is `0`
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
   iteration {
-    fingerprint = "fingerprint-associated-to-iteration"
-  }
-}
-
-# Update assigned iteration using an iteration incremental version
-resource "hcp_packer_channel" "staging" {
-  name        = "staging"
-  bucket_name = "alpine"
-  iteration {
-    // incremental_version is the version number assigned to a completed iteration.
-    incremental_version = 1
+    # Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
+    id = ""
+    # fingerprint = ""
+    # incremental_version = 0
   }
 }
 ```
 
-Using the latest channel to create a new channel with an assigned iteration.
+Using the latest channel to create a new channel the latest complete iteration assigned.
 ```terraform
 data "hcp_packer_image_iteration" "latest" {
   bucket_name = "alpine"

--- a/examples/resources/hcp_packer_channel/resource_assignment.tf
+++ b/examples/resources/hcp_packer_channel/resource_assignment.tf
@@ -2,10 +2,10 @@ resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
   iteration {
-    // Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
+    # Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
     id = "01H1SF9NWAK8AP25PAWDBGZ1YD"
-    // fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
-    // incremental_version = 1
+    # fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
+    # incremental_version = 1
   }
 }
 

--- a/examples/resources/hcp_packer_channel/resource_assignment.tf
+++ b/examples/resources/hcp_packer_channel/resource_assignment.tf
@@ -2,26 +2,22 @@ resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
   iteration {
-    id = "iteration-id"
+    // Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
+    id = "01H1SF9NWAK8AP25PAWDBGZ1YD"
+    // fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
+    // incremental_version = 1
   }
 }
 
-# Update assigned iteration using an iteration fingerprint
+# To configure a channel to have no assigned iteration, use a "zero value".
+# The zero value for `id` and `fingerprint` is `""`; for `incremental_version`, it is `0`
 resource "hcp_packer_channel" "staging" {
   name        = "staging"
   bucket_name = "alpine"
   iteration {
-    fingerprint = "fingerprint-associated-to-iteration"
+    # Exactly one of `id`, `fingerprint` or `incremental_version` must be passed
+    id = ""
+    # fingerprint = ""
+    # incremental_version = 0
   }
 }
-
-# Update assigned iteration using an iteration incremental version
-resource "hcp_packer_channel" "staging" {
-  name        = "staging"
-  bucket_name = "alpine"
-  iteration {
-    // incremental_version is the version number assigned to a completed iteration.
-    incremental_version = 1
-  }
-}
-

--- a/templates/resources/packer_channel.md.tmpl
+++ b/templates/resources/packer_channel.md.tmpl
@@ -14,7 +14,7 @@ description: |-
 To create a channel.
 {{ tffile "examples/resources/hcp_packer_channel/resource.tf" }}
 
-To create a channel with a Terraform-managed iteration.
+To create a channel with iteration assignment managed by Terraform.
 {{ tffile "examples/resources/hcp_packer_channel/resource_assignment.tf" }}
 
 Using the latest channel to create a new channel with the latest complete iteration assigned.

--- a/templates/resources/packer_channel.md.tmpl
+++ b/templates/resources/packer_channel.md.tmpl
@@ -11,13 +11,13 @@ description: |-
 
 ## Example Usage
 
-To create a channel with no assigned iteration.
+To create a channel.
 {{ tffile "examples/resources/hcp_packer_channel/resource.tf" }}
 
-To create, or update an existing, channel with an assigned iteration.
+To create a channel with a Terraform-managed iteration.
 {{ tffile "examples/resources/hcp_packer_channel/resource_assignment.tf" }}
 
-Using the latest channel to create a new channel with an assigned iteration.
+Using the latest channel to create a new channel the latest complete iteration assigned.
 {{ tffile "examples/resources/hcp_packer_channel/resource_using_latest_channel.tf" }}
 
 

--- a/templates/resources/packer_channel.md.tmpl
+++ b/templates/resources/packer_channel.md.tmpl
@@ -17,7 +17,7 @@ To create a channel.
 To create a channel with a Terraform-managed iteration.
 {{ tffile "examples/resources/hcp_packer_channel/resource_assignment.tf" }}
 
-Using the latest channel to create a new channel the latest complete iteration assigned.
+Using the latest channel to create a new channel with the latest complete iteration assigned.
 {{ tffile "examples/resources/hcp_packer_channel/resource_using_latest_channel.tf" }}
 
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Previously, when no iteration block existed on `hcp_packer_channel`, the provider would treat external management of the channel's iteration assignment as configuration drift and the assignment would be removed on next apply. Now, the channel's assigned iteration is ignored when there is no iteration block present. In use cases where users may want to force a channel to have no assigned iteration, they can use a zero value for one of the attributes in the iteration block.

Additionally, these changes enhance plans by populating the 2 unset iteration block attributes with the data associated with the 1 set attribute. This improves visibility in cases where the iteration associated with the chosen attribute may change due to external modifications (ex: deletion of an iteration with fingerprint `xyz` and then uploading another iteration with the fingerprint manually set to `xyz`, or deleting the latest complete iteration assigned version `7` and then uploading a new complete iteration which will then be automatically assigned version `7`). In cases where the 1 set attribute is not associated with any iteration, these changes move failure up the chain from apply-time to plan-time.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAcc.*PackerChannel.*'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAcc.*PackerChannel.* -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccPackerChannel
--- PASS: TestAccPackerChannel (8.93s)
=== RUN   TestAccPackerChannel_AssignedIteration
--- PASS: TestAccPackerChannel_AssignedIteration (9.06s)
=== RUN   TestAccPackerChannel_UpdateAssignedIteration
--- PASS: TestAccPackerChannel_UpdateAssignedIteration (14.08s)
=== RUN   TestAccPackerChannel_UpdateAssignedIterationWithFingerprint
--- PASS: TestAccPackerChannel_UpdateAssignedIterationWithFingerprint (6.44s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   38.876s
```
