### PR TITLE
Stop `Prerelease` workflow if the Changelog for the released version would be empty

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -88,6 +88,11 @@ jobs:
           CHANGELOG=$(changelog-build -changelog-template .changelog/changelog.tmpl -note-template .changelog/note.tmpl -entries-dir .changelog/ -last-release ${CURRENT_VERSION} -this-release ${GIT_COMMIT_SHA})
           
           echo "## ${NEW_VERSION} Changelog" >> $GITHUB_STEP_SUMMARY
+          if [[ $CHANGELOG == "" ]]; then
+            echo "Changelog was empty. Add at least one changelog entry to \`.changelog/\`." >> $GITHUB_STEP_SUMMARY
+            echo "Changelog was empty. Add at least one changelog entry to \`.changelog/\`. Exiting."
+            exit 1
+          fi
           echo -e "${CHANGELOG}" >> $GITHUB_STEP_SUMMARY
 
           DATE=$(date '+%B %d, %Y')
@@ -114,7 +119,7 @@ jobs:
           git diff @{upstream} @
 
       - name: Release New Version
-        if: ${{ github.ref_name == 'main' && steps.changes.outputs.HAS_CHANGES == 'true' }}
+        if: success() && github.ref_name == 'main' && steps.changes.outputs.HAS_CHANGES == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
         run: |


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Stops the `Prerelease` workflow if the Changelog for the released version would be empty.
  - Prevents automated releases from being triggered when the only changes since the last release are meta changes (like this PR) that don't affect the provider functionality (and thus don't get a changelog). 
  - Prevents releases from being triggered when changes are made that affect the provider functionality, but no changelogs were added since the last release. 

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:
https://github.com/hashicorp/terraform-provider-hcp/actions/runs/5672099858
https://github.com/hashicorp/terraform-provider-hcp/actions/runs/5672099858/job/15376976887
