### PR TITLE
HPR-1123: Resolve panics when Packer client helpers receive unexpected error formats

### DIFF
--- a/.changelog/545.txt
+++ b/.changelog/545.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Resolve panics when Packer API client helpers receive unexpected error formats
+```


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Resolves panics when Packer client helpers receive unexpected error formats
  - Error is now returned if we fail to cast to the expected error format

Changes should improve visibility into #538 if it recurs

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=Test.*Packer.* -test.v'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=Test.*Packer.* -test.v -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.456s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAcc_dataSourcePackerBucketNames
--- PASS: TestAcc_dataSourcePackerBucketNames (19.94s)
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (6.54s)
=== RUN   TestAcc_dataSourcePacker_revokedIteration
--- PASS: TestAcc_dataSourcePacker_revokedIteration (11.04s)
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (7.32s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (5.76s)
=== RUN   TestAcc_dataSourcePackerImage_emptyChannel
--- PASS: TestAcc_dataSourcePackerImage_emptyChannel (1.36s)
=== RUN   TestAcc_dataSourcePackerImage_channelAndIterationIDReject
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (3.45s)
=== RUN   TestAcc_dataSourcePackerImage_channelAccept
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (6.15s)
=== RUN   TestAcc_dataSourcePackerIteration
--- PASS: TestAcc_dataSourcePackerIteration (5.66s)
=== RUN   TestAcc_dataSourcePackerIteration_revokedIteration
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (10.94s)
=== RUN   TestAccPackerChannelAssignment_SimpleSetUnset
--- PASS: TestAccPackerChannelAssignment_SimpleSetUnset (13.48s)
=== RUN   TestAccPackerChannelAssignment_AssignLatest
--- PASS: TestAccPackerChannelAssignment_AssignLatest (15.21s)
=== RUN   TestAccPackerChannelAssignment_InvalidInputs
--- PASS: TestAccPackerChannelAssignment_InvalidInputs (6.28s)
=== RUN   TestAccPackerChannelAssignment_CreateFailsWhenPreassigned
--- PASS: TestAccPackerChannelAssignment_CreateFailsWhenPreassigned (8.22s)
=== RUN   TestAccPackerChannelAssignment_HCPManagedChannelErrors
--- PASS: TestAccPackerChannelAssignment_HCPManagedChannelErrors (3.31s)
=== RUN   TestAccPackerChannelAssignment_EnforceNull
--- PASS: TestAccPackerChannelAssignment_EnforceNull (29.72s)
=== RUN   TestAccPackerChannel
--- PASS: TestAccPackerChannel (6.57s)
=== RUN   TestAccPackerChannel_AssignedIteration
--- PASS: TestAccPackerChannel_AssignedIteration (7.97s)
=== RUN   TestAccPackerChannel_UpdateAssignedIteration
--- PASS: TestAccPackerChannel_UpdateAssignedIteration (13.20s)
=== RUN   TestAccPackerChannel_UpdateAssignedIterationWithFingerprint
--- PASS: TestAccPackerChannel_UpdateAssignedIterationWithFingerprint (6.02s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   188.738s
```
