### PR TITLE
[CC-5321] Add premium to Consul Cluster tier's description

### DIFF
--- a/.changelog/537.txt
+++ b/.changelog/537.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add "premium" to descriptions about Consul Cluster tier
+```

--- a/docs/data-sources/consul_cluster.md
+++ b/docs/data-sources/consul_cluster.md
@@ -57,7 +57,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `self_link` (String) A unique URL identifying the HCP Consul cluster.
 - `size` (String) The t-shirt size representation of each server VM that this Consul cluster is provisioned with. Valid option for development tier - `x_small`. Valid options for other tiers - `small`, `medium`, `large`. For more details - https://cloud.hashicorp.com/pricing/consul
 - `state` (String) The state of the HCP Consul cluster.
-- `tier` (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard` and `plus` are available at this time.
+- `tier` (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard`, `plus`, and `premium` are available at this time.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/consul_cluster.md
+++ b/docs/resources/consul_cluster.md
@@ -34,7 +34,7 @@ resource "hcp_consul_cluster" "example" {
 
 - `cluster_id` (String) The ID of the HCP Consul cluster.
 - `hvn_id` (String) The ID of the HVN this HCP Consul cluster is associated to.
-- `tier` (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard` and `plus` are available at this time. See [pricing information](https://www.hashicorp.com/products/consul/pricing).
+- `tier` (String) The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard`, `plus`, and `premium` are available at this time. See [pricing information](https://www.hashicorp.com/products/consul/pricing).
 
 ### Optional
 

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -130,7 +130,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Computed:    true,
 			},
 			"tier": {
-				Description: "The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard` and `plus` are available at this time.",
+				Description: "The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard`, `plus`, and `premium` are available at this time.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -68,7 +68,7 @@ func resourceConsulCluster() *schema.Resource {
 				ValidateDiagFunc: validateSlugID,
 			},
 			"tier": {
-				Description:      "The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard` and `plus` are available at this time. See [pricing information](https://www.hashicorp.com/products/consul/pricing).",
+				Description:      "The tier that the HCP Consul cluster will be provisioned as.  Only `development`, `standard`, `plus`, and `premium` are available at this time. See [pricing information](https://www.hashicorp.com/products/consul/pricing).",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

This is just a docs change. This adds the `premium` tier to Consul Cluster: https://www.hashicorp.com/products/consul/pricing

It's already supported in the backing Go code as an enum:

```
	// HashicorpCloudConsul20210204ClusterConfigTierPREMIUM captures enum value "PREMIUM"
	HashicorpCloudConsul20210204ClusterConfigTierPREMIUM HashicorpCloudConsul20210204ClusterConfigTier = "PREMIUM"
```

JIRA: https://hashicorp.atlassian.net/browse/CC-5321

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
