### PR TITLE
fix test CI

### DIFF
--- a/.changelog/591.txt
+++ b/.changelog/591.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+update hcp_vault_plugin resource test. remove hard coded values that were used for local testing.
+```

--- a/internal/provider/resource_vault_plugin.go
+++ b/internal/provider/resource_vault_plugin.go
@@ -95,7 +95,7 @@ func resourceVaultPluginCreate(ctx context.Context, d *schema.ResourceData, meta
 		ProjectID:      projectID,
 	}
 
-	log.Printf("[INFO] Adding Vault Plugin (%s) on Vault Cluster (%s)", pluginName, clusterID)
+	log.Printf("[INFO] Adding Vault Plugin (%s) on Vault Cluster (%s) [project_id=%s, organization_id=%s]", pluginName, clusterID, loc.ProjectID, loc.OrganizationID)
 
 	req := &vaultmodels.HashicorpCloudVault20201125AddPluginRequest{PluginName: pluginName, PluginType: pluginType}
 	_, err = clients.AddPlugin(ctx, client, loc, clusterID, req)


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixing acceptance test for `hcp_vault_plugin` resource by removing hard coded variables.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccVaultPlugin'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultPlugin -timeout 360m -parallel=10
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
=== RUN   TestAccVaultPlugin
--- PASS: TestAccVaultPlugin (925.98s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider   926.897s

...
```
