### PR TITLE
Fix test cleanup for `ChannelAssignment_HCPManagedChannelErrors`

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -33,9 +33,12 @@ var testAccProviderConfigure sync.Once
 // providerFactories are used to instantiate a provider during acceptance testing.
 // The factory function will be invoked for every Terraform CLI command executed
 // to create a provider server to which the CLI can reattach.
-var providerFactories = map[string]func() (*schema.Provider, error){
+var providerFactories = map[string](func() (*schema.Provider, error)){
 	"hcp": func() (*schema.Provider, error) {
 		return New()(), nil
+	},
+	"dummy": func() (*schema.Provider, error) {
+		return testAccNewDummyProvider(), nil
 	},
 }
 

--- a/internal/provider/resource_packer_channel_assignment_test.go
+++ b/internal/provider/resource_packer_channel_assignment_test.go
@@ -301,6 +301,9 @@ func TestAccPackerChannelAssignment_HCPManagedChannelErrors(t *testing.T) {
 				ImportStateId: fmt.Sprintf("%s:%s", bucketSlug, channelSlug),
 				ExpectError:   regexp.MustCompile(".*channel with.*is managed by HCP Packer.*"),
 			},
+			{ // Create a dummy non-empty state so that `CheckDestroy` will run.
+				Config: testAccConfigDummyNonemptyState,
+			},
 		},
 	})
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

The testing system will not run `CheckDestroy` for tests that don't generate a non-empty state.

- Adds a dummy testing-only provider and dummy testing-only resource that can be used to force the testing system to generate a non-empty state without performing any real actions.
  - This could be done using the `null` provider instead, but would require extra configuration from tests that need to use it. This solution adds code that is effectively a one-liner fix for tests that run into this issue. 
- Fixes an issue where one of the channel assignment tests wasn't running `CheckDestroy` which is used to clean up the bucket created in `PreCheck`, leading to environment pollution with buckets created in prior testing runs.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=Test.*Packer.*HCP.* -test.v -count=1 -v'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=Test.*Packer.*HCP.* -test.v -count=1 -v -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.370s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.405s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.133s [no tests to run]
=== RUN   TestAccPackerChannelAssignment_HCPManagedChannelErrors
--- PASS: TestAccPackerChannelAssignment_HCPManagedChannelErrors (5.01s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   5.694s```
