### PR TITLE
HCPF-704: Fix Missing/Incorrect Resource-level `project_id` Implementations

### DIFF
--- a/.changelog/522.txt
+++ b/.changelog/522.txt
@@ -7,3 +7,19 @@ whether or not the attribute was still present in the configuration file.
 
 NOTE: See associated PR for caveats on temporary regressions.
 ```
+
+```release-note:deprecation
+Setting the `project_id` attribute on `hcp_hvn_peering_connection` and 
+`data.hcp_hvn_peering_connection` is now deprecated. The value of the field was 
+required to match the project ID for `hvn_1` and will now be determined 
+automatically. Remove the `project_id` field from the configuration for affected 
+resources and data sources.
+```
+
+```release-note:deprecation
+Setting the `hvn_2` attribute of `data.hcp_hvn_peering_connection` is now 
+deprecated. The value of the attribute is not needed to fetch data, and it was 
+never validated against the real value for `hvn_2`. The value will now be 
+populated automatically. Remove the `hvn_2` attribute from the configuration for 
+affected data sources.
+```

--- a/.changelog/522.txt
+++ b/.changelog/522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed several missing/incorrect resource-level `project_id` implementations. NOTE: See associated PR for caveats on temporary regressions.
+```

--- a/.changelog/522.txt
+++ b/.changelog/522.txt
@@ -1,3 +1,9 @@
 ```release-note:bug
-Fixed several missing/incorrect resource-level `project_id` implementations. NOTE: See associated PR for caveats on temporary regressions.
+Fixed several missing/incorrect implementations for the resource-level 
+`project_id` attribute that could lead to undefined or undesirable behavior on 
+some resources and data sources when the `project_id` attribute had been used 
+and its most recent value was different from the provider-level `project_id`,
+whether or not the attribute was still present in the configuration file.
+
+NOTE: See associated PR for caveats on temporary regressions.
 ```

--- a/.changelog/522.txt
+++ b/.changelog/522.txt
@@ -12,21 +12,21 @@ NOTE: See associated PR for caveats on temporary regressions.
 Setting the `project_id` attribute on `hcp_hvn_peering_connection` and 
 `data.hcp_hvn_peering_connection` is now deprecated. The value of the field was 
 required to match the project ID for `hvn_1` and will now be determined 
-automatically. Remove the `project_id` field from the configuration for affected 
-resources and data sources.
+automatically. Remove the `project_id` field from the configuration for 
+affected resources and data sources.
 ```
 
 ```release-note:deprecation
 Setting the `hvn_2` attribute of `data.hcp_hvn_peering_connection` is now 
 deprecated. The value of the attribute is not needed to fetch data, and it was 
 never validated against the real value for `hvn_2`. The value will now be 
-populated automatically. Remove the `hvn_2` attribute from the configuration for 
-affected data sources.
+populated automatically. Remove the `hvn_2` attribute from the configuration 
+for affected data sources.
 ```
 
 ```release-note:deprecation
-Setting the `project_id` attribute on `data.hvn_route` is now deprecated. The 
-value of the field was required to match the project ID in `hvn_link` and will 
-now be determined automatically. Remove the `project_id` field from the 
-configuration for affected data sources.
+Setting the `project_id` attribute on `hcp_hvn_route` and `data.hcp_hvn_route`
+is now deprecated. The value of the field was required to match the project ID 
+in `hvn_link` and will now be determined automatically. Remove the `project_id` 
+field from the configuration for affected resources and data sources.
 ```

--- a/.changelog/522.txt
+++ b/.changelog/522.txt
@@ -23,3 +23,10 @@ never validated against the real value for `hvn_2`. The value will now be
 populated automatically. Remove the `hvn_2` attribute from the configuration for 
 affected data sources.
 ```
+
+```release-note:deprecation
+Setting the `project_id` attribute on `data.hvn_route` is now deprecated. The 
+value of the field was required to match the project ID in `hvn_link` and will 
+now be determined automatically. Remove the `project_id` field from the 
+configuration for affected data sources.
+```

--- a/docs/data-sources/hvn_peering_connection.md
+++ b/docs/data-sources/hvn_peering_connection.md
@@ -26,12 +26,12 @@ data "hcp_hvn_peering_connection" "test" {
 ### Required
 
 - `hvn_1` (String) The unique URL of one of the HVNs being peered.
-- `hvn_2` (String) The unique URL of one of the HVNs being peered.
 - `peering_id` (String) The ID of the peering connection.
 
 ### Optional
 
-- `project_id` (String) The ID of the HCP project where the HVN peering connection is located.
+- `hvn_2` (String, Deprecated) The unique URL of one of the HVNs being peered. Setting this attribute is deprecated, but it will remain usable in read-only form.
+- `project_id` (String, Deprecated) The ID of the HCP project where the HVN peering connection is located. Always matches hvn_1's project ID. Setting this attribute is deprecated, but it will remain usable in read-only form.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -39,7 +39,7 @@ data "hcp_hvn_peering_connection" "test" {
 - `created_at` (String) The time that the peering connection was created.
 - `expires_at` (String) The time after which the peering connection will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.
 - `id` (String) The ID of this resource.
-- `organization_id` (String) The ID of the HCP organization where the peering connection is located. Always matches the HVNs' organization.
+- `organization_id` (String) The ID of the HCP organization where the peering connection is located. Always matches both HVNs' organization ID
 - `self_link` (String) A unique URL identifying the peering connection
 - `state` (String) The state of the HVN peering connection.
 

--- a/docs/data-sources/hvn_peering_connection.md
+++ b/docs/data-sources/hvn_peering_connection.md
@@ -16,7 +16,6 @@ The HVN peering connection data source provides information about an existing pe
 data "hcp_hvn_peering_connection" "test" {
   peering_id = var.peering_id
   hvn_1      = var.hvn_1
-  hvn_2      = var.hvn_2
 }
 ```
 

--- a/docs/data-sources/hvn_route.md
+++ b/docs/data-sources/hvn_route.md
@@ -29,7 +29,7 @@ data "hcp_hvn_route" "example" {
 
 ### Optional
 
-- `project_id` (String) The ID of the HCP project where the HVN route is located.
+- `project_id` (String, Deprecated) The ID of the HCP project where the HVN route is located. Always matches the project ID in `hvn_link`. Setting this attribute is deprecated, but it will remain usable in read-only form.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/hvn_peering_connection.md
+++ b/docs/resources/hvn_peering_connection.md
@@ -43,7 +43,7 @@ resource "hcp_hvn_peering_connection" "peer_1" {
 
 ### Optional
 
-- `project_id` (String) The ID of the HCP project where the HVN peering connection is located.
+- `project_id` (String, Deprecated) The ID of the HCP project where HVN peering connection is located. Always matches hvn_1's project ID. Setting this attribute is deprecated, but it will remain usable in read-only form.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -51,7 +51,7 @@ resource "hcp_hvn_peering_connection" "peer_1" {
 - `created_at` (String) The time that the peering connection was created.
 - `expires_at` (String) The time after which the peering connection will be considered expired if it hasn't transitioned into `ACCEPTED` or `ACTIVE` state.
 - `id` (String) The ID of this resource.
-- `organization_id` (String) The ID of the HCP organization where the peering connection is located. Always matches the HVNs' organization.
+- `organization_id` (String) The ID of the HCP organization where the peering connection is located. Always matches both HVNs' organization ID.
 - `peering_id` (String) The ID of the peering connection.
 - `self_link` (String) A unique URL identifying the peering connection
 - `state` (String) The state of the HVN peering connection.

--- a/docs/resources/hvn_route.md
+++ b/docs/resources/hvn_route.md
@@ -67,7 +67,7 @@ resource "hcp_hvn_route" "example-peering-route" {
 
 ### Optional
 
-- `project_id` (String) The ID of the HCP project where the HVN route is located.
+- `project_id` (String, Deprecated) The ID of the HCP project where the HVN route is located. Always matches the project ID in `hvn_link`. Setting this attribute is deprecated, but it will remain usable in read-only form.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/examples/data-sources/hcp_hvn_peering_connection/data-source.tf
+++ b/examples/data-sources/hcp_hvn_peering_connection/data-source.tf
@@ -1,5 +1,4 @@
 data "hcp_hvn_peering_connection" "test" {
   peering_id = var.peering_id
   hvn_1      = var.hvn_1
-  hvn_2      = var.hvn_2
 }

--- a/examples/data-sources/hcp_hvn_peering_connection/variables.tf
+++ b/examples/data-sources/hcp_hvn_peering_connection/variables.tf
@@ -7,8 +7,3 @@ variable "hvn_1" {
   description = "The unique URL of one of the HVNs being peered."
   type        = string
 }
-
-variable "hvn_2" {
-  description = "The unique URL of one of the HVNs being peered."
-  type        = string
-}

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -113,18 +113,16 @@ func dataSourceAzurePeeringConnection() *schema.Resource {
 
 func dataSourceAzurePeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-	orgID := client.Config.OrganizationID
-
 	peeringID := d.Get("peering_id").(string)
 
-	hvnLink, err := buildLinkFromURL(d.Get("hvn_link").(string), HvnResourceType, orgID)
+	hvnLink, err := buildLinkFromURL(d.Get("hvn_link").(string), HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	waitForActive := d.Get("wait_for_active_state").(bool)
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
+		OrganizationID: hvnLink.Location.OrganizationID,
 		ProjectID:      hvnLink.Location.ProjectID,
 	}
 

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -116,15 +116,17 @@ func dataSourceAzurePeeringConnectionRead(ctx context.Context, d *schema.Resourc
 	orgID := client.Config.OrganizationID
 
 	peeringID := d.Get("peering_id").(string)
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
-	}
+
 	hvnLink, err := buildLinkFromURL(d.Get("hvn_link").(string), HvnResourceType, orgID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	waitForActive := d.Get("wait_for_active_state").(bool)
+
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		OrganizationID: client.Config.OrganizationID,
+		ProjectID:      hvnLink.Location.ProjectID,
+	}
 
 	// Query for the peering.
 	log.Printf("[INFO] Reading peering connection (%s)", peeringID)

--- a/internal/provider/data_source_consul_agent_helm_config.go
+++ b/internal/provider/data_source_consul_agent_helm_config.go
@@ -122,15 +122,8 @@ func dataSourceConsulAgentHelmConfigRead(ctx context.Context, d *schema.Resource
 		return diag.Errorf("unable to retrieve project ID: %v", err)
 	}
 
-	organizationID := client.Config.OrganizationID
-
-	v, ok := d.GetOk("project_id")
-	if ok {
-		projectID = v.(string)
-	}
-
 	loc := &models.HashicorpCloudLocationLocation{
-		OrganizationID: organizationID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 

--- a/internal/provider/data_source_consul_agent_kubernetes_secret.go
+++ b/internal/provider/data_source_consul_agent_kubernetes_secret.go
@@ -76,12 +76,10 @@ func dataSourceConsulAgentKubernetesSecretRead(ctx context.Context, d *schema.Re
 		return diag.Errorf("unable to retrieve project ID: %v", err)
 	}
 
-	organizationID := client.Config.OrganizationID
-
 	clusterID := d.Get("cluster_id").(string)
 
 	loc := &models.HashicorpCloudLocationLocation{
-		OrganizationID: organizationID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 

--- a/internal/provider/data_source_hvn_peering_connection.go
+++ b/internal/provider/data_source_hvn_peering_connection.go
@@ -78,7 +78,6 @@ func dataSourceHvnPeeringConnection() *schema.Resource {
 
 func dataSourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-	orgID := client.Config.OrganizationID
 
 	peeringID := d.Get("peering_id").(string)
 
@@ -91,7 +90,7 @@ func dataSourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
-	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, orgID)
+	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/data_source_hvn_route.go
+++ b/internal/provider/data_source_hvn_route.go
@@ -82,10 +82,6 @@ func dataSourceHVNRouteRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("project_id", hvnLink.Location.ProjectID); err != nil {
-		return diag.FromErr(err)
-	}
-
 	routeID := d.Get("hvn_route_id").(string)
 	routeLink := newLink(hvnLink.Location, HVNRouteResourceType, routeID)
 	routeURL, err := linkURL(routeLink)

--- a/internal/provider/resource_azure_peering_connection.go
+++ b/internal/provider/resource_azure_peering_connection.go
@@ -144,10 +144,6 @@ func resourceAzurePeeringConnectionCreate(ctx context.Context, d *schema.Resourc
 	peerResourceGroupName := d.Get("peer_resource_group_name").(string)
 
 	orgID := client.Config.OrganizationID
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
-		ProjectID:      client.Config.ProjectID,
-	}
 
 	hvnLink, err := buildLinkFromURL(d.Get("hvn_link").(string), HvnResourceType, orgID)
 	if err != nil {
@@ -164,6 +160,11 @@ func resourceAzurePeeringConnectionCreate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("unable to check for presence of an existing HVN (%s): %v", hvnLink.ID, err)
 	}
 	log.Printf("[INFO] HVN (%s) found, proceeding with peering connection create", hvnLink.ID)
+
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		OrganizationID: orgID,
+		ProjectID:      hvnLink.Location.ProjectID,
+	}
 
 	// Check if peering already exists
 	if peeringID != "" {

--- a/internal/provider/resource_azure_peering_connection.go
+++ b/internal/provider/resource_azure_peering_connection.go
@@ -143,9 +143,7 @@ func resourceAzurePeeringConnectionCreate(ctx context.Context, d *schema.Resourc
 	peerTenantID := d.Get("peer_tenant_id").(string)
 	peerResourceGroupName := d.Get("peer_resource_group_name").(string)
 
-	orgID := client.Config.OrganizationID
-
-	hvnLink, err := buildLinkFromURL(d.Get("hvn_link").(string), HvnResourceType, orgID)
+	hvnLink, err := buildLinkFromURL(d.Get("hvn_link").(string), HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -162,7 +160,7 @@ func resourceAzurePeeringConnectionCreate(ctx context.Context, d *schema.Resourc
 	log.Printf("[INFO] HVN (%s) found, proceeding with peering connection create", hvnLink.ID)
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
+		OrganizationID: hvnLink.Location.OrganizationID,
 		ProjectID:      hvnLink.Location.ProjectID,
 	}
 

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -257,10 +257,6 @@ func resourceBoundaryClusterCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceBoundaryClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
-	}
 
 	link, err := buildLinkFromURL(d.Id(), BoundaryClusterResourceType, client.Config.OrganizationID)
 	if err != nil {
@@ -268,6 +264,8 @@ func resourceBoundaryClusterUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	clusterID := link.ID
+	loc := link.Location
+
 	upgradeType, maintenanceWindow, diagErr := getBoundaryClusterMaintainanceWindowConfig(d)
 	if diagErr != nil {
 		return diagErr

--- a/internal/provider/resource_consul_cluster_root_token.go
+++ b/internal/provider/resource_consul_cluster_root_token.go
@@ -99,11 +99,8 @@ func resourceConsulClusterRootTokenCreate(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("unable to retrieve project ID: %v", err)
 	}
 
-	// fetch organizationID by project ID
-	organizationID := client.Config.OrganizationID
-
 	loc := &models.HashicorpCloudLocationLocation{
-		OrganizationID: organizationID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 
@@ -164,17 +161,20 @@ func resourceConsulClusterRootTokenRead(ctx context.Context, d *schema.ResourceD
 	if matchesID(clusterID) {
 		clusterID = filepath.Base(clusterID)
 	}
-	organizationID := client.Config.OrganizationID
-	projectID := client.Config.ProjectID
+
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
+	}
 
 	loc := &models.HashicorpCloudLocationLocation{
-		OrganizationID: organizationID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 
 	log.Printf("[INFO] reading Consul cluster (%s) [project_id=%s, organization_id=%s]", clusterID, loc.ProjectID, loc.OrganizationID)
 
-	_, err := clients.GetConsulClusterByID(ctx, client, loc, clusterID)
+	_, err = clients.GetConsulClusterByID(ctx, client, loc, clusterID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			// No cluster exists, so this root token should be removed from state
@@ -205,17 +205,20 @@ func resourceConsulClusterRootTokenDelete(ctx context.Context, d *schema.Resourc
 	if matchesID(clusterID) {
 		clusterID = filepath.Base(clusterID)
 	}
-	organizationID := client.Config.OrganizationID
-	projectID := client.Config.ProjectID
+
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
+	}
 
 	loc := &models.HashicorpCloudLocationLocation{
-		OrganizationID: organizationID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 
 	log.Printf("[INFO] reading Consul cluster (%s) [project_id=%s, organization_id=%s]", clusterID, loc.ProjectID, loc.OrganizationID)
 
-	_, err := clients.GetConsulClusterByID(ctx, client, loc, clusterID)
+	_, err = clients.GetConsulClusterByID(ctx, client, loc, clusterID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			// No cluster exists, so this root token should be removed from state

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -99,24 +99,22 @@ func resourceHvnPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 		log.Printf("[DEBUG] Failed to update analytics with module name (%s)", err)
 	}
 
-	orgID := client.Config.OrganizationID
-
 	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
 	if err != nil {
 		return diag.Errorf("unable to retrieve project ID: %v", err)
 	}
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 
-	hvn1Link, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, orgID)
+	hvn1Link, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	hvn2Link, err := buildLinkFromURL(d.Get("hvn_2").(string), HvnResourceType, orgID)
+	hvn2Link, err := buildLinkFromURL(d.Get("hvn_2").(string), HvnResourceType, loc.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -182,16 +180,15 @@ func resourceHvnPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-	orgID := client.Config.OrganizationID
 
-	link, err := buildLinkFromURL(d.Id(), PeeringResourceType, orgID)
+	link, err := buildLinkFromURL(d.Id(), PeeringResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	peeringID := link.ID
 	loc := link.Location
-	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, orgID)
+	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -225,16 +222,15 @@ func resourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceHvnPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-	orgID := client.Config.OrganizationID
 
-	link, err := buildLinkFromURL(d.Id(), PeeringResourceType, orgID)
+	link, err := buildLinkFromURL(d.Id(), PeeringResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	peeringID := link.ID
 	loc := link.Location
-	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, orgID)
+	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -93,7 +93,7 @@ Remove this attribute from the configuration for any affected resources.
 
 func resourceHvnPeeringConnectionCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	// Force project_id to match the project_id from hvn_1 if it has been manually overridden in configuration
-	// When then project_id attribute's "Optional" property is removed after the deprecation period
+	// When the project_id attribute's "Optional" property is removed after the deprecation period
 	// ends, CustomizeDiff can be removed.
 	if d.HasChange("project_id") {
 		hvn1Link, err := parseLinkURL(d.Get("hvn_1").(string), HvnResourceType)

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -13,7 +13,6 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
@@ -23,6 +22,7 @@ func resourceHvnPeeringConnection() *schema.Resource {
 		CreateContext: resourceHvnPeeringConnectionCreate,
 		ReadContext:   resourceHvnPeeringConnectionRead,
 		DeleteContext: resourceHvnPeeringConnectionDelete,
+		CustomizeDiff: resourceHvnPeeringConnectionCustomizeDiff,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &peeringDefaultTimeout,
 			Create:  &peeringCreateTimeout,
@@ -45,23 +45,25 @@ func resourceHvnPeeringConnection() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			// Optional inputs
-			"project_id": {
-				Description:  "The ID of the HCP project where the HVN peering connection is located.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsUUID,
-				Computed:     true,
-			},
 			// Computed outputs
 			"peering_id": {
 				Description: "The ID of the peering connection.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"project_id": {
+				Description: "The ID of the HCP project where HVN peering connection is located. Always matches hvn_1's project ID. Setting this attribute is deprecated, but it will remain usable in read-only form.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Deprecated: `
+Setting the 'project_id' attribute is deprecated, but it will remain usable in read-only form.
+Previously, the value for this attribute was required to match the project ID contained in 'hvn_1'. Now, the value will be calculated automatically.
+Remove this attribute from the configuration for any affected resources.
+`,
+			},
 			"organization_id": {
-				Description: "The ID of the HCP organization where the peering connection is located. Always matches the HVNs' organization.",
+				Description: "The ID of the HCP organization where the peering connection is located. Always matches both HVNs' organization ID.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -89,6 +91,23 @@ func resourceHvnPeeringConnection() *schema.Resource {
 	}
 }
 
+func resourceHvnPeeringConnectionCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// Force project_id to match the project_id from hvn_1 if it has been manually overridden in configuration
+	// When then project_id attribute's "Optional" property is removed after the deprecation period
+	// ends, CustomizeDiff can be removed.
+	if d.HasChange("project_id") {
+		hvn1Link, err := parseLinkURL(d.Get("hvn_1").(string), HvnResourceType)
+		if err != nil {
+			return err
+		}
+		if err := d.SetNew("project_id", hvn1Link.Location.ProjectID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resourceHvnPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
@@ -99,22 +118,16 @@ func resourceHvnPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 		log.Printf("[DEBUG] Failed to update analytics with module name (%s)", err)
 	}
 
-	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
 	if err != nil {
 		return diag.Errorf("unable to retrieve project ID: %v", err)
 	}
 
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      projectID,
-	}
-
-	hvn1Link, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
+	hvn1Link, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	hvn2Link, err := buildLinkFromURL(d.Get("hvn_2").(string), HvnResourceType, loc.OrganizationID)
+	hvn2Link, err := buildLinkFromURL(d.Get("hvn_2").(string), HvnResourceType, hvn1Link.Location.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -160,12 +173,12 @@ func resourceHvnPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 	d.SetId(url)
 
 	// Wait for peering connection to be created
-	if err := clients.WaitForOperation(ctx, client, "create peering connection", loc, peeringResponse.Payload.Operation.ID); err != nil {
+	if err := clients.WaitForOperation(ctx, client, "create peering connection", hvn1Link.Location, peeringResponse.Payload.Operation.ID); err != nil {
 		return diag.Errorf("unable to create peering connection (%s) between HVNs (%s) and (%s): %v", peering.ID, peering.Hvn.ID, peering.Target.HvnTarget.Hvn.ID, err)
 	}
 	log.Printf("[INFO] Created peering connection (%s) between HVNs (%s) and (%s)", peering.ID, peering.Hvn.ID, peering.Target.HvnTarget.Hvn.ID)
 
-	peering, err = clients.WaitForPeeringToBeAccepted(ctx, client, peering.ID, hvn1Link.ID, loc, d.Timeout(schema.TimeoutCreate))
+	peering, err = clients.WaitForPeeringToBeAccepted(ctx, client, peering.ID, hvn1Link.ID, hvn1Link.Location, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -181,20 +194,19 @@ func resourceHvnPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 func resourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
-	link, err := buildLinkFromURL(d.Id(), PeeringResourceType, client.Config.OrganizationID)
+	hvn1Link, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	peeringID := link.ID
-	loc := link.Location
-	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
+	peeringLink, err := buildLinkFromURL(d.Id(), PeeringResourceType, hvn1Link.Location.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	peeringID := peeringLink.ID
 	log.Printf("[INFO] Reading peering connection (%s)", peeringID)
-	peering, err := clients.GetPeeringByID(ctx, client, peeringID, hvnLink1.ID, loc)
+	peering, err := clients.GetPeeringByID(ctx, client, peeringID, hvn1Link.ID, peeringLink.Location)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			log.Printf("[WARN] Peering connection (%s) not found, removing from state", peeringID)
@@ -204,12 +216,12 @@ func resourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("unable to retrieve peering connection (%s): %v", peeringID, err)
 	}
 
-	hvnLink2 := newLink(peering.Target.HvnTarget.Hvn.Location, HvnResourceType, peering.Target.HvnTarget.Hvn.ID)
-	hvnURL2, err := linkURL(hvnLink2)
+	hvn2Link := newLink(peering.Target.HvnTarget.Hvn.Location, HvnResourceType, peering.Target.HvnTarget.Hvn.ID)
+	hvn2URL, err := linkURL(hvn2Link)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("hvn_2", hvnURL2); err != nil {
+	if err := d.Set("hvn_2", hvn2URL); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -223,24 +235,24 @@ func resourceHvnPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 func resourceHvnPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
-	link, err := buildLinkFromURL(d.Id(), PeeringResourceType, client.Config.OrganizationID)
+	hvn1Link, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	peeringID := link.ID
-	loc := link.Location
-	hvnLink1, err := buildLinkFromURL(d.Get("hvn_1").(string), HvnResourceType, loc.OrganizationID)
+	peeringLink, err := buildLinkFromURL(d.Id(), PeeringResourceType, hvn1Link.Location.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	peeringID := peeringLink.ID
 
 	deletePeeringParams := network_service.NewDeletePeeringParams()
 	deletePeeringParams.Context = ctx
 	deletePeeringParams.ID = peeringID
-	deletePeeringParams.HvnID = hvnLink1.ID
-	deletePeeringParams.LocationOrganizationID = loc.OrganizationID
-	deletePeeringParams.LocationProjectID = loc.ProjectID
+	deletePeeringParams.HvnID = hvn1Link.ID
+	deletePeeringParams.LocationOrganizationID = peeringLink.Location.OrganizationID
+	deletePeeringParams.LocationProjectID = peeringLink.Location.ProjectID
 
 	log.Printf("[INFO] Deleting peering connection (%s)", peeringID)
 	deletePeeringResponse, err := client.Network.DeletePeering(deletePeeringParams, nil)
@@ -253,7 +265,7 @@ func resourceHvnPeeringConnectionDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	// Wait for peering to be deleted
-	if err := clients.WaitForOperation(ctx, client, "delete peering connection", loc, deletePeeringResponse.Payload.Operation.ID); err != nil {
+	if err := clients.WaitForOperation(ctx, client, "delete peering connection", peeringLink.Location, deletePeeringResponse.Payload.Operation.ID); err != nil {
 		if strings.Contains(err.Error(), "execution already started") {
 			return nil
 		}
@@ -288,14 +300,14 @@ func resourceHvnPeeringConnectionImport(ctx context.Context, d *schema.ResourceD
 	}
 
 	// Only hvn_1 is required to fetch the peering connection. hvn_2 will be populated during the refresh phase immediately after import.
-	hvnLink := newLink(loc, HvnResourceType, hvnID)
-	hvnURL, err := linkURL(hvnLink)
+	hvn1Link := newLink(loc, HvnResourceType, hvnID)
+	hvn1URL, err := linkURL(hvn1Link)
 	if err != nil {
 		return nil, err
 	}
 
 	d.SetId(url)
-	if err := d.Set("hvn_1", hvnURL); err != nil {
+	if err := d.Set("hvn_1", hvn1URL); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/resource_hvn_peering_connection_test.go
+++ b/internal/provider/resource_hvn_peering_connection_test.go
@@ -42,7 +42,6 @@ resource "hcp_hvn_peering_connection" "test" {
 data "hcp_hvn_peering_connection" "test" {
 	peering_id = hcp_hvn_peering_connection.test.peering_id
 	hvn_1      = hcp_hvn_peering_connection.test.hvn_1
-	hvn_2      = hcp_hvn_peering_connection.test.hvn_2
 }
 `, hvn1UniqueID, hvn2UniqueID)
 

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -98,7 +98,7 @@ Remove this attribute from the configuration for any affected resources.
 
 func resourceHvnRouteCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	// Force project_id to match the project_id from hvn_link if it has been manually overridden in configuration
-	// When then project_id attribute's "Optional" property is removed after the deprecation period
+	// When the project_id attribute's "Optional" property is removed after the deprecation period
 	// ends, CustomizeDiff can be removed.
 	if d.HasChange("project_id") {
 		hvnLink, err := parseLinkURL(d.Get("hvn_link").(string), HvnResourceType)

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -14,7 +14,6 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
@@ -25,11 +24,11 @@ var hvnRouteDeleteTimeout = time.Minute * 25
 
 func resourceHvnRoute() *schema.Resource {
 	return &schema.Resource{
-		Description: "The HVN route resource allows you to manage an HVN route.",
-
+		Description:   "The HVN route resource allows you to manage an HVN route.",
 		CreateContext: resourceHvnRouteCreate,
 		ReadContext:   resourceHvnRouteRead,
 		DeleteContext: resourceHvnRouteDelete,
+		CustomizeDiff: resourceHvnRouteCustomizeDiff,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &hvnRouteDefaultTimeout,
 			Create:  &hvnRouteCreateTimeout,
@@ -38,7 +37,6 @@ func resourceHvnRoute() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceHVNRouteImport,
 		},
-
 		Schema: map[string]*schema.Schema{
 			// Required inputs
 			"hvn_link": {
@@ -67,16 +65,18 @@ func resourceHvnRoute() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			// Optional inputs
-			"project_id": {
-				Description:  "The ID of the HCP project where the HVN route is located.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsUUID,
-				Computed:     true,
-			},
 			// Computed outputs
+			"project_id": {
+				Description: "The ID of the HCP project where the HVN route is located. Always matches the project ID in `hvn_link`. Setting this attribute is deprecated, but it will remain usable in read-only form.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Deprecated: `
+Setting the 'project_id' attribute is deprecated, but it will remain usable in read-only form.
+Previously, the value for this attribute was required to match the project ID contained in 'hvn_link'. Now, the value will be calculated automatically.
+Remove this attribute from the configuration for any affected resources.
+`,
+			},
 			"self_link": {
 				Description: "A unique URL identifying the HVN route.",
 				Type:        schema.TypeString,
@@ -96,25 +96,32 @@ func resourceHvnRoute() *schema.Resource {
 	}
 }
 
+func resourceHvnRouteCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// Force project_id to match the project_id from hvn_link if it has been manually overridden in configuration
+	// When then project_id attribute's "Optional" property is removed after the deprecation period
+	// ends, CustomizeDiff can be removed.
+	if d.HasChange("project_id") {
+		hvnLink, err := parseLinkURL(d.Get("hvn_link").(string), HvnResourceType)
+		if err != nil {
+			return err
+		}
+		if err := d.SetNew("project_id", hvnLink.Location.ProjectID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func resourceHvnRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
-
-	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
-	if err != nil {
-		return diag.Errorf("unable to retrieve project ID: %v", err)
-	}
-
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      projectID,
-	}
 
 	destination := d.Get("destination_cidr").(string)
 	hvnRouteID := d.Get("hvn_route_id").(string)
 
 	hvn := d.Get("hvn_link").(string)
 	var hvnLink *sharedmodels.HashicorpCloudLocationLink
-	hvnLink, err = buildLinkFromURL(hvn, HvnResourceType, loc.OrganizationID)
+	hvnLink, err := buildLinkFromURL(hvn, HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -124,10 +131,10 @@ func resourceHvnRouteCreate(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.Errorf("unable to parse target_link for HVN route (%s): %v", hvnRouteID, err)
 	}
-	targetLink.Location.OrganizationID = loc.OrganizationID
+	targetLink.Location.OrganizationID = hvnLink.Location.OrganizationID
 
 	// Check for an existing HVN.
-	retrievedHvn, err := clients.GetHvnByID(ctx, client, loc, hvnLink.ID)
+	retrievedHvn, err := clients.GetHvnByID(ctx, client, hvnLink.Location, hvnLink.ID)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			return diag.Errorf("unable to find the HVN (%s) for the HVN route", hvnLink.ID)
@@ -141,7 +148,7 @@ func resourceHvnRouteCreate(ctx context.Context, d *schema.ResourceData, meta in
 	targetLink.Location.Region = retrievedHvn.Location.Region
 
 	// Create HVN route
-	hvnRouteResp, err := clients.CreateHVNRoute(ctx, client, hvnRouteID, hvnLink, destination, targetLink, loc)
+	hvnRouteResp, err := clients.CreateHVNRoute(ctx, client, hvnRouteID, hvnLink, destination, targetLink, hvnLink.Location)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -157,18 +164,18 @@ func resourceHvnRouteCreate(ctx context.Context, d *schema.ResourceData, meta in
 	d.SetId(url)
 
 	// Wait for HVN route to be created.
-	if err := clients.WaitForOperation(ctx, client, "create HVN route", loc, hvnRouteResp.Operation.ID); err != nil {
+	if err := clients.WaitForOperation(ctx, client, "create HVN route", hvnLink.Location, hvnRouteResp.Operation.ID); err != nil {
 		return diag.Errorf("unable to create HVN route (%s): %v", hvnRouteID, err)
 	}
 
 	log.Printf("[INFO] Created HVN route (%s)", hvnRouteID)
 
-	hvnRoute, err = clients.WaitForHVNRouteToBeActive(ctx, client, hvnLink.ID, hvnRouteID, loc, d.Timeout(schema.TimeoutCreate))
+	hvnRoute, err = clients.WaitForHVNRouteToBeActive(ctx, client, hvnLink.ID, hvnRouteID, hvnLink.Location, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := setHVNRouteResourceData(d, hvnRoute, loc); err != nil {
+	if err := setHVNRouteResourceData(d, hvnRoute, hvnLink.Location); err != nil {
 		return diag.FromErr(err)
 	}
 	return nil
@@ -180,32 +187,30 @@ func resourceHvnRouteRead(ctx context.Context, d *schema.ResourceData, meta inte
 	hvn := d.Get("hvn_link").(string)
 	var hvnLink *sharedmodels.HashicorpCloudLocationLink
 
-	hvnLink, err := parseLinkURL(hvn, HvnResourceType)
+	hvnLink, err := buildLinkFromURL(hvn, HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	idLink, err := buildLinkFromURL(d.Id(), HVNRouteResourceType, client.Config.OrganizationID)
+	routeLink, err := buildLinkFromURL(d.Id(), HVNRouteResourceType, hvnLink.Location.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	loc := idLink.Location
-
-	log.Printf("[INFO] Reading HVN route (%s)", idLink.ID)
-	route, err := clients.GetHVNRoute(ctx, client, hvnLink.ID, idLink.ID, loc)
+	log.Printf("[INFO] Reading HVN route (%s)", routeLink.ID)
+	route, err := clients.GetHVNRoute(ctx, client, hvnLink.ID, routeLink.ID, hvnLink.Location)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
-			log.Printf("[WARN] HVN route (%s) not found, removing from state", idLink.ID)
+			log.Printf("[WARN] HVN route (%s) not found, removing from state", routeLink.ID)
 			d.SetId("")
 			return nil
 		}
 
-		return diag.Errorf("unable to retrieve HVN route (%s): %v", idLink.ID, err)
+		return diag.Errorf("unable to retrieve HVN route (%s): %v", routeLink.ID, err)
 	}
 
 	// HVN route found, update resource data.
-	if err := setHVNRouteResourceData(d, route, loc); err != nil {
+	if err := setHVNRouteResourceData(d, route, hvnLink.Location); err != nil {
 		return diag.FromErr(err)
 	}
 	return nil
@@ -214,22 +219,21 @@ func resourceHvnRouteRead(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceHvnRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*clients.Client)
 
-	link, err := buildLinkFromURL(d.Id(), HVNRouteResourceType, client.Config.OrganizationID)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	routeID := link.ID
-	loc := link.Location
-
 	hvn := d.Get("hvn_link").(string)
-	hvnLink, err := buildLinkFromURL(hvn, HvnResourceType, loc.OrganizationID)
+	hvnLink, err := buildLinkFromURL(hvn, HvnResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	routeLink, err := buildLinkFromURL(d.Id(), HVNRouteResourceType, hvnLink.Location.OrganizationID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	routeID := routeLink.ID
 
 	log.Printf("[INFO] Deleting HVN route (%s)", routeID)
-	resp, err := clients.DeleteHVNRouteByID(ctx, client, hvnLink.ID, routeID, loc)
+	resp, err := clients.DeleteHVNRouteByID(ctx, client, hvnLink.ID, routeID, hvnLink.Location)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			log.Printf("[WARN] HVN route (%s) not found, so no action was taken", routeID)
@@ -239,7 +243,7 @@ func resourceHvnRouteDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("unable to delete HVN route (%s): %v", routeID, err)
 	}
 
-	if err := clients.WaitForOperation(ctx, client, "delete HVN route", loc, resp.Operation.ID); err != nil {
+	if err := clients.WaitForOperation(ctx, client, "delete HVN route", hvnLink.Location, resp.Operation.ID); err != nil {
 		return diag.Errorf("unable to delete HVN route (%s): %v", routeID, err)
 	}
 
@@ -266,6 +270,10 @@ func setHVNRouteResourceData(d *schema.ResourceData, route *networkmodels.Hashic
 	hvnLink := newLink(loc, route.Target.HvnConnection.Type, route.Target.HvnConnection.ID)
 	targetLink, err := linkURL(hvnLink)
 	if err != nil {
+		return err
+	}
+
+	if err := d.Set("project_id", loc.ProjectID); err != nil {
 		return err
 	}
 

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -192,7 +192,7 @@ func resourceHvnRouteRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
+		ProjectID:      idLink.Location.ProjectID,
 	}
 
 	log.Printf("[INFO] Reading HVN route (%s)", idLink.ID)

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -185,15 +185,12 @@ func resourceHvnRouteRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	idLink, err := parseLinkURL(d.Id(), HVNRouteResourceType)
+	idLink, err := buildLinkFromURL(d.Id(), HVNRouteResourceType, client.Config.OrganizationID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      idLink.Location.ProjectID,
-	}
+	loc := idLink.Location
 
 	log.Printf("[INFO] Reading HVN route (%s)", idLink.ID)
 	route, err := clients.GetHVNRoute(ctx, client, hvnLink.ID, idLink.ID, loc)

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -120,11 +120,16 @@ func resourcePackerChannel() *schema.Resource {
 
 func resourcePackerChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	bucketName := d.Get("bucket_name").(string)
+
 	client := meta.(*clients.Client)
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
+	}
 
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 	if err := setLocationData(d, loc); err != nil {
 		return diag.FromErr(err)
@@ -211,11 +216,15 @@ func resourcePackerChannelUpdate(ctx context.Context, d *schema.ResourceData, me
 	channelName := d.Get("name").(string)
 
 	client := meta.(*clients.Client)
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
 	}
 
+	loc := &sharedmodels.HashicorpCloudLocationLocation{
+		OrganizationID: client.Config.OrganizationID,
+		ProjectID:      projectID,
+	}
 	if err := setLocationData(d, loc); err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,15 +271,20 @@ func resourcePackerChannelDelete(ctx context.Context, d *schema.ResourceData, me
 	channelName := d.Get("name").(string)
 
 	client := meta.(*clients.Client)
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: client.Config.OrganizationID,
-		ProjectID:      client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 	if err := setLocationData(d, loc); err != nil {
 		return diag.FromErr(err)
 	}
 
-	_, err := clients.DeleteBucketChannel(ctx, client, loc, bucketName, channelName)
+	_, err = clients.DeleteBucketChannel(ctx, client, loc, bucketName, channelName)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -107,7 +107,7 @@ func resourceVaultClusterAdminTokenCreate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.Errorf("error creating HCP Vault cluster admin token (cluster_id %q) (project_id %q): %+v",
 			clusterID,
-			client.Config.ProjectID,
+			loc.ProjectID,
 			err,
 		)
 	}
@@ -137,11 +137,13 @@ func resourceVaultClusterAdminTokenRead(ctx context.Context, d *schema.ResourceD
 	client := meta.(*clients.Client)
 
 	clusterID := d.Get("cluster_id").(string)
-	organizationID := client.Config.OrganizationID
-	projectID := client.Config.ProjectID
+	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve project ID: %v", err)
+	}
 
 	loc := &models.HashicorpCloudLocationLocation{
-		OrganizationID: organizationID,
+		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 	}
 
@@ -187,7 +189,7 @@ func resourceVaultClusterAdminTokenRead(ctx context.Context, d *schema.ResourceD
 		if err != nil {
 			return diag.Errorf("error verifying HCP Vault cluster admin token (cluster_id %q) (project_id %q): %+v",
 				clusterID,
-				client.Config.ProjectID,
+				loc.ProjectID,
 				err,
 			)
 		}
@@ -204,7 +206,7 @@ func resourceVaultClusterAdminTokenRead(ctx context.Context, d *schema.ResourceD
 			if err != nil {
 				return diag.Errorf("error creating HCP Vault cluster admin token (cluster_id %q) (project_id %q): %+v",
 					clusterID,
-					client.Config.ProjectID,
+					loc.ProjectID,
 					err,
 				)
 			}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Fixes missing/incorrect resource-specific, resource-level `project_id` implementations for:

- `hcp_packer_channel`
  - Read (was missing)
  - Update (was missing)
  - Delete (was missing)
- `hcp_azure_peering_connection`
  - Create (was incorrect, assumed HVN used provider-level value)
- `data.hcp_azure_peering_connection`
  - Read (was incorrect, assumed HVN used provider-level value)
- `hcp_hvn_route`
  - Read (was missing)
- `hcp_vault_cluster_admin_token`
  - Read (was missing)
  - Logging (was incorrect, didn't pull from `loc`)
- `hcp_consul_cluster_root_token`
  - Read (was missing)
  - Delete (was missing)
- `data.consul_agent_helm_config`
  - Read (had redundant code)
- `hcp_boundary_cluster`
  - Update (was incorrect, implementation existed but was not used)

Deprecates some unnecessary fields on some resources and data sources:
- The `project_id` attribute is no longer settable for `hcp_hvn_peering_connection` and `data.hcp_hvn_peering_connection`. 
  - The value of the field was required to match the project ID for `hvn_1` and will now be automatically determined instead. 
  - **This is a breaking change that will require practitioners to remove the `project_id` field from the configuration for affected resources and data sources before the end of the deprecation period.**
  - During the deprecation period, the field will be settable, but practitioner-defined values will be ignored.
- The `project_id` attribute is no longer settable for `hcp_hvn_route` and `data.hcp_hvn_route`. 
  - The value of the field was required to match the project ID for `hvn_link` and will now be automatically determined instead. 
  - **This is a breaking change that will require practitioners to remove the `project_id` field from the configuration for affected resources and data sources before the end of the deprecation period.**
  - During the deprecation period, the field will be settable, but practitioner-defined values will be ignored.
- The `hvn_2` attribute is no longer settable for `data.hcp_hvn_peering_connection`. 
  - The value of the attribute is not needed to fetch data, and it was never validated against the real value for `hvn_2`, which may result in unintended behavior or unexpected errors downstream. The value will now be populated automatically. 
  - **This is a breaking change that will require practitioners to remove the `hvn_2` attribute from the configuration for affected data sources before the end of the deprecation period.**
  - During the deprecation period, the field will be settable, but practitioner-defined values will be ignored.

Also, minor code cleanliness changes for accessing the OrgID in some of the above (and some other) resources.

**_Modified resources and data sources may experience a minor regression with the following symptoms_** (Note: they may _already_ experience these symptoms):

- Resources/data sources where the resource-level `project_id` attribute was set at some point, but later removed from the configuration file, will continue to use the last known user-supplied value for the resource-level `project_id` attribute, regardless of any provider-level `project_id` value. 
- Resources/data sources that have never had a user-supplied resource-level `project_id` attribute will use the provider-level `project_id` value that was present when the resource was created. Updates to the provider-level `project_id` will not affect these resources.

This behavior is already present in some forms on some resources and data sources, and will be fixed in a later update. The regression is considered acceptable in this case because the missing/incorrect implementations for resource-level `project_id`s have undefined behavior that is potentially dangerous/destructive. 

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAcc.*PackerChannel.*'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAcc.*PackerChannel.* -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccPackerChannel
--- PASS: TestAccPackerChannel (9.71s)
=== RUN   TestAccPackerChannel_AssignedIteration
--- PASS: TestAccPackerChannel_AssignedIteration (9.57s)
=== RUN   TestAccPackerChannel_UpdateAssignedIteration
--- PASS: TestAccPackerChannel_UpdateAssignedIteration (15.23s)
=== RUN   TestAccPackerChannel_UpdateAssignedIterationWithFingerprint
--- PASS: TestAccPackerChannel_UpdateAssignedIterationWithFingerprint (7.14s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   42.031s
```

```
$ make testacc TESTARGS='-run=TestAcc.*HvnPeering.*'   
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAcc.*HvnPeering.* -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccHvnPeeringConnection
--- PASS: TestAccHvnPeeringConnection (175.02s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   175.331s
```
I don't have an environment configured for running acceptance tests on the provider other than for HCP Packer. **If someone else can run the remaining tests, that would be greatly appreciated.** 