### PR TITLE
Bump github.com/hashicorp/hcp-sdk-go from 0.49.0 to 0.54.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcp-sdk-go v0.49.0
+	github.com/hashicorp/hcp-sdk-go v0.54.0
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/hashicorp/hc-install v0.5.2 h1:SfwMFnEXVVirpwkDuSF5kymUOhrUxrTq3udEse
 github.com/hashicorp/hc-install v0.5.2/go.mod h1:9QISwe6newMWIfEiXpzuu1k9HAGtQYgnSH8H9T8wmoI=
 github.com/hashicorp/hcl/v2 v2.16.1 h1:BwuxEMD/tsYgbhIW7UuI3crjovf3MzuFWiVgiv57iHg=
 github.com/hashicorp/hcl/v2 v2.16.1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
-github.com/hashicorp/hcp-sdk-go v0.49.0 h1:eKjJfDdngfIB17G8EmzMWJmye3daK+UbxWO9qjPVS1Q=
-github.com/hashicorp/hcp-sdk-go v0.49.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
+github.com/hashicorp/hcp-sdk-go v0.54.0 h1:7cyymgoRFGzmmUHohuzi8Jf3u5zShZpfg+2EHTXJh3M=
+github.com/hashicorp/hcp-sdk-go v0.54.0/go.mod h1:hZqky4HEzsKwvLOt4QJlZUrjeQmb4UCZUhDP2HyQFfc=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Bump github.com/hashicorp/hcp-sdk-go from 0.49.0 to 0.54.0

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

[Test Workflow](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/5651160290/job/15308785105)