### PR TITLE
Hvt 4182 http proxy for hcpv in hcp tfp

### DIFF
--- a/.changelog/577.txt
+++ b/.changelog/577.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add `proxy_endpoint` field to enable toggling the proxy option on HCP Vault clusters, along with corresponding read-only `vault_proxy_endpoint_url` field.
+```

--- a/docs/data-sources/vault_cluster.md
+++ b/docs/data-sources/vault_cluster.md
@@ -46,7 +46,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `organization_id` (String) The ID of the organization this HCP Vault cluster is located in.
 - `paths_filter` (List of String) The performance replication [paths filter](https://developer.hashicorp.com/vault/tutorials/cloud-ops/vault-replication-terraform#review-hcpvault-tf). Applies to performance replication secondaries only and operates in "deny" mode only.
 - `primary_link` (String) The `self_link` of the HCP Vault Plus tier cluster which is the primary in the performance replication setup with this HCP Vault Plus tier cluster. If not specified, it is a standalone Plus tier HCP Vault cluster.
-- `proxy_endpoint` (String) Denotes that the cluster has a public endpoint. Defaults to false.
+- `proxy_endpoint` (String) Denotes that the cluster has a proxy endpoint. Valid options are `ENABLED`, `DISABLED`. Defaults to `DISABLED`.
 - `public_endpoint` (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - `region` (String) The region where the HCP Vault cluster is located.
 - `self_link` (String) A unique URL identifying the Vault cluster.

--- a/docs/data-sources/vault_cluster.md
+++ b/docs/data-sources/vault_cluster.md
@@ -46,12 +46,14 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `organization_id` (String) The ID of the organization this HCP Vault cluster is located in.
 - `paths_filter` (List of String) The performance replication [paths filter](https://developer.hashicorp.com/vault/tutorials/cloud-ops/vault-replication-terraform#review-hcpvault-tf). Applies to performance replication secondaries only and operates in "deny" mode only.
 - `primary_link` (String) The `self_link` of the HCP Vault Plus tier cluster which is the primary in the performance replication setup with this HCP Vault Plus tier cluster. If not specified, it is a standalone Plus tier HCP Vault cluster.
+- `proxy_endpoint` (String) Denotes that the cluster has a public endpoint. Defaults to false.
 - `public_endpoint` (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - `region` (String) The region where the HCP Vault cluster is located.
 - `self_link` (String) A unique URL identifying the Vault cluster.
 - `state` (String) The state of the Vault cluster.
 - `tier` (String) The tier that the HCP Vault cluster will be provisioned as.  Only 'development' is available at this time.
 - `vault_private_endpoint_url` (String) The private URL for the Vault cluster.
+- `vault_proxy_endpoint_url` (String) The proxy URL for the Vault cluster. This will be empty if `proxy_endpoint` is `DISABLED`.
 - `vault_public_endpoint_url` (String) The public URL for the Vault cluster. This will be empty if `public_endpoint` is `false`.
 - `vault_version` (String) The Vault version of the cluster.
 

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -58,6 +58,7 @@ resource "hcp_vault_cluster" "example" {
 - `project_id` (String) The ID of the HCP project where the Vault cluster is located. 
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
 If a project is not configured in the HCP Provider config block, the oldest project in the organization will be used.
+- `proxy_endpoint` (String) Denotes that the cluster has a proxy endpoint. Valid options are `ENABLED`, `DISABLED`. Defaults to `DISABLED`.
 - `public_endpoint` (Boolean) Denotes that the cluster has a public endpoint. Defaults to false.
 - `tier` (String) Tier of the HCP Vault cluster. Valid options for tiers - `dev`, `starter_small`, `standard_small`, `standard_medium`, `standard_large`, `plus_small`, `plus_medium`, `plus_large`. See [pricing information](https://www.hashicorp.com/products/vault/pricing). Changing a cluster's size or tier is only available to admins. See [Scale a cluster](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/vault-scaling).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
@@ -73,6 +74,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `self_link` (String) A unique URL identifying the Vault cluster.
 - `state` (String) The state of the Vault cluster.
 - `vault_private_endpoint_url` (String) The private URL for the Vault cluster.
+- `vault_proxy_endpoint_url` (String) The proxy URL for the Vault cluster. This will be empty if `proxy_endpoint` is `DISABLED`.
 - `vault_public_endpoint_url` (String) The public URL for the Vault cluster. This will be empty if `public_endpoint` is `false`.
 - `vault_version` (String) The Vault version of the cluster.
 

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -169,7 +169,7 @@ func UpdateVaultMajorVersionUpgradeConfig(ctx context.Context, client *Client, l
 // UpdateVaultCluster will make a call to the Vault service to update the Vault cluster configuration.
 func UpdateVaultClusterConfig(
 	ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string,
-	tier *string, publicIpsEnabled *bool,
+	tier *string, publicIpsEnabled *bool, httpProxyOption *vaultmodels.HashicorpCloudVault20201125HTTPProxyOption,
 	metrics *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig, auditLog *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig,
 ) (*vaultmodels.HashicorpCloudVault20201125UpdateResponse, error) {
 
@@ -181,11 +181,18 @@ func UpdateVaultClusterConfig(
 		config.Tier = &tier
 		updateMaskPaths = append(updateMaskPaths, "config.tier")
 	}
-	if publicIpsEnabled != nil {
-		config.NetworkConfig = &vaultmodels.HashicorpCloudVault20201125InputNetworkConfig{
-			PublicIpsEnabled: *publicIpsEnabled,
+	if publicIpsEnabled != nil || httpProxyOption != nil {
+		config.NetworkConfig = &vaultmodels.HashicorpCloudVault20201125InputNetworkConfig{}
+
+		if publicIpsEnabled != nil {
+			config.NetworkConfig.PublicIpsEnabled = *publicIpsEnabled
+			updateMaskPaths = append(updateMaskPaths, "config.network_config.public_ips_enabled")
 		}
-		updateMaskPaths = append(updateMaskPaths, "config.network_config.public_ips_enabled")
+
+		if httpProxyOption != nil {
+			config.NetworkConfig.HTTPProxyOption = httpProxyOption
+			updateMaskPaths = append(updateMaskPaths, "config.network_config.http_proxy_option")
+		}
 	}
 	if metrics != nil {
 		config.MetricsConfig = metrics

--- a/internal/clients/vault_cluster.go
+++ b/internal/clients/vault_cluster.go
@@ -167,9 +167,11 @@ func UpdateVaultMajorVersionUpgradeConfig(ctx context.Context, client *Client, l
 }
 
 // UpdateVaultCluster will make a call to the Vault service to update the Vault cluster configuration.
-func UpdateVaultClusterConfig(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation,
-	clusterID string, tier *string, metrics *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig,
-	auditLog *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig) (*vaultmodels.HashicorpCloudVault20201125UpdateResponse, error) {
+func UpdateVaultClusterConfig(
+	ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, clusterID string,
+	tier *string, publicIpsEnabled *bool,
+	metrics *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig, auditLog *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig,
+) (*vaultmodels.HashicorpCloudVault20201125UpdateResponse, error) {
 
 	config := &vaultmodels.HashicorpCloudVault20201125InputClusterConfig{}
 	updateMaskPaths := []string{}
@@ -178,6 +180,12 @@ func UpdateVaultClusterConfig(ctx context.Context, client *Client, loc *sharedmo
 		tier := vaultmodels.HashicorpCloudVault20201125Tier(*tier)
 		config.Tier = &tier
 		updateMaskPaths = append(updateMaskPaths, "config.tier")
+	}
+	if publicIpsEnabled != nil {
+		config.NetworkConfig = &vaultmodels.HashicorpCloudVault20201125InputNetworkConfig{
+			PublicIpsEnabled: *publicIpsEnabled,
+		}
+		updateMaskPaths = append(updateMaskPaths, "config.network_config.public_ips_enabled")
 	}
 	if metrics != nil {
 		config.MetricsConfig = metrics

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -53,7 +53,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Computed:    true,
 			},
 			"proxy_endpoint": {
-				Description: "Denotes that the cluster has a public endpoint. Defaults to false.",
+				Description: "Denotes that the cluster has a proxy endpoint. Valid options are `ENABLED`, `DISABLED`. Defaults to `DISABLED`.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -52,6 +52,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
+			"proxy_endpoint": {
+				Description: "Denotes that the cluster has a public endpoint. Defaults to false.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"min_vault_version": {
 				Description: "The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.",
 				Type:        schema.TypeString,
@@ -94,6 +99,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 			},
 			"vault_private_endpoint_url": {
 				Description: "The private URL for the Vault cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vault_proxy_endpoint_url": {
+				Description: "The proxy URL for the Vault cluster. This will be empty if `proxy_endpoint` is `DISABLED`.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -93,6 +93,16 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Default:     false,
 				Optional:    true,
 			},
+			"proxy_endpoint": {
+				Description:      "Denotes that the cluster has a proxy endpoint. Valid options are `ENABLED`, `DISABLED`. Defaults to `DISABLED`.",
+				Type:             schema.TypeString,
+				Default:          "DISABLED",
+				Optional:         true,
+				ValidateDiagFunc: validateVaultClusterProxyEndpoint,
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
+			},
 			"min_vault_version": {
 				Description:      "The minimum Vault version to use when creating the cluster. If not specified, it is defaulted to the version that is currently recommended by HCP.",
 				Type:             schema.TypeString,
@@ -283,6 +293,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 			},
 			"vault_private_endpoint_url": {
 				Description: "The private URL for the Vault cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"vault_proxy_endpoint_url": {
+				Description: "The proxy URL for the Vault cluster. This will be empty if `proxy_endpoint` is `DISABLED`.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -717,6 +732,7 @@ func resourceVaultClusterDelete(ctx context.Context, d *schema.ResourceData, met
 
 	return nil
 }
+
 func updateVaultClusterConfig(ctx context.Context, client *clients.Client, d *schema.ResourceData, cluster *vaultmodels.HashicorpCloudVault20201125Cluster, clusterID string) diag.Diagnostics {
 	metricsConfig, diagErr := getObservabilityConfig("metrics_config", d)
 	if diagErr != nil {

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -739,7 +739,7 @@ func updateVaultClusterConfig(ctx context.Context, client *clients.Client, d *sc
 	isSecondary := false
 	destTier := getClusterTier(d)
 	publicIpsEnabled := getPublicIpsEnabled(d)
-	httpProxyOption := getHttpProxyOption(d)
+	httpProxyOption := getHTTPProxyOption(d)
 
 	clusterSharedLoc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: cluster.Location.OrganizationID,
@@ -827,7 +827,7 @@ func getPublicIpsEnabled(d *schema.ResourceData) *bool {
 	return nil
 }
 
-func getHttpProxyOption(d *schema.ResourceData) *vaultmodels.HashicorpCloudVault20201125HTTPProxyOption {
+func getHTTPProxyOption(d *schema.ResourceData) *vaultmodels.HashicorpCloudVault20201125HTTPProxyOption {
 	// If we don't change the proxy_endpoint, return nil so we don't pass http_proxy_option to the update.
 	if d.HasChange("proxy_endpoint") {
 		httpProxyOption := vaultmodels.HashicorpCloudVault20201125HTTPProxyOption(strings.ToUpper(d.Get("proxy_endpoint").(string)))

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -918,7 +918,9 @@ func setVaultClusterResourceData(d *schema.ResourceData, cluster *vaultmodels.Ha
 		}
 	} else {
 		// This is needed to remove a previously-set vault_proxy_endpoint_url after an update to disable.
-		d.Set("vault_proxy_endpoint_url", cluster.DNSNames.Proxy)
+		if err := d.Set("vault_proxy_endpoint_url", cluster.DNSNames.Proxy); err != nil {
+			return err
+		}
 	}
 
 	if err := d.Set("created_at", cluster.CreatedAt.String()); err != nil {

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -916,6 +916,9 @@ func setVaultClusterResourceData(d *schema.ResourceData, cluster *vaultmodels.Ha
 		if err := d.Set("vault_proxy_endpoint_url", fmt.Sprintf("https://%s", cluster.DNSNames.Proxy)); err != nil {
 			return err
 		}
+	} else {
+		// This is needed to remove a previously-set vault_proxy_endpoint_url after an update to disable.
+		d.Set("vault_proxy_endpoint_url", cluster.DNSNames.Proxy)
 	}
 
 	if err := d.Set("created_at", cluster.CreatedAt.String()); err != nil {

--- a/internal/provider/resource_vault_cluster_const_test.go
+++ b/internal/provider/resource_vault_cluster_const_test.go
@@ -30,13 +30,15 @@ resource "hcp_vault_cluster" "test" {
 }
 `
 
-// sets public_endpoint to true and add metrics and audit log
-const updatedVaultClusterPublicAndMetricsAuditLog = `
+// sets public_endpoint to true, proxy_endpoint to ENABLED,
+// add metrics and audit log, and update MVU
+const updatedVaultClusterPublicProxyObservabilityAndMVU = `
 resource "hcp_vault_cluster" "test" {
 	cluster_id         = "{{ .ClusterID }}"
 	hvn_id             = hcp_hvn.test.hvn_id
 	tier               = "{{ .Tier }}"
 	public_endpoint    = {{ .PublicEndpoint }}
+	proxy_endpoint     = "{{ .ProxyEndpoint }}"
 	metrics_config			   {
 		splunk_hecendpoint = "https://http-input-splunkcloud.com"
 		splunk_token =       "test"
@@ -51,14 +53,15 @@ resource "hcp_vault_cluster" "test" {
 }
 `
 
-// changes tier, remove any metrics or audit log config, optionally toggle public
-// endpoint on or off
-const updatedVaultClusterTierAndMVUConfig = `
+// changes tier, remove any metrics or audit log config, and
+// toggle public_endpoint and proxy_endpoint
+const updatedVaultClusterTierPublicProxyAndMVU = `
 resource "hcp_vault_cluster" "test" {
 	cluster_id         = "{{ .ClusterID }}"
 	hvn_id             = hcp_hvn.test.hvn_id
 	tier               = "{{ .Tier }}"
 	public_endpoint    = {{ .PublicEndpoint }}
+	proxy_endpoint     = "{{ .ProxyEndpoint }}"
 	major_version_upgrade_config {
 		upgrade_type = "SCHEDULED"
 		maintenance_window_day = "WEDNESDAY"
@@ -98,6 +101,7 @@ resource "hcp_vault_cluster_admin_token" "test" {
 		Region         string
 		Tier           string
 		PublicEndpoint string
+		ProxyEndpoint  string
 	}{
 		ClusterID:      in.VaultClusterName,
 		HvnID:          in.HvnName,
@@ -105,6 +109,7 @@ resource "hcp_vault_cluster_admin_token" "test" {
 		Region:         in.Region,
 		Tier:           tier,
 		PublicEndpoint: in.PublicEndpoint,
+		ProxyEndpoint:  in.ProxyEndpoint,
 	})
 	require.NoError(t, err)
 	return tfResources.String()

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -200,7 +200,7 @@ func createClusteAndTestAdminTokenGeneration(t *testing.T, in *inputT) resource.
 			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_public_endpoint_url"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_private_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_private_endpoint_url", ""),
-			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_proxy_endpoint_url"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "vault_proxy_endpoint_url", ""),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "state"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "created_at"),
 
@@ -337,7 +337,7 @@ func updateTierPublicProxyAndRemoveObservability(t *testing.T, in *inputT) resou
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_public_endpoint_url", "8200"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_private_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_private_endpoint_url", "8200"),
-			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_proxy_endpoint_url"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "vault_proxy_endpoint_url", ""),
 			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "metrics_config.0"),
 			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "audit_log_config.0"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "major_version_upgrade_config.0.upgrade_type", "SCHEDULED"),

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -27,6 +27,7 @@ type inputT struct {
 	UpdateTier1                string
 	UpdateTier2                string
 	PublicEndpoint             string
+	ProxyEndpoint              string
 	Secondary                  *inputT // optional
 	tf                         string
 }
@@ -54,6 +55,7 @@ func TestAccVaultClusterAzure(t *testing.T) {
 		UpdateTier1:                "STANDARD_SMALL",
 		UpdateTier2:                "STANDARD_MEDIUM",
 		PublicEndpoint:             "false",
+		ProxyEndpoint:              "DISABLED",
 	}
 	tf := setTestAccVaultClusterConfig(t, vaultCluster, azureTestInput, azureTestInput.Tier)
 	// save so e don't have to generate this again and again
@@ -81,6 +83,7 @@ func TestAccVaultClusterAWS(t *testing.T) {
 		UpdateTier1:                "STANDARD_SMALL",
 		UpdateTier2:                "STANDARD_MEDIUM",
 		PublicEndpoint:             "false",
+		ProxyEndpoint:              "DISABLED",
 	}
 
 	tf := setTestAccVaultClusterConfig(t, vaultCluster, awsTestInput, awsTestInput.Tier)
@@ -161,8 +164,8 @@ func awsTestSteps(t *testing.T, inp inputT) []resource.TestStep {
 		tfApply(t, in),
 		testTFDataSources(t, in),
 		updateClusterTier(t, in),
-		updateVaultPublicEndpointObservabilityDataAndMVU(t, in),
-		updateTierPublicEndpointAndRemoveObservabilityData(t, in),
+		updatePublicProxyObservabilityAndMVU(t, in),
+		updateTierPublicProxyAndRemoveObservability(t, in),
 	}
 }
 
@@ -197,6 +200,7 @@ func createClusteAndTestAdminTokenGeneration(t *testing.T, in *inputT) resource.
 			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_public_endpoint_url"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_private_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_private_endpoint_url", ""),
+			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_proxy_endpoint_url"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "state"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "created_at"),
 
@@ -258,6 +262,7 @@ func testTFDataSources(t *testing.T, in *inputT) resource.TestStep {
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "cluster_id", in.VaultClusterDataSourceName, "cluster_id"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "hvn_id", in.VaultClusterDataSourceName, "hvn_id"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "public_endpoint", in.VaultClusterDataSourceName, "public_endpoint"),
+			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "proxy_endpoint", in.VaultClusterDataSourceName, "proxy_endpoint"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "min_vault_version", in.VaultClusterDataSourceName, "min_vault_version"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "tier", in.VaultClusterDataSourceName, "tier"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "organization_id", in.VaultClusterDataSourceName, "organization_id"),
@@ -267,8 +272,8 @@ func testTFDataSources(t *testing.T, in *inputT) resource.TestStep {
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "namespace", in.VaultClusterDataSourceName, "namespace"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "vault_version", in.VaultClusterDataSourceName, "vault_version"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "vault_public_endpoint_url", in.VaultClusterDataSourceName, "vault_public_endpoint_url"),
-			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "vault_private_endpoint_url", in.VaultClusterDataSourceName, "vault_private_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_private_endpoint_url", "8200"),
+			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "vault_proxy_endpoint_url", in.VaultClusterDataSourceName, "vault_proxy_endpoint_url"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "created_at", in.VaultClusterDataSourceName, "created_at"),
 			resource.TestCheckResourceAttrPair(in.VaultClusterResourceName, "state", in.VaultClusterDataSourceName, "state"),
 		),
@@ -279,7 +284,7 @@ func testTFDataSources(t *testing.T, in *inputT) resource.TestStep {
 func updateClusterTier(t *testing.T, in *inputT) resource.TestStep {
 	newIn := *in
 	return resource.TestStep{
-		Config: testConfig(setTestAccVaultClusterConfig(t, updatedVaultClusterTierAndMVUConfig, newIn, newIn.UpdateTier1)),
+		Config: testConfig(setTestAccVaultClusterConfig(t, updatedVaultClusterTierPublicProxyAndMVU, newIn, newIn.UpdateTier1)),
 		Check: resource.ComposeTestCheckFunc(
 			testAccCheckVaultClusterExists(in.VaultClusterResourceName),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "tier", in.UpdateTier1),
@@ -290,19 +295,23 @@ func updateClusterTier(t *testing.T, in *inputT) resource.TestStep {
 	}
 }
 
-// This step verifies the successful update of "public_endpoint", "audit_log", "metrics" and MVU config
-func updateVaultPublicEndpointObservabilityDataAndMVU(t *testing.T, in *inputT) resource.TestStep {
+// This step verifies the successful update of "public_endpoint", "proxy_endpoint", "audit_log", "metrics" and MVU config.
+func updatePublicProxyObservabilityAndMVU(t *testing.T, in *inputT) resource.TestStep {
 	newIn := *in
 	newIn.PublicEndpoint = "true"
+	newIn.ProxyEndpoint = "ENABLED"
 	return resource.TestStep{
-		Config: testConfig(setTestAccVaultClusterConfig(t, updatedVaultClusterPublicAndMetricsAuditLog, newIn, newIn.UpdateTier1)),
+		Config: testConfig(setTestAccVaultClusterConfig(t, updatedVaultClusterPublicProxyObservabilityAndMVU, newIn, newIn.UpdateTier1)),
 		Check: resource.ComposeTestCheckFunc(
 			testAccCheckVaultClusterExists(in.VaultClusterResourceName),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "public_endpoint", "true"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "proxy_endpoint", "ENABLED"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_public_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_public_endpoint_url", "8200"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_private_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_private_endpoint_url", "8200"),
+			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_proxy_endpoint_url"),
+			testAccCheckFullURL(in.VaultClusterResourceName, "vault_proxy_endpoint_url", ""),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "metrics_config.0.splunk_hecendpoint", "https://http-input-splunkcloud.com"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "metrics_config.0.splunk_token"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "audit_log_config.0.datadog_api_key"),
@@ -312,20 +321,23 @@ func updateVaultPublicEndpointObservabilityDataAndMVU(t *testing.T, in *inputT) 
 	}
 }
 
-// This step verifies the successful update of both "tier" and "public_endpoint" and removal of "metrics" and "audit_log"
-func updateTierPublicEndpointAndRemoveObservabilityData(t *testing.T, in *inputT) resource.TestStep {
+// This step verifies the successful update of "tier", "public_endpoint", "proxy_endpoint" and removal of "metrics" and "audit_log"
+func updateTierPublicProxyAndRemoveObservability(t *testing.T, in *inputT) resource.TestStep {
 	newIn := *in
 	newIn.PublicEndpoint = "false"
+	newIn.ProxyEndpoint = "DISABLED"
 	return resource.TestStep{
-		Config: testConfig(setTestAccVaultClusterConfig(t, updatedVaultClusterTierAndMVUConfig, newIn, newIn.UpdateTier2)),
+		Config: testConfig(setTestAccVaultClusterConfig(t, updatedVaultClusterTierPublicProxyAndMVU, newIn, newIn.UpdateTier2)),
 		Check: resource.ComposeTestCheckFunc(
 			testAccCheckVaultClusterExists(in.VaultClusterResourceName),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "tier", in.UpdateTier2),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "public_endpoint", "false"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "proxy_endpoint", "DISABLED"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_public_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_public_endpoint_url", "8200"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_private_endpoint_url"),
 			testAccCheckFullURL(in.VaultClusterResourceName, "vault_private_endpoint_url", "8200"),
+			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "vault_proxy_endpoint_url"),
 			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "metrics_config.0"),
 			resource.TestCheckNoResourceAttr(in.VaultClusterResourceName, "audit_log_config.0"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "major_version_upgrade_config.0.upgrade_type", "SCHEDULED"),

--- a/internal/provider/resource_vault_cluster_test.go
+++ b/internal/provider/resource_vault_cluster_test.go
@@ -189,6 +189,7 @@ func createClusteAndTestAdminTokenGeneration(t *testing.T, in *inputT) resource.
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "cloud_provider", in.CloudProvider),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "region", in.Region),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "public_endpoint", "false"),
+			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "proxy_endpoint", "DISABLED"),
 			resource.TestCheckResourceAttr(in.VaultClusterResourceName, "namespace", "admin"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "vault_version"),
 			resource.TestCheckResourceAttrSet(in.VaultClusterResourceName, "organization_id"),

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -345,8 +345,19 @@ func validateVaultClusterProxyEndpoint(v interface{}, path cty.Path) diag.Diagno
 
 	err := vaultmodels.HashicorpCloudVault20201125HTTPProxyOption(strings.ToUpper(v.(string))).Validate(strfmt.Default)
 	if err != nil {
-		enumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
-		expectedEnumList := strings.ToLower(enumList)
+		enumList := regexp.MustCompile(`\[(.*)\]`).FindStringSubmatch(err.Error())
+		expectedEnumList := strings.ToLower(enumList[1])
+
+		// Remove invalid option from allowed list in error message
+		expectedEnumList = strings.ReplaceAll(
+			expectedEnumList,
+			strings.ToLower(string(vaultmodels.HashicorpCloudVault20201125HTTPProxyOptionHTTPPROXYOPTIONINVALID)),
+			"",
+		)
+
+		// Format as comma-separated list
+		expectedEnumList = strings.Join(strings.Fields(expectedEnumList), ", ")
+
 		msg := fmt.Sprintf("expected '%v' to be one of: %v", v, expectedEnumList)
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -340,6 +340,25 @@ func validateVaultPathsFilter(v interface{}, path cty.Path) diag.Diagnostics {
 	return diagnostics
 }
 
+func validateVaultClusterProxyEndpoint(v interface{}, path cty.Path) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	err := vaultmodels.HashicorpCloudVault20201125HTTPProxyOption(strings.ToUpper(v.(string))).Validate(strfmt.Default)
+	if err != nil {
+		enumList := regexp.MustCompile(`\[.*\]`).FindString(err.Error())
+		expectedEnumList := strings.ToLower(enumList)
+		msg := fmt.Sprintf("expected '%v' to be one of: %v", v, expectedEnumList)
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       msg,
+			Detail:        msg + " (value is case-insensitive).",
+			AttributePath: path,
+		})
+	}
+
+	return diagnostics
+}
+
 func validateCIDRBlockHVN(v interface{}, path cty.Path) diag.Diagnostics {
 	// HVNs allow RFC 1918 Network CIDRs
 	return validateCIDRBlock(v, path, RFC1918Networks)


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Updating the `hcp_vault_cluster` resource to have `proxy_endpoint` (writeable) and `vault_proxy_endpoint_url` (read-only) fields. The `proxy_endpoint` field allows users to toggle the proxy on/off for their cluster. This feature was released on Mon Aug 7 for HCP Vault Dedicated through the UI.

As part of this change, we are also refactoring `public_endpoint` updates to be grouped into `UpdateVaultClusterConfig` call and moving off of `UpdateVaultClusterPublicIps`. Please refer to the [ADR](https://docs.google.com/document/d/1wad3DHl8HN5AZW9VH2_sIGoZtosRpeCKxZ_BdJ0V42U/edit) for more details.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<details><summary>AWS</summary>

```zsh
$ make testacc TESTARGS='-run=TestAccVaultClusterAWS'
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultClusterAWS -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	0.617s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.771s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.577s [no tests to run]
=== RUN   TestAccVaultClusterAWS
=== PAUSE TestAccVaultClusterAWS
=== CONT  TestAccVaultClusterAWS
--- PASS: TestAccVaultClusterAWS (3218.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	3219.240s
```

Checking the three updates that are run on acceptance tests:

[First update](https://github.com/hashicorp/terraform-provider-hcp/blob/5a3daf8036e260b7428915b0494b39f3cfe370a8/internal/provider/resource_vault_cluster_test.go#L166) is tier only:
<img width="1728" alt="Screen Shot 2023-08-10 at 10 26 39 AM" src="https://github.com/hashicorp/terraform-provider-hcp/assets/25168806/e6359a36-0e9e-4748-956b-f25ca817faf4">

[Second update](https://github.com/hashicorp/terraform-provider-hcp/blob/hvt-4182-http-proxy-for-hcpv-in-hcp-tfp/internal/provider/resource_vault_cluster_test.go#L167) now updates public and proxy in addition to observability on update call (mvu update is through different endpoint)
<img width="1728" alt="Screen Shot 2023-08-10 at 10 27 08 AM" src="https://github.com/hashicorp/terraform-provider-hcp/assets/25168806/fa59c7f0-a232-4313-94c6-22dd64f3c894">

[Third update](https://github.com/hashicorp/terraform-provider-hcp/blob/5a3daf8036e260b7428915b0494b39f3cfe370a8/internal/provider/resource_vault_cluster_test.go#L168) now updates public and proxy in addition to observability and tier on update call
</details>

<details><summary>Azure (slightly affected by update refactoring, but Azure currently only tests tier update)</summary>

```zsh
$ make testacc TESTARGS='-run=TestAccVaultClusterAzure'
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultClusterAzure -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
=== RUN   TestAccVaultClusterAzure
=== PAUSE TestAccVaultClusterAzure
=== CONT  TestAccVaultClusterAzure
--- PASS: TestAccVaultClusterAzure (3453.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	3454.288s
```

</details>

<details><summary>Validation with local binary</summary>

First, created clusters on latest 0.68.0 (when HCP TFP has no knowledge of proxy fields, so clusters are created with zero enum i.e. `HTTP_PROXY_OPTION_INVALID`) using `test.tf`:
```tf
terraform {
  required_version = ">=1.0"
  required_providers {
    hcp = {
      source  = "hashicorp/hcp"
      version = "0.68.0"
    }

    # hcp = {
    #   source  = "localhost/providers/hcp"
    #   version = "0.0.1"
    # }
  }
}

// Organization principal
provider "hcp" {
  client_id     = "Aok5s8hobLi3aTM9bds56ZQFuIdZQWMO"
  client_secret = "xYUYZy_VHLGEl2p9VfR6D_a3LA4F2lKNZC06THf_E9HcIaQs0uI6EP-uvQz9-3UN"
}

// Create a HashiCorp Virtual Network (HVN):
resource "hcp_hvn" "terraform-hvn" {
  hvn_id         = "terraform-hvn"
  cloud_provider = "aws"
  region         = "us-west-2"
  cidr_block     = "172.25.16.0/20"
}

resource "hcp_hvn" "terraform-hvn-az" {
  hvn_id         = "terraform-hvn-az"
  cloud_provider = "azure"
  region         = "eastus"
  cidr_block     = "172.26.16.0/20"
}

// Create HCPV cluster on AWS:
resource "hcp_vault_cluster" "tf-vault-cluster" {
  depends_on      = [hcp_hvn.terraform-hvn]
  hvn_id          = hcp_hvn.terraform-hvn.hvn_id
  cluster_id      = "tf-vault-cluster"
  tier            = "starter_small"
  public_endpoint = true
  lifecycle {
    prevent_destroy = true
  }
}

// Create HCPV cluster on Azure:
resource "hcp_vault_cluster" "tf-vault-cluster-az" {
  depends_on      = [hcp_hvn.terraform-hvn-az]
  hvn_id          = hcp_hvn.terraform-hvn-az.hvn_id
  cluster_id      = "tf-vault-cluster-az"
  tier            = "starter_small"
  public_endpoint = true
  lifecycle {
    prevent_destroy = true
  }
}

```

Followed guide [here](https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md#how-to-test-existing-resources) to test using local binary and point my `test.tf`  file to

```tf
    hcp = {
      source  = "localhost/providers/hcp"
      version = "0.0.1"
    }
```

After I created the clusters, I had to run `terraform refresh` for the new field to be picked up (otherwise it would try to populate the field to `DISABLED` default). After refreshing then running `terraform plan`, no changes show up as expected. Even though the cluster was created with `INVALID` enum, on `terraform refresh`, the cloud-vault-service API masks invalid values as `DISABLED` [here](https://github.com/hashicorp/cloud-vault-service/blob/23e753a02257f6bfbb8e111c9909f8a43072e577/service/public/20201125/convert/config.go#L227-L232), which is why we are able to get "no change."

```zsh
[~/test/hvt-4182/test-prod]$ terraform refresh
hcp_hvn.terraform-hvn-az: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.network.hvn/terraform-hvn-az]
hcp_hvn.terraform-hvn: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.network.hvn/terraform-hvn]
hcp_vault_cluster.tf-vault-cluster-az: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.vault.cluster/tf-vault-cluster-az]
hcp_vault_cluster.tf-vault-cluster: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.vault.cluster/tf-vault-cluster]
[~/test/hvt-4182/test-prod]$ terraform plan
hcp_hvn.terraform-hvn: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.network.hvn/terraform-hvn]
hcp_hvn.terraform-hvn-az: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.network.hvn/terraform-hvn-az]
hcp_vault_cluster.tf-vault-cluster-az: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.vault.cluster/tf-vault-cluster-az]
hcp_vault_cluster.tf-vault-cluster: Refreshing state... [id=/project/4e61ebde-1d37-4c03-aeed-c3622d0d1e8d/hashicorp.vault.cluster/tf-vault-cluster]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Also validated the following with the local binary:
- [x] AWS create with `DISABLED`
- [x] Azure create with `DISABLED`
- [x] AWS create with `ENABLED`
- [x] AWS update to `ENABLED`
- [x] AWS update to `DISABLED`
- [x] Azure create with `ENABLED` returns service error
- [x] Azure update to `ENABLED` returns service error
- [x] Azure update for both public IP and scaling no longer takes 2 updates (40 minutes); it only takes one update now.

</details>