### PR TITLE
Case insensitive HCP Boundary tier configuration 

### DIFF
--- a/.changelog/554.txt
+++ b/.changelog/554.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Updated Boundary `Tier` configuration to be case insensitive.
+```

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -106,6 +106,9 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"STANDARD", "PLUS"}, true),
 				Required:     true,
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					return strings.EqualFold(oldValue, newValue)
+				},
 			},
 			"maintenance_window_config": {
 				Type:        schema.TypeList,
@@ -177,6 +180,7 @@ func resourceBoundaryClusterCreate(ctx context.Context, d *schema.ResourceData, 
 	tier := d.Get("tier").(string)
 	var tierPb boundarymodels.HashicorpCloudBoundary20211221ClusterMarketingSKU
 	if tier != "" {
+		tier = strings.ToUpper(tier)
 		tier = boundaryClusterTierPrefix + tier
 		tierPb = boundarymodels.HashicorpCloudBoundary20211221ClusterMarketingSKU(tier)
 	}
@@ -464,6 +468,7 @@ func setBoundaryClusterResourceData(d *schema.ResourceData, cluster *boundarymod
 	}
 
 	tierStr := strings.TrimPrefix(string(*cluster.MarketingSku), boundaryClusterTierPrefix)
+	tierStr = strings.ToUpper(tierStr)
 	if err := d.Set("tier", tierStr); err != nil {
 		return err
 	}

--- a/internal/provider/resource_boundary_cluster_test.go
+++ b/internal/provider/resource_boundary_cluster_test.go
@@ -21,7 +21,7 @@ resource hcp_boundary_cluster "test" {
 	cluster_id = "%[1]s"
 	username = "test-user"
 	password = "password123!"
-	tier = "PLUS"
+	tier = "PluS"
 	%%s
 }
 `, boundaryUniqueID)


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Builds upon #544. Makes the tier configration case insensitive

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
