### PR TITLE
Do not swallow sdk error

### DIFF
--- a/.changelog/542.txt
+++ b/.changelog/542.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Capture unknown error from SDK when getting project or organization.
+```

--- a/.changelog/542.txt
+++ b/.changelog/542.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
-Capture unknown error from SDK when getting project or organization.
+```release-note:bug
+Capture unknown errors from the HCP Go SDK when getting project or organization, where errors were previously replaced with a static message.
 ```

--- a/internal/clients/retry_request.go
+++ b/internal/clients/retry_request.go
@@ -17,10 +17,6 @@ const (
 	counterStart = 1
 )
 
-func unknownError(err error) error {
-	return fmt.Errorf("unknown err: %w, please ensure your HCP_API_HOST, HCP_CLIENT_ID, and HCP_CLIENT_SECRET are correct", err)
-}
-
 var errorCodesToRetry = [...]int{502, 503, 504}
 
 // Helper to check what requests to retry based on the response HTTP code
@@ -40,7 +36,7 @@ func RetryOrganizationServiceList(client *Client, params *organization_service.O
 	if err != nil {
 		serviceErr, ok := err.(*organization_service.OrganizationServiceListDefault)
 		if !ok {
-			return nil, unknownError(err)
+			return nil, err
 		}
 		counter := counterStart
 		for shouldRetryErrorCode(serviceErr.Code(), errorCodesToRetry[:]) && counter < retryCount {
@@ -66,7 +62,7 @@ func RetryProjectServiceList(client *Client, params *project_service.ProjectServ
 	if err != nil {
 		serviceErr, ok := err.(*project_service.ProjectServiceListDefault)
 		if !ok {
-			return nil, unknownError(err)
+			return nil, err
 		}
 
 		counter := counterStart
@@ -93,7 +89,7 @@ func RetryProjectServiceGet(client *Client, params *project_service.ProjectServi
 	if err != nil {
 		serviceErr, ok := err.(*project_service.ProjectServiceGetDefault)
 		if !ok {
-			return nil, unknownError(err)
+			return nil, err
 		}
 
 		counter := counterStart

--- a/internal/clients/retry_request.go
+++ b/internal/clients/retry_request.go
@@ -4,9 +4,7 @@
 package clients
 
 import (
-	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
@@ -14,11 +12,14 @@ import (
 )
 
 const (
-	retryCount          = 10
-	retryDelay          = 10
-	counterStart        = 1
-	unknownErrorMessage = "could not complete request: please ensure your HCP_API_HOST, HCP_CLIENT_ID, and HCP_CLIENT_SECRET are correct"
+	retryCount   = 10
+	retryDelay   = 10
+	counterStart = 1
 )
+
+func unknownError(err error) error {
+	return fmt.Errorf("unknown err: %w, please ensure your HCP_API_HOST, HCP_CLIENT_ID, and HCP_CLIENT_SECRET are correct", err)
+}
 
 var errorCodesToRetry = [...]int{502, 503, 504}
 
@@ -37,11 +38,12 @@ func RetryOrganizationServiceList(client *Client, params *organization_service.O
 	resp, err := client.Organization.OrganizationServiceList(params, nil)
 
 	if err != nil {
-		if reflect.TypeOf(err.Error()).Name() != "organization_service.OrganizationServiceListDefault" {
-			return nil, errors.New(unknownErrorMessage)
+		serviceErr, ok := err.(*organization_service.OrganizationServiceListDefault)
+		if !ok {
+			return nil, unknownError(err)
 		}
 		counter := counterStart
-		for shouldRetryErrorCode(err.(*organization_service.OrganizationServiceListDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+		for shouldRetryErrorCode(serviceErr.Code(), errorCodesToRetry[:]) && counter < retryCount {
 			resp, err = client.Organization.OrganizationServiceList(params, nil)
 			if err == nil {
 				break
@@ -62,12 +64,13 @@ func RetryProjectServiceList(client *Client, params *project_service.ProjectServ
 	resp, err := client.Project.ProjectServiceList(params, nil)
 
 	if err != nil {
-		if reflect.TypeOf(err.Error()).Name() != "project_service.ProjectServiceListDefault" {
-			return nil, errors.New(unknownErrorMessage)
+		serviceErr, ok := err.(*project_service.ProjectServiceListDefault)
+		if !ok {
+			return nil, unknownError(err)
 		}
 
 		counter := counterStart
-		for shouldRetryErrorCode(err.(*project_service.ProjectServiceListDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+		for shouldRetryErrorCode(serviceErr.Code(), errorCodesToRetry[:]) && counter < retryCount {
 			resp, err = client.Project.ProjectServiceList(params, nil)
 			if err == nil {
 				break
@@ -88,12 +91,13 @@ func RetryProjectServiceGet(client *Client, params *project_service.ProjectServi
 	resp, err := client.Project.ProjectServiceGet(params, nil)
 
 	if err != nil {
-		if reflect.TypeOf(err.Error()).Name() != "project_service.ProjectServiceGetDefault" {
-			return nil, errors.New(unknownErrorMessage)
+		serviceErr, ok := err.(*project_service.ProjectServiceGetDefault)
+		if !ok {
+			return nil, unknownError(err)
 		}
 
 		counter := counterStart
-		for shouldRetryErrorCode(err.(*project_service.ProjectServiceGetDefault).Code(), errorCodesToRetry[:]) && counter < retryCount {
+		for shouldRetryErrorCode(serviceErr.Code(), errorCodesToRetry[:]) && counter < retryCount {
 			resp, err = client.Project.ProjectServiceGet(params, nil)
 			if err == nil {
 				break


### PR DESCRIPTION
### :hammer_and_wrench: Description

If the error is returned from hcp-sdk is not known then wrap it before returning instead of swallowing it completely. Currently, its impossible to decipher what went wrong just from logs.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
https://gist.github.com/aidan-mundy/bcda1f2c7be52d3a2e152d5ab9d3d622

The three failing tests have been persistent failures for a while, and are unrelated to this PR. 
