### PR TITLE
Move Statuspage.io config to a dedicated file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,4 +23,4 @@
 *boundary* @hashicorp/boundary-cloud
 
 # Statuspage.io configuration is owned by the Core SRE team
-/internal/provider/provider.go @hashicorp/core-sre @hashicorp/experiences-platform
+/internal/provider/statuspage.go @hashicorp/core-sre 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,10 +5,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"time"
 
@@ -201,28 +197,6 @@ func getProjectFromCredentials(ctx context.Context, client *clients.Client) (pro
 	return project, diags
 }
 
-// Status endpoint for prod.
-const statuspageURL = "https://status.hashicorp.com/api/v2/components.json"
-
-var hcpComponentIds = map[string]string{
-	"0q55nwmxngkc": "HCP API",
-	"sxffkgfb4fhb": "HCP Consul",
-	"0mbkqnrzg33w": "HCP Packer",
-	"mgv1p2j9x444": "HCP Portal",
-	"mb7xrbx9gjnq": "HCP Vault",
-}
-
-type statuspage struct {
-	Components []component `json:"components"`
-}
-
-type component struct {
-	ID     string `json:"id"`
-	Status status `json:"status"`
-}
-
-type status string
-
 // getOldestProject retrieves the oldest project from a list based on its created_at time.
 func getOldestProject(projects []*models.ResourcemanagerProject) (oldestProj *models.ResourcemanagerProject) {
 	oldestTime := time.Now()
@@ -235,96 +209,4 @@ func getOldestProject(projects []*models.ResourcemanagerProject) (oldestProj *mo
 		}
 	}
 	return oldestProj
-}
-
-func isHCPOperational() (diags diag.Diagnostics) {
-	req, err := http.NewRequest("GET", statuspageURL, nil)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "You may experience issues using HCP.",
-			Detail:   fmt.Sprintf("Unable to create request to verify HCP status: %s", err),
-		})
-
-		return diags
-	}
-
-	var cl = http.Client{}
-	resp, err := cl.Do(req)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "You may experience issues using HCP.",
-			Detail:   fmt.Sprintf("Unable to complete request to verify HCP status: %s", err),
-		})
-
-		return diags
-	}
-	defer resp.Body.Close()
-
-	jsBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "You may experience issues using HCP.",
-			Detail:   fmt.Sprintf("Unable read response to verify HCP status: %s", err),
-		})
-
-		return diags
-	}
-
-	sp := statuspage{}
-	err = json.Unmarshal(jsBytes, &sp)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "You may experience issues using HCP.",
-			Detail:   fmt.Sprintf("Unable unmarshal response to verify HCP status: %s", err),
-		})
-
-		return diags
-	}
-
-	// Translate the status page component IDs into a map of component name and operation status.
-	var systemStatus = map[string]status{}
-
-	for _, c := range sp.Components {
-		name, ok := hcpComponentIds[c.ID]
-		if ok {
-			systemStatus[name] = c.Status
-		}
-	}
-
-	operational := true
-	for _, st := range systemStatus {
-		if st != "operational" {
-			operational = false
-		}
-	}
-
-	if !operational {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "You may experience issues using HCP.",
-			Detail:   fmt.Sprintf("HCP is reporting the following:\n\n%v\nPlease check https://status.hashicorp.com for more details.", printStatus(systemStatus)),
-		})
-	}
-
-	return diags
-}
-
-func printStatus(m map[string]status) string {
-	var maxLenKey int
-	for k := range m {
-		if len(k) > maxLenKey {
-			maxLenKey = len(k)
-		}
-	}
-
-	pr := ""
-	for k, v := range m {
-		pr += fmt.Sprintf("%s:%*s %s\n", k, 5+(maxLenKey-len(k)), " ", v)
-	}
-
-	return pr
 }

--- a/internal/provider/statuspage.go
+++ b/internal/provider/statuspage.go
@@ -1,0 +1,124 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// Status endpoint for prod.
+const statuspageURL = "https://status.hashicorp.com/api/v2/components.json"
+
+var hcpComponentIds = map[string]string{
+	"0q55nwmxngkc": "HCP API",
+	"sxffkgfb4fhb": "HCP Consul",
+	"0mbkqnrzg33w": "HCP Packer",
+	"mgv1p2j9x444": "HCP Portal",
+	"mb7xrbx9gjnq": "HCP Vault",
+}
+
+type statuspage struct {
+	Components []component `json:"components"`
+}
+
+type component struct {
+	ID     string `json:"id"`
+	Status status `json:"status"`
+}
+
+type status string
+
+func isHCPOperational() (diags diag.Diagnostics) {
+	req, err := http.NewRequest("GET", statuspageURL, nil)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "You may experience issues using HCP.",
+			Detail:   fmt.Sprintf("Unable to create request to verify HCP status: %s", err),
+		})
+
+		return diags
+	}
+
+	var cl = http.Client{}
+	resp, err := cl.Do(req)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "You may experience issues using HCP.",
+			Detail:   fmt.Sprintf("Unable to complete request to verify HCP status: %s", err),
+		})
+
+		return diags
+	}
+	defer resp.Body.Close()
+
+	jsBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "You may experience issues using HCP.",
+			Detail:   fmt.Sprintf("Unable read response to verify HCP status: %s", err),
+		})
+
+		return diags
+	}
+
+	sp := statuspage{}
+	err = json.Unmarshal(jsBytes, &sp)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "You may experience issues using HCP.",
+			Detail:   fmt.Sprintf("Unable unmarshal response to verify HCP status: %s", err),
+		})
+
+		return diags
+	}
+
+	// Translate the status page component IDs into a map of component name and operation status.
+	var systemStatus = map[string]status{}
+
+	for _, c := range sp.Components {
+		name, ok := hcpComponentIds[c.ID]
+		if ok {
+			systemStatus[name] = c.Status
+		}
+	}
+
+	operational := true
+	for _, st := range systemStatus {
+		if st != "operational" {
+			operational = false
+		}
+	}
+
+	if !operational {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "You may experience issues using HCP.",
+			Detail:   fmt.Sprintf("HCP is reporting the following:\n\n%v\nPlease check https://status.hashicorp.com for more details.", printStatus(systemStatus)),
+		})
+	}
+
+	return diags
+}
+
+func printStatus(m map[string]status) string {
+	var maxLenKey int
+	for k := range m {
+		if len(k) > maxLenKey {
+			maxLenKey = len(k)
+		}
+	}
+
+	pr := ""
+	for k, v := range m {
+		pr += fmt.Sprintf("%s:%*s %s\n", k, 5+(maxLenKey-len(k)), " ", v)
+	}
+
+	return pr
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

Currently, adding a new resource/datasource requires approval from @hashicorp/core-sre because they own the Statuspage.io configuration in `provider.go`, where new resources are configured.

- Moves the Statuspage.io config to a new dedicated file
- Updates CODEOWNERS respectively
  - @hashicorp/experiences-platform doesn't exist, so it is removed
  - @hashicorp/core-sre removed from `provider.go` and added to `statuspage.go`

### :building_construction: Acceptance tests

- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=Test.*Provider.* -test.v'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=Test.*Provider.* -test.v -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.443s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.176s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.203s [no tests to run]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   0.579s
```
