### PR TITLE
HPR-1231: Deprecate `data.hcp_packer_image_iteration`

### DIFF
--- a/.changelog/569.txt
+++ b/.changelog/569.txt
@@ -1,0 +1,4 @@
+```release-note:deprecation
+The `hcp_packer_image_iteration` data source is now deprecated.
+Use the `hcp_packer_image` or `hcp_packer_iteration` data sources instead.
+```

--- a/docs/data-sources/packer_image_iteration.md
+++ b/docs/data-sources/packer_image_iteration.md
@@ -2,12 +2,14 @@
 page_title: "hcp_packer_image_iteration Data Source - terraform-provider-hcp"
 subcategory: ""
 description: |-
-  The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
+  The Packer ImageIteration data source iteration gets the most recent iteration (or build) of an image, given a channel.
 ---
 
 # hcp_packer_image_iteration (Data Source)
 
-The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.
+-> **Note:** The `hcp_packer_image_iteration` data source is deprecated. Use the `hcp_packer_image` or `hcp_packer_iteration` data sources instead.
+
+The Packer ImageIteration data source iteration gets the most recent iteration (or build) of an image, given a channel.
 
 ## Example Usage
 

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -17,8 +17,9 @@ import (
 
 func dataSourcePackerImageIteration() *schema.Resource {
 	return &schema.Resource{
-		Description: "The Packer Image data source iteration gets the most recent iteration (or build) of an image, given a channel.",
-		ReadContext: dataSourcePackerImageIterationRead,
+		Description:        "The Packer ImageIteration data source iteration gets the most recent iteration (or build) of an image, given a channel.",
+		DeprecationMessage: "The `hcp_packer_image_iteration` data source is deprecated. Use `hcp_packer_image` or `hcp_packer_iteration` instead.",
+		ReadContext:        dataSourcePackerImageIterationRead,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultPackerTimeout,
 		},
@@ -53,7 +54,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-
 			// Actual iteration:
 			"incremental_version": {
 				Description: "Incremental version of this iteration",

--- a/templates/data-sources/packer_image_iteration.md.tmpl
+++ b/templates/data-sources/packer_image_iteration.md.tmpl
@@ -7,6 +7,8 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
+-> **Note:** The `hcp_packer_image_iteration` data source is deprecated. Use the `hcp_packer_image` or `hcp_packer_iteration` data sources instead.
+
 {{ .Description | trimspace }}
 
 ## Example Usage


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Deprecates `data.hcp_packer_image_iteration`

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=Test.*dataSourcePacker.* -test.v' 
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=Test.*dataSourcePacker.* -test.v -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.229s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.158s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.115s [no tests to run]
=== RUN   TestAcc_dataSourcePackerBucketNames
--- PASS: TestAcc_dataSourcePackerBucketNames (21.77s)
=== RUN   TestAcc_dataSourcePacker
--- PASS: TestAcc_dataSourcePacker (6.97s)
=== RUN   TestAcc_dataSourcePacker_revokedIteration
--- PASS: TestAcc_dataSourcePacker_revokedIteration (11.98s)
=== RUN   TestAcc_dataSourcePackerImage
--- PASS: TestAcc_dataSourcePackerImage (7.21s)
=== RUN   TestAcc_dataSourcePackerImage_revokedIteration
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (5.02s)
=== RUN   TestAcc_dataSourcePackerImage_emptyChannel
--- PASS: TestAcc_dataSourcePackerImage_emptyChannel (1.27s)
=== RUN   TestAcc_dataSourcePackerImage_channelAndIterationIDReject
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (3.53s)
=== RUN   TestAcc_dataSourcePackerImage_channelAccept
--- PASS: TestAcc_dataSourcePackerImage_channelAccept (6.60s)
=== RUN   TestAcc_dataSourcePackerIteration
--- PASS: TestAcc_dataSourcePackerIteration (5.61s)
=== RUN   TestAcc_dataSourcePackerIteration_revokedIteration
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (11.25s)
=== RUN   TestAcc_dataSourcePackerRunTask
--- PASS: TestAcc_dataSourcePackerRunTask (9.24s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   90.822s
```
