### PR TITLE
Move SDKv2 tests to use `terraform-plugin-test`

### DIFF
--- a/internal/providersdkv2/data_source_aws_transit_gateway_attachment.go
+++ b/internal/providersdkv2/data_source_aws_transit_gateway_attachment.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_consul_agent_helm_config.go
+++ b/internal/providersdkv2/data_source_consul_agent_helm_config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_consul_agent_kubernetes_secret.go
+++ b/internal/providersdkv2/data_source_consul_agent_kubernetes_secret.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_consul_cluster.go
+++ b/internal/providersdkv2/data_source_consul_cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_consul_versions.go
+++ b/internal/providersdkv2/data_source_consul_versions.go
@@ -12,7 +12,6 @@ import (
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/stable/2021-02-04/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/consul"
 )

--- a/internal/providersdkv2/data_source_hvn_route.go
+++ b/internal/providersdkv2/data_source_hvn_route.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_packer_bucket_names.go
+++ b/internal/providersdkv2/data_source_packer_bucket_names.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/internal/providersdkv2/data_source_packer_bucket_names_test.go
+++ b/internal/providersdkv2/data_source_packer_bucket_names_test.go
@@ -6,7 +6,7 @@ package providersdkv2
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAcc_dataSourcePackerBucketNames(t *testing.T) {

--- a/internal/providersdkv2/data_source_packer_image_test.go
+++ b/internal/providersdkv2/data_source_packer_image_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAcc_dataSourcePackerImage_Simple(t *testing.T) {

--- a/internal/providersdkv2/data_source_packer_iteration_test.go
+++ b/internal/providersdkv2/data_source_packer_iteration_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAcc_dataSourcePackerIteration_Simple(t *testing.T) {

--- a/internal/providersdkv2/data_source_packer_run_task_test.go
+++ b/internal/providersdkv2/data_source_packer_run_task_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_vault_cluster.go
+++ b/internal/providersdkv2/data_source_vault_cluster.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/data_source_vault_plugin.go
+++ b/internal/providersdkv2/data_source_vault_plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/location_test.go
+++ b/internal/providersdkv2/location_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/version"
 )

--- a/internal/providersdkv2/resource_aws_network_peering.go
+++ b/internal/providersdkv2/resource_aws_network_peering.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_aws_network_peering_test.go
+++ b/internal/providersdkv2/resource_aws_network_peering_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_aws_network_peering_test.go
+++ b/internal/providersdkv2/resource_aws_network_peering_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )

--- a/internal/providersdkv2/resource_aws_transit_gateway_attachment.go
+++ b/internal/providersdkv2/resource_aws_transit_gateway_attachment.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )

--- a/internal/providersdkv2/resource_azure_peering_connection_test.go
+++ b/internal/providersdkv2/resource_azure_peering_connection_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_boundary_cluster_test.go
+++ b/internal/providersdkv2/resource_boundary_cluster_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_consul_cluster.go
+++ b/internal/providersdkv2/resource_consul_cluster.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/consul"
 	"github.com/hashicorp/terraform-provider-hcp/internal/input"

--- a/internal/providersdkv2/resource_consul_cluster_root_token.go
+++ b/internal/providersdkv2/resource_consul_cluster_root_token.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_consul_cluster_test.go
+++ b/internal/providersdkv2/resource_consul_cluster_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_consul_snapshot.go
+++ b/internal/providersdkv2/resource_consul_snapshot.go
@@ -9,13 +9,11 @@ import (
 	"strconv"
 	"time"
 
-	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/stable/2021-02-04/models"
+	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_consul_snapshot_test.go
+++ b/internal/providersdkv2/resource_consul_snapshot_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_hvn.go
+++ b/internal/providersdkv2/resource_hvn.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"time"
 
-	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/client/network_service"
 	networkmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/models"
+	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/internal/providersdkv2/resource_hvn_peering_connection_test.go
+++ b/internal/providersdkv2/resource_hvn_peering_connection_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_hvn_route.go
+++ b/internal/providersdkv2/resource_hvn_route.go
@@ -14,7 +14,6 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_hvn_route_test.go
+++ b/internal/providersdkv2/resource_hvn_route_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_hvn_route_test.go
+++ b/internal/providersdkv2/resource_hvn_route_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )

--- a/internal/providersdkv2/resource_hvn_test.go
+++ b/internal/providersdkv2/resource_hvn_test.go
@@ -12,7 +12,6 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_hvn_test.go
+++ b/internal/providersdkv2/resource_hvn_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )

--- a/internal/providersdkv2/resource_packer_channel_assignment_test.go
+++ b/internal/providersdkv2/resource_packer_channel_assignment_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_packer_channel_test.go
+++ b/internal/providersdkv2/resource_packer_channel_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccPackerChannel(t *testing.T) {

--- a/internal/providersdkv2/resource_packer_run_task_test.go
+++ b/internal/providersdkv2/resource_packer_run_task_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_vault_cluster.go
+++ b/internal/providersdkv2/resource_vault_cluster.go
@@ -12,11 +12,9 @@ import (
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/input"
 )

--- a/internal/providersdkv2/resource_vault_cluster_perf_replication_test.go
+++ b/internal/providersdkv2/resource_vault_cluster_perf_replication_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/providersdkv2/resource_vault_cluster_test.go
+++ b/internal/providersdkv2/resource_vault_cluster_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_vault_plugin.go
+++ b/internal/providersdkv2/resource_vault_plugin.go
@@ -12,11 +12,9 @@ import (
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/resource_vault_plugin_test.go
+++ b/internal/providersdkv2/resource_vault_plugin_test.go
@@ -13,9 +13,8 @@ import (
 	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	grpcstatus "google.golang.org/grpc/status"
-
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 var (

--- a/internal/providersdkv2/resource_vault_plugin_test.go
+++ b/internal/providersdkv2/resource_vault_plugin_test.go
@@ -11,8 +11,8 @@ import (
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	vaultmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"

--- a/internal/providersdkv2/test_helpers_test.go
+++ b/internal/providersdkv2/test_helpers_test.go
@@ -11,9 +11,9 @@ import (
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/providersdkv2/validators_test.go
+++ b/internal/providersdkv2/validators_test.go
@@ -8,9 +8,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_validateStringNotEmpty(t *testing.T) {


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Move SDKv2 tests to use `terraform-plugin-test`
  - Framework resources use this package, and it is backwards compatible. Changing all SDKv2 tests to use it now will make migrating SDKv2 resources to Framework a little bit easier in the future

### Acceptance Tests
https://github.com/hashicorp/terraform-provider-hcp/actions/runs/6499954022