### PR TITLE
HPR-1208: Fix panic when `hcp_packer_image` points to an empty channel

### DIFF
--- a/.changelog/533.txt
+++ b/.changelog/533.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed panic when `hcp_packer_image` points to a channel without an assigned iteration.
+```

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -160,7 +160,7 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 			channelSlug)
 		if err != nil {
 			return diag.FromErr(err)
-		} 
+		}
 		if channel.Iteration == nil {
 			return diag.Errorf("Channel does not have an assigned iteration (channel: %s)", channelSlug)
 		}

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -160,7 +160,8 @@ func dataSourcePackerImageRead(ctx context.Context, d *schema.ResourceData, meta
 			channelSlug)
 		if err != nil {
 			return diag.FromErr(err)
-		} else if channel.Iteration == nil {
+		} 
+		if channel.Iteration == nil {
 			return diag.Errorf("Channel does not have an assigned iteration (channel: %s)", channelSlug)
 		}
 		iteration = channel.Iteration

--- a/internal/provider/data_source_packer_image_iteration_test.go
+++ b/internal/provider/data_source_packer_image_iteration_test.go
@@ -320,7 +320,7 @@ func upsertBuild(t *testing.T, bucketSlug, fingerprint, iterationID string) {
 	}
 }
 
-func createChannel(t *testing.T, bucketSlug, channelSlug, iterationID string) {
+func upsertChannel(t *testing.T, bucketSlug, channelSlug, iterationID string) {
 	t.Helper()
 
 	client := testAccProvider.Meta().(*clients.Client)
@@ -484,7 +484,7 @@ func TestAcc_dataSourcePacker(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestAlpineBucket, fingerprint, itID)
-					createChannel(t, acctestAlpineBucket, acctestProductionChannel, itID)
+					upsertChannel(t, acctestAlpineBucket, acctestProductionChannel, itID)
 				},
 				Config: testConfig(testAccPackerAlpineProductionImage),
 				Check: resource.ComposeTestCheckFunc(
@@ -522,7 +522,7 @@ func TestAcc_dataSourcePacker_revokedIteration(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestUbuntuBucket, fingerprint, itID)
-					createChannel(t, acctestUbuntuBucket, acctestProductionChannel, itID)
+					upsertChannel(t, acctestUbuntuBucket, acctestProductionChannel, itID)
 					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
 					// it's assigned to a channel
 					revokeIteration(t, itID, acctestUbuntuBucket, revokeAt)

--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -139,7 +139,7 @@ func TestAcc_dataSourcePackerImage(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestImageBucket, fingerprint, itID)
-					createChannel(t, acctestImageBucket, acctestImageChannel, itID)
+					upsertChannel(t, acctestImageBucket, acctestImageChannel, itID)
 				},
 				Config: testAccPackerImageAlpineProduction,
 				Check: resource.ComposeTestCheckFunc(
@@ -183,18 +183,40 @@ func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestUbuntuImageBucket, fingerprint, itID)
-					createChannel(t, acctestUbuntuImageBucket, acctestImageChannel, itID)
+					upsertChannel(t, acctestUbuntuImageBucket, acctestImageChannel, itID)
 					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
 					// it's assigned to a channel
 					revokeIteration(t, itID, acctestUbuntuImageBucket, revokeAt)
-					// Sleep to make sure the iteration is revoked when we test
-					time.Sleep(5 * time.Second)
 				},
 				Config: testConfig(testAccPackerImageUbuntuProduction),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "revoke_at", revokeAt.String()),
 					resource.TestCheckResourceAttr("data.hcp_packer_image.ubuntu-foo", "cloud_image_id", "ami-42"),
 				),
+			},
+		},
+	})
+}
+
+func TestAcc_dataSourcePackerImage_emptyChannel(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
+		ProviderFactories: providerFactories,
+		CheckDestroy: func(*terraform.State) error {
+			deleteChannel(t, acctestArchImageBucket, acctestImageChannel, true)
+			deleteBucket(t, acctestArchImageBucket, true)
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				PlanOnly: true,
+				PreConfig: func() {
+					upsertRegistry(t)
+					upsertBucket(t, acctestArchImageBucket)
+					upsertChannel(t, acctestArchImageBucket, acctestImageChannel, "")
+				},
+				Config:      testConfig(testAccPackerImageArchProduction),
+				ExpectError: regexp.MustCompile(`.*Channel does not have an assigned iteration.*`),
 			},
 		},
 	})
@@ -228,7 +250,7 @@ func TestAcc_dataSourcePackerImage_channelAndIterationIDReject(t *testing.T) {
 							t.Fatal(err.Error())
 						}
 						upsertBuild(t, acctestArchImageBucket, fingerprint, itID)
-						createChannel(t, acctestArchImageBucket, acctestImageChannel, itID)
+						upsertChannel(t, acctestArchImageBucket, acctestImageChannel, itID)
 					},
 					Config:      testConfig(cfg),
 					ExpectError: regexp.MustCompile("Error: Invalid combination of arguments"),
@@ -261,7 +283,7 @@ func TestAcc_dataSourcePackerImage_channelAccept(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestArchImageBucket, fingerprint, itID)
-					createChannel(t, acctestArchImageBucket, acctestImageChannel, itID)
+					upsertChannel(t, acctestArchImageBucket, acctestImageChannel, itID)
 				},
 				Config: testConfig(testAccPackerImageArchProduction),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -65,7 +65,7 @@ func TestAcc_dataSourcePackerIteration(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestIterationBucket, fingerprint, itID)
-					createChannel(t, acctestIterationBucket, acctestIterationChannel, itID)
+					upsertChannel(t, acctestIterationBucket, acctestIterationChannel, itID)
 				},
 				Config: testConfig(testAccPackerIterationAlpineProduction),
 				Check: resource.ComposeTestCheckFunc(
@@ -103,7 +103,7 @@ func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
 						t.Fatal(err.Error())
 					}
 					upsertBuild(t, acctestIterationUbuntuBucket, fingerprint, itID)
-					createChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, itID)
+					upsertChannel(t, acctestIterationUbuntuBucket, acctestIterationChannel, itID)
 					// Schedule revocation to the future, otherwise we won't be able to revoke an iteration that
 					// it's assigned to a channel
 					revokeIteration(t, itID, acctestIterationUbuntuBucket, revokeAt)


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixes #526 
Fixes #496 

- Fixes a bug where the image data source crashes when the channel it points to doesn't have an iteration assigned
- Adds a unit test for an empty channel 

### :building_construction: Acceptance tests

- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAcc.*PackerImage.* -test.v'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAcc.*PackerImage.* -test.v -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.468s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.934s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (9.02s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (5.72s)
=== RUN   TestAcc_dataSourcePackerImage_emptyChannel
--- PASS: TestAcc_dataSourcePackerImage_emptyChannel (1.43s)
=== RUN   TestAcc_dataSourcePackerImage_channelAndIterationIDReject
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (3.90s)
=== RUN   TestAcc_dataSourcePackerImage_channelAccept
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (6.04s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   26.774s
```
