### PR TITLE
Add concurrency group to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
         type: string
         default: 'Test.*'
 
+concurrency: acceptance-testing-environment
+
 permissions:
   contents: read
     


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Add concurrency group to test workflow
  - Prevents multiple acceptance testing jobs from running at the same time, which could cause unexpected outcomes.