### PR TITLE
hcp_vault_cluster resource changes for adding vault plugins

### DIFF
--- a/.changelog/575.txt
+++ b/.changelog/575.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add `vault_plugin` resource as optional subresource for `hcp_vault_cluster`
+```

--- a/docs/data-sources/vault_cluster.md
+++ b/docs/data-sources/vault_cluster.md
@@ -31,6 +31,7 @@ data "hcp_vault_cluster" "example" {
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
 If a project is not configured in the HCP Provider config block, the oldest project in the organization will be used.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `vault_plugin` (Block List) The external plugins to install on the vault cluster (see [below for nested schema](#nestedblock--vault_plugin))
 
 ### Read-Only
 
@@ -61,6 +62,15 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 Optional:
 
 - `default` (String)
+
+
+<a id="nestedblock--vault_plugin"></a>
+### Nested Schema for `vault_plugin`
+
+Required:
+
+- `plugin_name` (String) The name of the plugin
+- `plugin_type` (String) The type of the plugin
 
 
 <a id="nestedblock--audit_log_config"></a>

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -61,6 +61,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `public_endpoint` (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - `tier` (String) Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://www.hashicorp.com/products/vault/pricing). Changing a cluster's size or tier is only available to admins. See [Scale a cluster](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/vault-scaling).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `vault_plugin` (Block List) The external plugins that are to be installed on the vault cluster (see [below for nested schema](#nestedblock--vault_plugin))
 
 ### Read-Only
 
@@ -126,6 +127,15 @@ Optional:
 - `default` (String)
 - `delete` (String)
 - `update` (String)
+
+
+<a id="nestedblock--vault_plugin"></a>
+### Nested Schema for `vault_plugin`
+
+Required:
+
+- `plugin_name` (String) The name of the plugin - Valid options for plugin name - 'venafi-pki-backend'
+- `plugin_type` (String) The type of the plugin - Valid options for plugin type - 'SECRET', 'AUTH', 'DATABASE'
 
 -> **Note:** When establishing performance replication links between clusters in different HVNs, an HVN peering connection is required. This can be defined explicitly using an [`hcp_hvn_peering_connection`](hvn_peering_connection.md), or HCP will create the connection automatically (peering connections can be imported after creation using [terraform import](https://www.terraform.io/cli/import)). Note HVN peering [CIDR block requirements](https://cloud.hashicorp.com/docs/hcp/network/routes#cidr-block-requirements).
 

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -61,7 +61,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `public_endpoint` (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - `tier` (String) Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://www.hashicorp.com/products/vault/pricing). Changing a cluster's size or tier is only available to admins. See [Scale a cluster](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/vault-scaling).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `vault_plugin` (Block List) The external plugins that are to be installed on the vault cluster (see [below for nested schema](#nestedblock--vault_plugin))
+- `vault_plugin` (Block List) The external plugins to install on the vault cluster (see [below for nested schema](#nestedblock--vault_plugin))
 
 ### Read-Only
 

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -325,17 +325,40 @@ func DeletePlugin(ctx context.Context, client *Client, loc *sharedmodels.Hashico
 	}
 	request.Location = locInternal
 	request.ClusterID = clusterID
-	delPluginPluginParams := vault_service.NewDeletePluginParams()
-	delPluginPluginParams.Context = ctx
-	delPluginPluginParams.ClusterID = clusterID
-	delPluginPluginParams.LocationProjectID = loc.ProjectID
-	delPluginPluginParams.LocationOrganizationID = loc.OrganizationID
-	delPluginPluginParams.Body = request
+	delPluginParams := vault_service.NewDeletePluginParams()
+	delPluginParams.Context = ctx
+	delPluginParams.ClusterID = clusterID
+	delPluginParams.LocationProjectID = loc.ProjectID
+	delPluginParams.LocationOrganizationID = loc.OrganizationID
+	delPluginParams.Body = request
 
-	delPluginResp, err := client.Vault.DeletePlugin(delPluginPluginParams, nil)
+	delPluginResp, err := client.Vault.DeletePlugin(delPluginParams, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	return delPluginResp.Payload, nil
+}
+
+// ListPlugins will make a call to the Vault service plugin status api to get names of valid plugins
+func ListPlugins(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string) (*vaultmodels.HashicorpCloudVault20201125PluginRegistrationStatusResponse, error) {
+	region := &sharedmodels.HashicorpCloudLocationRegion{}
+	if loc.Region != nil {
+		region = loc.Region
+	}
+
+	listPluginsParams := vault_service.NewPluginRegistrationStatusParams()
+	listPluginsParams.Context = ctx
+	listPluginsParams.ClusterID = clusterID
+	listPluginsParams.LocationProjectID = loc.ProjectID
+	listPluginsParams.LocationOrganizationID = loc.OrganizationID
+	listPluginsParams.LocationRegionProvider = &region.Provider
+	listPluginsParams.LocationRegionRegion = &region.Region
+
+	listPluginsResp, err := client.Vault.PluginRegistrationStatus(listPluginsParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return listPluginsResp.Payload, nil
 }

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -340,7 +340,7 @@ func DeletePlugin(ctx context.Context, client *Client, loc *sharedmodels.Hashico
 	return delPluginResp.Payload, nil
 }
 
-// ListPlugins will make a call to the Vault service plugin status api to get names of valid plugins
+// ListPlugins will make a call to the Vault service plugin status api to get all available plugins for the cluster.
 func ListPlugins(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string) (*vaultmodels.HashicorpCloudVault20201125PluginRegistrationStatusResponse, error) {
 	region := &sharedmodels.HashicorpCloudLocationRegion{}
 	if loc.Region != nil {

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -273,3 +273,69 @@ func DeleteVaultPathsFilter(ctx context.Context, client *Client, loc *sharedmode
 
 	return deleteResp.Payload, nil
 }
+
+// AddPlugin will make a call to the Vault service to add a plugin to a Vault cluster
+func AddPlugin(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string,
+	request *vaultmodels.HashicorpCloudVault20201125AddPluginRequest) (vaultmodels.HashicorpCloudVault20201125AddPluginResponse, error) {
+
+	region := &sharedmodels.HashicorpCloudLocationRegion{}
+	if loc.Region != nil {
+		region = loc.Region
+	}
+	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
+		OrganizationID: loc.OrganizationID,
+		ProjectID:      loc.ProjectID,
+		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
+			Provider: region.Provider,
+			Region:   region.Region,
+		},
+	}
+	request.Location = locInternal
+	request.ClusterID = clusterID
+	addPluginParams := vault_service.NewAddPluginParams()
+	addPluginParams.Context = ctx
+	addPluginParams.ClusterID = clusterID
+	addPluginParams.LocationProjectID = loc.ProjectID
+	addPluginParams.LocationOrganizationID = loc.OrganizationID
+	addPluginParams.Body = request
+
+	addPluginResp, err := client.Vault.AddPlugin(addPluginParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return addPluginResp.Payload, nil
+}
+
+// DeletePlugin will make a call to the Vault service to remove a plugin to a Vault cluster
+func DeletePlugin(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string,
+	request *vaultmodels.HashicorpCloudVault20201125DeletePluginRequest) (vaultmodels.HashicorpCloudVault20201125DeletePluginResponse, error) {
+
+	region := &sharedmodels.HashicorpCloudLocationRegion{}
+	if loc.Region != nil {
+		region = loc.Region
+	}
+	locInternal := &vaultmodels.HashicorpCloudInternalLocationLocation{
+		OrganizationID: loc.OrganizationID,
+		ProjectID:      loc.ProjectID,
+		Region: &vaultmodels.HashicorpCloudInternalLocationRegion{
+			Provider: region.Provider,
+			Region:   region.Region,
+		},
+	}
+	request.Location = locInternal
+	request.ClusterID = clusterID
+	delPluginPluginParams := vault_service.NewDeletePluginParams()
+	delPluginPluginParams.Context = ctx
+	delPluginPluginParams.ClusterID = clusterID
+	delPluginPluginParams.LocationProjectID = loc.ProjectID
+	delPluginPluginParams.LocationOrganizationID = loc.OrganizationID
+	delPluginPluginParams.Body = request
+
+	delPluginResp, err := client.Vault.DeletePlugin(delPluginPluginParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return delPluginResp.Payload, nil
+}

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -208,6 +208,26 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 					},
 				},
 			},
+			"vault_plugin": {
+				Description: "The external plugins to install on the vault cluster",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"plugin_name": {
+							Description: "The name of the plugin",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"plugin_type": {
+							Description: "The type of the plugin",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -242,8 +262,14 @@ func dataSourceVaultClusterRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.SetId(url)
 
+	plugins, err := clients.ListPlugins(ctx, client, loc, clusterID)
+	if err != nil {
+		log.Printf("[ERROR] Vault cluster (%s) failed to list plugins", clusterID)
+		return diag.FromErr(err)
+	}
+
 	// Cluster found, update resource data.
-	if err := setVaultClusterResourceData(d, cluster); err != nil {
+	if err := setVaultClusterResourceData(d, cluster, plugins.Plugins); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -276,6 +276,10 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 					},
 				},
 			},
+			// vault_plugin is a terraform resource used to specify a plugin for installation.
+			//
+			// plugin_name is only validated on updates because the PluginStatus API to list the valid available plugin names requires a created cluster.
+			// plugin_type is validated on create & update because there is a static list for valid plugint types.
 			"vault_plugin": {
 				Description: "The external plugins to install on the vault cluster",
 				Type:        schema.TypeList,
@@ -660,7 +664,7 @@ func resourceVaultClusterUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diagErr
 	}
 
-	// get plugins for plugin-name validation in getPluginConfig
+	// get list of plugins for plugin-name validation in getPluginConfig
 	plugins, err := clients.ListPlugins(ctx, client, loc, clusterID)
 	if err != nil {
 		log.Printf("[ERROR] Vault cluster (%s) failed to list plugins", clusterID)

--- a/internal/provider/resource_vault_cluster_const_test.go
+++ b/internal/provider/resource_vault_cluster_const_test.go
@@ -52,10 +52,6 @@ resource "hcp_vault_cluster" "test" {
 		plugin_type = "SECRET"
 		plugin_name = "venafi-pki-backend"
 	}
-	vault_plugin {
-		plugin_type = "DATABASE"
-		plugin_name = "vault-plugin-database-oracle"
-	}
 }
 `
 
@@ -71,10 +67,6 @@ resource "hcp_vault_cluster" "test" {
 		upgrade_type = "SCHEDULED"
 		maintenance_window_day = "WEDNESDAY"
 		maintenance_window_time = "WINDOW_12AM_4AM"
-	}
-	vault_plugin {
-		plugin_type = "SECRET"
-		plugin_name = "venafi-pki-backend"
 	}
 }
 `

--- a/internal/provider/resource_vault_cluster_const_test.go
+++ b/internal/provider/resource_vault_cluster_const_test.go
@@ -48,6 +48,14 @@ resource "hcp_vault_cluster" "test" {
 	major_version_upgrade_config {
 		upgrade_type = "MANUAL"
 	}
+	vault_plugin {
+		plugin_type = "SECRET"
+		plugin_name = "venafi-pki-backend"
+	}
+	vault_plugin {
+		plugin_type = "DATABASE"
+		plugin_name = "vault-plugin-database-oracle"
+	}
 }
 `
 
@@ -63,6 +71,10 @@ resource "hcp_vault_cluster" "test" {
 		upgrade_type = "SCHEDULED"
 		maintenance_window_day = "WEDNESDAY"
 		maintenance_window_time = "WINDOW_12AM_4AM"
+	}
+	vault_plugin {
+		plugin_type = "SECRET"
+		plugin_name = "venafi-pki-backend"
 	}
 }
 `

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -286,6 +286,8 @@ func updateClusterTier(t *testing.T, in *inputT) resource.TestStep {
 			resource.TestCheckResourceAttr(vaultClusterResourceName, "major_version_upgrade_config.0.upgrade_type", "SCHEDULED"),
 			resource.TestCheckResourceAttr(vaultClusterResourceName, "major_version_upgrade_config.0.maintenance_window_day", "WEDNESDAY"),
 			resource.TestCheckResourceAttr(vaultClusterResourceName, "major_version_upgrade_config.0.maintenance_window_time", "WINDOW_12AM_4AM"),
+			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_plugin.0"),
+			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_plugin.0"),
 		),
 	}
 }
@@ -333,6 +335,8 @@ func updateTierPublicEndpointAndRemoveObservabilityData(t *testing.T, in *inputT
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "major_version_upgrade_config.0.upgrade_type", "SCHEDULED"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "major_version_upgrade_config.0.maintenance_window_day", "WEDNESDAY"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "major_version_upgrade_config.0.maintenance_window_time", "WINDOW_12AM_4AM"),
+			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_plugin.0"),
+			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_plugin.0"),
 		),
 	}
 }

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
@@ -156,7 +157,7 @@ func testAccCheckVaultClusterDestroy(s *terraform.State) error {
 func awsTestSteps(t *testing.T, inp inputT) []resource.TestStep {
 	in := &inp
 	return []resource.TestStep{
-		createClusteAndTestAdminTokenGeneration(t, in),
+		createClusterAndTestAdminTokenGeneration(t, in),
 		importResourcesInTFState(t, in),
 		tfApply(t, in),
 		testTFDataSources(t, in),
@@ -169,7 +170,7 @@ func awsTestSteps(t *testing.T, inp inputT) []resource.TestStep {
 func azureTestSteps(t *testing.T, inp inputT) []resource.TestStep {
 	in := &inp
 	return []resource.TestStep{
-		createClusteAndTestAdminTokenGeneration(t, in),
+		createClusterAndTestAdminTokenGeneration(t, in),
 		importResourcesInTFState(t, in),
 		tfApply(t, in),
 		testTFDataSources(t, in),
@@ -178,7 +179,7 @@ func azureTestSteps(t *testing.T, inp inputT) []resource.TestStep {
 }
 
 // This step tests Vault cluster and admin token resource creation.
-func createClusteAndTestAdminTokenGeneration(t *testing.T, in *inputT) resource.TestStep {
+func createClusterAndTestAdminTokenGeneration(t *testing.T, in *inputT) resource.TestStep {
 	return resource.TestStep{
 		Config: testConfig(in.tf),
 		Check: resource.ComposeTestCheckFunc(
@@ -289,7 +290,7 @@ func updateClusterTier(t *testing.T, in *inputT) resource.TestStep {
 	}
 }
 
-// This step verifies the successful update of "public_endpoint", "audit_log", "metrics" and MVU config
+// This step verifies the successful update of "public_endpoint", "audit_log", "metrics", MVU config, and plugin config
 func updateVaultPublicEndpointObservabilityDataAndMVU(t *testing.T, in *inputT) resource.TestStep {
 	newIn := *in
 	newIn.PublicEndpoint = "true"
@@ -307,6 +308,8 @@ func updateVaultPublicEndpointObservabilityDataAndMVU(t *testing.T, in *inputT) 
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "audit_log_config.0.datadog_api_key"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "audit_log_config.0.datadog_region", "us1"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "major_version_upgrade_config.0.upgrade_type", "MANUAL"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "vault_plugin.0.plugin_name", "venafi-pki-backend"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "vault_plugin.0.plugin_type", "SECRET"),
 		),
 	}
 }

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -460,3 +460,19 @@ func validateVaultPluginType(v interface{}, path cty.Path) diag.Diagnostics {
 
 	return diagnostics
 }
+
+func validateVaultPluginName(pluginName string, pluginType string, plugins []*vaultmodels.HashicorpCloudVault20201125PluginRegistrationStatus) diag.Diagnostics {
+	var found bool
+	for _, plugin := range plugins {
+		if strings.EqualFold(pluginName, plugin.PluginName) && strings.EqualFold(pluginType, string(*plugin.PluginType)) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return diag.Errorf(fmt.Sprintf("plugin of plugin name: %s and plugin type: %s is not supported for installation by HCP Vault", pluginName, pluginType))
+	}
+
+	return nil
+}

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -449,6 +449,12 @@ func validateVaultPluginType(v interface{}, path cty.Path) diag.Diagnostics {
 	if err != nil {
 		enumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
 		expectedEnumList := strings.ToLower(enumList)
+		// Remove invalid option from allowed list in error message
+		expectedEnumList = strings.ReplaceAll(
+			expectedEnumList,
+			strings.ToLower(string(vaultmodels.HashicorpCloudVault20201125PluginTypePLUGINTYPEINVALID)),
+			"",
+		)
 		msg := fmt.Sprintf("expected '%v' to be one of: %v", v, expectedEnumList)
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -441,3 +441,22 @@ func validateBoundaryPassword(v interface{}, path cty.Path) diag.Diagnostics {
 
 	return diagnostics
 }
+
+func validateVaultPluginType(v interface{}, path cty.Path) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	err := vaultmodels.HashicorpCloudVault20201125PluginType(strings.ToUpper(v.(string))).Validate(strfmt.Default)
+	if err != nil {
+		enumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		expectedEnumList := strings.ToLower(enumList)
+		msg := fmt.Sprintf("expected '%v' to be one of: %v", v, expectedEnumList)
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       msg,
+			Detail:        msg + " (value is case-insensitive).",
+			AttributePath: path,
+		})
+	}
+
+	return diagnostics
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

The terraform provider for HCP vault will be updated so new optional stanzas will be added to the 'hcp_vault_cluster' terraform resource, so plugins can be specified to be added when using terraform to provision HCP Vault clusters.

A new 'vault_plugin' resource will be created, which can be specified as a subresource which can be optionally added. This will allow for a list of vault_plugin resources to be specified to indicate the plugins a user wants to install on their cluster.

There will be validation for valid plugin_type. Validation is not done for plugin_name. This is because valid plugin names are stored in Launch darkly, which would require a cloud-sdk dependency in the provider, which I feel like would be discouraged as this is a public repo.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

During the acceptance test, I used two different plugin configs. 

config1:  
```
vault_plugin {
		plugin_type = "SECRET"
		plugin_name = "venafi-pki-backend"
	}
```
	
config 2: 
```
	vault_plugin {
		plugin_type = "SECRET"
		plugin_name = "venafi-pki-backend"
	}
	vault_plugin {
		plugin_type = "DATABASE"
		plugin_name = "vault-plugin-database-oracle"
	}
```
	
Update 1: config 1 (one plugin added)
Update 2: config 2 (one new plugin added. idempotent plugin/add api called twice)
Update 3: config 1	(one plugin removed. )


The datadog API endpoints support that the plugins were being added/deleted at the correct intervals. I also confirmed on the database that the plugin_registration table matched the expected state.
![Screenshot 2023-08-07 at 3 10 15 PM](https://github.com/hashicorp/terraform-provider-hcp/assets/96261585/daa240fa-e776-4f4c-b0e9-ace326690eb3)

Because only 1 customer managed plugin is available right now, new tests must be added in future when more plugins are available.

```
make testacc TESTARGS='-run=TestAccVaultClusterAWS'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultClusterAWS -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.333s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.298s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.288s [no tests to run]
=== RUN   TestAccVaultClusterAWS
=== PAUSE TestAccVaultClusterAWS
=== CONT  TestAccVaultClusterAWS
--- PASS: TestAccVaultClusterAWS (3173.02s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   3173.386s

...
```
