### PR TITLE
Remove subcategories from Guides

### DIFF
--- a/.changelog/622.txt
+++ b/.changelog/622.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix documentation duplicate subcategory issue introduced by [#620](https://github.com/hashicorp/terraform-provider-hcp/pull/620)
+```

--- a/docs/guides/consul-federation.md
+++ b/docs/guides/consul-federation.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Consul"
+subcategory: ""
 page_title: "Consul Federation with Auto HVN Peering - HCP Provider"
 description: |-
     An example of federating a new HCP Consul cluster with an existing one via auto peering.

--- a/docs/guides/consul-root-token.md
+++ b/docs/guides/consul-root-token.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Consul"
+subcategory: ""
 page_title: "Create a new ACL root token - HCP Provider"
 description: |-
     An example of creating a new ACL root token.

--- a/docs/guides/consul-snapshots.md
+++ b/docs/guides/consul-snapshots.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Consul"
+subcategory: ""
 page_title: "Create Consul cluster snapshots in HCP - HCP Provider"
 description: |-
     An example of creating an HCP Consul cluster snapshot.

--- a/docs/guides/hvn-route-migration-guide.md
+++ b/docs/guides/hvn-route-migration-guide.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HashiCorp Virtual Networks"
+subcategory: ""
 page_title: "HVN Route Migration Guide - HCP Provider"
 description: |-
     An guide to migrating HCP networking resources to use HVN routes.

--- a/docs/guides/packer-channel-management.md
+++ b/docs/guides/packer-channel-management.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Packer"
+subcategory: ""
 page_title: "Advanced Packer Channel Management - HCP Provider"
 description: |-
     A guide to integreting HCP Packer resources and data sources for more advanced channel management.

--- a/docs/guides/packer-run-tasks-with-terraform.md
+++ b/docs/guides/packer-run-tasks-with-terraform.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Packer"
+subcategory: ""
 page_title: "Packer Run Tasks with Terraform - HCP Provider"
 description: |-
     A guide to integrating HCP Packer with Terraform using Run Tasks. 

--- a/docs/guides/vault-admin-token.md
+++ b/docs/guides/vault-admin-token.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Vault"
+subcategory: ""
 page_title: "Create a Vault cluster and admin token - HCP Provider"
 description: |-
     An example of creating a Vault cluster and admin token.

--- a/docs/guides/vault-performance-replication.md
+++ b/docs/guides/vault-performance-replication.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Vault"
+subcategory: ""
 page_title: "Configure Vault performance replication - HCP Provider"
 description: |-
     Configure performance replication between two Plus tier clusters.

--- a/docs/guides/vault-scaling.md
+++ b/docs/guides/vault-scaling.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Vault"
+subcategory: ""
 page_title: "Resize or scale a Vault cluster - HCP Provider"
 description: |-
     Change a current HCP Vault cluster in terms of tiers (Dev, Starter, Standard, Plus) or sizes (S, M, L).

--- a/templates/guides/consul-federation.md.tmpl
+++ b/templates/guides/consul-federation.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Consul"
+subcategory: ""
 page_title: "Consul Federation with Auto HVN Peering - HCP Provider"
 description: |-
     An example of federating a new HCP Consul cluster with an existing one via auto peering.

--- a/templates/guides/consul-root-token.md.tmpl
+++ b/templates/guides/consul-root-token.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Consul"
+subcategory: ""
 page_title: "Create a new ACL root token - HCP Provider"
 description: |-
     An example of creating a new ACL root token.

--- a/templates/guides/consul-snapshots.md.tmpl
+++ b/templates/guides/consul-snapshots.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Consul"
+subcategory: ""
 page_title: "Create Consul cluster snapshots in HCP - HCP Provider"
 description: |-
     An example of creating an HCP Consul cluster snapshot.

--- a/templates/guides/hvn-route-migration-guide.md.tmpl
+++ b/templates/guides/hvn-route-migration-guide.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HashiCorp Virtual Networks"
+subcategory: ""
 page_title: "HVN Route Migration Guide - HCP Provider"
 description: |-
     An guide to migrating HCP networking resources to use HVN routes.

--- a/templates/guides/packer-channel-management.md.tmpl
+++ b/templates/guides/packer-channel-management.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Packer"
+subcategory: ""
 page_title: "Advanced Packer Channel Management - HCP Provider"
 description: |-
     A guide to integreting HCP Packer resources and data sources for more advanced channel management.

--- a/templates/guides/packer-run-tasks-with-terraform.md.tmpl
+++ b/templates/guides/packer-run-tasks-with-terraform.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Packer"
+subcategory: ""
 page_title: "Packer Run Tasks with Terraform - HCP Provider"
 description: |-
     A guide to integrating HCP Packer with Terraform using Run Tasks. 

--- a/templates/guides/vault-admin-token.md.tmpl
+++ b/templates/guides/vault-admin-token.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Vault"
+subcategory: ""
 page_title: "Create a Vault cluster and admin token - HCP Provider"
 description: |-
     An example of creating a Vault cluster and admin token.

--- a/templates/guides/vault-performance-replication.md.tmpl
+++ b/templates/guides/vault-performance-replication.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Vault"
+subcategory: ""
 page_title: "Configure Vault performance replication - HCP Provider"
 description: |-
     Configure performance replication between two Plus tier clusters.

--- a/templates/guides/vault-scaling.md.tmpl
+++ b/templates/guides/vault-scaling.md.tmpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "HCP Vault"
+subcategory: ""
 page_title: "Resize or scale a Vault cluster - HCP Provider"
 description: |-
     Change a current HCP Vault cluster in terms of tiers (Dev, Starter, Standard, Plus) or sizes (S, M, L).


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Remove subcategories from Guides to fix duplicate folders: https://registry.terraform.io/providers/hashicorp/hcp/0.72.1/docs
