### PR TITLE
Increase revocation time to account for parallelization pausing tests

### DIFF
--- a/internal/provider/data_source_packer_image_test.go
+++ b/internal/provider/data_source_packer_image_test.go
@@ -144,7 +144,7 @@ func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 	bucketSlug := testAccCreateSlug("ImageRevoked")
 	channelSlug := bucketSlug // No need for a different slug
 
-	revokeAt := strfmt.DateTime(time.Now().UTC().Add(5 * time.Minute))
+	revokeAt := strfmt.DateTime(time.Now().UTC().Add(24 * time.Hour))
 
 	buildOptions := defaultBuildOptions
 	region := buildOptions.images[0].Region

--- a/internal/provider/data_source_packer_iteration_test.go
+++ b/internal/provider/data_source_packer_iteration_test.go
@@ -61,7 +61,7 @@ func TestAcc_dataSourcePackerIteration_Simple(t *testing.T) {
 func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
 	bucketSlug := testAccCreateSlug("IterationRevoked")
 	channelSlug := bucketSlug // No need for a different slug
-	revokeAt := strfmt.DateTime(time.Now().UTC().Add(5 * time.Minute))
+	revokeAt := strfmt.DateTime(time.Now().UTC().Add(24 * time.Hour))
 
 	config := testAccPackerDataIterationBuilder("Revoked", fmt.Sprintf("%q", bucketSlug), fmt.Sprintf("%q", channelSlug))
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Increase revocation time to account for parallelization pausing tests
  - Fixes the two packer tests that are currently blocking releases
  - Wasn't caught by original testing because packer tests run faster than the 5 minute revocation time, but the full test suite takes a few hours. Increased to 24 hours to give plenty of time.

Thank you @helenfufu for bringing this to my attention!

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

https://github.com/hashicorp/terraform-provider-hcp/actions/runs/5886473625/job/15964386346