### PR TITLE
Updates for a manual patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.71.1 (September 25, 2023)
+
+BUG FIXES:
+
+* project_id unauthorized issue when using config client secret [[GH-604](https://github.com/hashicorp/terraform-provider-hcp/pull/604)]
+
 ## v0.71.0 (September 20, 2023)
 
 FEATURES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.71.0"
+      version = "~> 0.71.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.71.0"
+      version = "~> 0.71.1"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description
Currently we need to release a patch fix to a bug that went [out](https://github.com/hashicorp/terraform-provider-hcp/issues/603) in the `0.71.0`. 

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
