### PR TITLE
Fix semver validation

### DIFF
--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/go-version"
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/stable/2021-02-04/models"
 	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -95,8 +96,7 @@ func validateStringInSlice(valid []string, ignoreCase bool) schema.SchemaValidat
 // validateSemVer ensures a specified string is a SemVer.
 func validateSemVer(v interface{}, path cty.Path) diag.Diagnostics {
 	var diagnostics diag.Diagnostics
-
-	if !regexp.MustCompile(`^v?\d+.\d+.\d+$`).MatchString(v.(string)) {
+	if _, err := version.NewSemver(v.(string)); err != nil {
 		msg := "must be a valid semver"
 		diagnostics = append(diagnostics, diag.Diagnostic{
 			Severity:      diag.Error,

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -102,8 +102,12 @@ func Test_validateSemVer(t *testing.T) {
 			input:    "1.2.3",
 			expected: nil,
 		},
+		"valid pre-release semver": {
+			input:    "1.2.3-rc",
+			expected: nil,
+		},
 		"invalid semver": {
-			input: "v1.2.3.4.5",
+			input: "v1.2.3.beta",
 			expected: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity:      diag.Error,


### PR DESCRIPTION
The existing validation prevented from specifying a pre-release version which is also a valid semver.
The PR changes it to utilize the [go-version](https://github.com/hashicorp/go-version) library helper which follows the[ SemVer](https://semver.org/) spec.

