### PR TITLE
Fix HVN Docs

### DIFF
--- a/docs/data-sources/hvn.md
+++ b/docs/data-sources/hvn.md
@@ -3,6 +3,7 @@ page_title: "hcp_hvn Data Source - terraform-provider-hcp"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
   The HVN data source provides information about an existing HashiCorp Virtual Network.
+---
 
 # hcp_hvn (Data Source)
 

--- a/docs/data-sources/hvn_peering_connection.md
+++ b/docs/data-sources/hvn_peering_connection.md
@@ -3,6 +3,7 @@ page_title: "hcp_hvn_peering_connection Data Source - terraform-provider-hcp"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
   The HVN peering connection data source provides information about an existing peering connection between HVNs.
+---
 
 # hcp_hvn_peering_connection (Data Source)
 
@@ -46,4 +47,3 @@ data "hcp_hvn_peering_connection" "test" {
 Optional:
 
 - `default` (String)
-

--- a/docs/data-sources/hvn_route.md
+++ b/docs/data-sources/hvn_route.md
@@ -3,6 +3,7 @@ page_title: "hcp_hvn_route Data Source - terraform-provider-hcp"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
   The HVN route data source provides information about an existing HVN route.
+---
 
 # hcp_hvn_route (Data Source)
 
@@ -45,4 +46,3 @@ data "hcp_hvn_route" "example" {
 Optional:
 
 - `default` (String)
-

--- a/docs/guides/hvn-route-migration-guide.md
+++ b/docs/guides/hvn-route-migration-guide.md
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "HashiCorp Virtual Networks"
 page_title: "HVN Route Migration Guide - HCP Provider"
 description: |-
     An guide to migrating HCP networking resources to use HVN routes.

--- a/docs/resources/aws_network_peering.md
+++ b/docs/resources/aws_network_peering.md
@@ -3,6 +3,7 @@ page_title: "hcp_aws_network_peering Resource - terraform-provider-hcp"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
   The AWS network peering resource allows you to manage a network peering between an HVN and a peer AWS VPC.
+---
 
 # hcp_aws_network_peering (Resource)
 

--- a/docs/resources/hvn_peering_connection.md
+++ b/docs/resources/hvn_peering_connection.md
@@ -3,6 +3,7 @@ page_title: "hcp_hvn_peering_connection Resource - terraform-provider-hcp"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
   The HVN peering connection resource allows you to manage a peering connection between HVNs.
+---
 
 # hcp_hvn_peering_connection (Resource)
 

--- a/templates/data-sources/hvn.md.tmpl
+++ b/templates/data-sources/hvn.md.tmpl
@@ -3,6 +3,7 @@ page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/data-sources/hvn_peering_connection.md.tmpl
+++ b/templates/data-sources/hvn_peering_connection.md.tmpl
@@ -3,6 +3,7 @@ page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
 
 # {{.Name}} ({{.Type}})
 
@@ -13,4 +14,3 @@ description: |-
 {{ tffile "examples/data-sources/hcp_hvn_peering_connection/data-source.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
-

--- a/templates/data-sources/hvn_route.md.tmpl
+++ b/templates/data-sources/hvn_route.md.tmpl
@@ -3,6 +3,7 @@ page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
 
 # {{.Name}} ({{.Type}})
 
@@ -13,4 +14,3 @@ description: |-
 {{ tffile "examples/data-sources/hcp_hvn_route/data-source.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
-

--- a/templates/guides/hvn-route-migration-guide.md.tmpl
+++ b/templates/guides/hvn-route-migration-guide.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "HashiCorp Virtual Networks"
 page_title: "HVN Route Migration Guide - HCP Provider"
 description: |-
     An guide to migrating HCP networking resources to use HVN routes.

--- a/templates/resources/aws_network_peering.md.tmpl
+++ b/templates/resources/aws_network_peering.md.tmpl
@@ -3,6 +3,7 @@ page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
 
 # {{.Name}} ({{.Type}})
 
@@ -18,11 +19,4 @@ description: |-
 
 Import is supported using the following syntax:
 
-```shell
-# Using an explicit project ID, the import ID is:
-# {project_id}:{hvn_id}:{peering_id}
-terraform import hcp_aws_network_peering.peer f709ec73-55d4-46d8-897d-816ebba28778:main-hvn:11eb60b3-d4ec-5eed-aacc-0242ac120015
-# Using the provider-default project ID, the import ID is:
-# {hvn_id}:{peering_id}
-terraform import hcp_aws_network_peering.peer main-hvn:11eb60b3-d4ec-5eed-aacc-0242ac120015
-```
+{{ codefile "shell" "examples/resources/hcp_aws_network_peering/import.sh" }}

--- a/templates/resources/hvn_peering_connection.md.tmpl
+++ b/templates/resources/hvn_peering_connection.md.tmpl
@@ -3,6 +3,7 @@ page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: "HashiCorp Virtual Networks"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
 
 # {{.Name}} ({{.Type}})
 
@@ -18,13 +19,4 @@ description: |-
 
 Import is supported using the following syntax:
 
-```shell
-# Only the first HVN ID is required (hvn_1_id), HVN 2 will be populated after import.
-
-# Using an explicit project ID, the import ID is:
-# {project_id}:{hvn_1_id}:{peering_id}
-terraform import hcp_hvn_peering_connection.peer_1 f709ec73-55d4-46d8-897d-816ebba28778:hvn-1:peer-1
-# Using the provider-default project ID, the import ID is:
-# {hvn_1_id}:{peering_id}
-terraform import hcp_hvn_peering_connection.peer_1 hvn-1:peer-1
-```
+{{ codefile "shell" "examples/resources/hcp_hvn_peering_connection/import.sh" }}


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Fixes problems missed/introduced by #585 
  - Improper header formatting (header displays as part of page text and categorization is ignored)
  - Templates not using `import.sh` in the `examples` folder
  - Product-specific guides missing a product category