### PR TITLE
[docs] Fix link to architecture image now that cloud website has moved

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-![HCP Architecture Diagram](https://content.hashicorp.com/api/assets?product=hcp-docs&version=refs%2Fheads%2Fmain&asset=public%2Fimg%2Fdocs%2Fhcp-arch-diagram.png&width=994&height=645&w=2048&q=75)
+![HCP Architecture Diagram](https://content.hashicorp.com/api/assets?product=hcp-docs&version=refs/heads/main&asset=public/img/docs/hcp-arch-diagram.png)
 
 ## Authenticating with HCP
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-![HCP Architecture Diagram](https://cloud.hashicorp.com/img/docs/hcp-arch-diagram.png)
+![HCP Architecture Diagram](https://content.hashicorp.com/api/assets?product=hcp-docs&version=refs%2Fheads%2Fmain&asset=public%2Fimg%2Fdocs%2Fhcp-arch-diagram.png&width=994&height=645&w=2048&q=75)
 
 ## Authenticating with HCP
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,7 +13,7 @@ description: |-
 
 The HCP provider provides resources to manage [HashiCorp Cloud Platform](https://cloud.hashicorp.com/) (HCP) resources.
 
-![HCP Architecture Diagram](https://cloud.hashicorp.com/img/docs/hcp-arch-diagram.png)
+![HCP Architecture Diagram](https://content.hashicorp.com/api/assets?product=hcp-docs&version=refs/heads/main&asset=public/img/docs/hcp-arch-diagram.png)
 
 ## Authenticating with HCP
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

The docs were pulling an image from cloud.hashicorp.com. We recently moved that domain, so this PR fixes the image sourcing. 

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

No acceptance testing necessary, but I did check that the image link renders well by putting the markdown into https://registry.terraform.io/tools/doc-preview
