### PR TITLE
Add tier configuration for HCP Boundary

### DIFF
--- a/.changelog/544.txt
+++ b/.changelog/544.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Adds `tier` to the `hcp_boundary_cluster` resource to manage the cluster pricing and feature set.
+```

--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -39,6 +39,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `id` (String) The ID of this resource.
 - `maintenance_window_config` (List of Object) (see [below for nested schema](#nestedatt--maintenance_window_config))
 - `state` (String) The state of the Boundary cluster.
+- `tier` (String) The tier of the Boundary cluster.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -33,6 +33,7 @@ resource "hcp_boundary_cluster" "example" {
 
 - `cluster_id` (String) The ID of the Boundary cluster
 - `password` (String, Sensitive) The password of the initial admin user. This must be at least 8 characters in length. Note that this may show up in logs, and it will be stored in the state file.
+- `tier` (String) The tier that the HCP Boundary cluster will be provisioned as, 'Standard' or 'Plus'.
 - `username` (String) The username of the initial admin user. This must be at least 3 characters in length, alphanumeric, hyphen, or period.
 
 ### Optional

--- a/internal/provider/data_source_boundary_cluster.go
+++ b/internal/provider/data_source_boundary_cluster.go
@@ -56,6 +56,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"tier": {
+				Description: "The tier of the Boundary cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"maintenance_window_config": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/internal/provider/resource_boundary_cluster_test.go
+++ b/internal/provider/resource_boundary_cluster_test.go
@@ -21,6 +21,7 @@ resource hcp_boundary_cluster "test" {
 	cluster_id = "%[1]s"
 	username = "test-user"
 	password = "password123!"
+	tier = "PLUS"
 	%%s
 }
 `, boundaryUniqueID)
@@ -66,6 +67,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "cluster_url"),
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 				),
 			},
 			{
@@ -93,6 +95,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "cluster_url"),
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 				),
 			},
 			{
@@ -104,6 +107,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrPair(boundaryClusterResourceName, "cluster_url", boundaryClusterDataSourceName, "cluster_url"),
 					testAccCheckFullURL(boundaryClusterDataSourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrPair(boundaryClusterResourceName, "state", boundaryClusterDataSourceName, "state"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 				),
 			},
 			{
@@ -116,6 +120,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "cluster_url"),
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.upgrade_type", "SCHEDULED"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.day", "TUESDAY"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.start", "2"),


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Adds cluter `Tier` configuration for HCP Boundary clusters. A cluster can either be `PLUS` OR `STANDARD` tier.

More about HCP Boundary tiers: https://www.hashicorp.com/products/boundary/pricing

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
➜  terraform-provider-hcp git:(uruemu/ICU-9830) ✗ make testacc TESTARGS='-run=TestAccBoundaryCluster'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccBoundaryCluster -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccBoundaryCluster
--- PASS: TestAccBoundaryCluster (146.78s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   147.301s
```
