### PR TITLE
Upgrade from Protocol 5 to 6

### DIFF
--- a/.changelog/637.txt
+++ b/.changelog/637.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Upgrade to Terraform Provider Protocol 6
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The HashiCorp Cloud Platform (HCP) Terraform Provider is a plugin for Terraform 
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.12.x
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.1.5
 
 > [!WARNING]
 > An upcoming release of the provider will require a Terraform with version >= 1.1.5

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -7,7 +7,7 @@ To learn more about how to create issues and pull requests in this repository, a
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.1.5
 - [Go](https://golang.org/doc/install) >= 1.20
 
 ## Building the Provider

--- a/internal/provider/acctest/setup.go
+++ b/internal/provider/acctest/setup.go
@@ -12,23 +12,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider"
 	"github.com/hashicorp/terraform-provider-hcp/version"
 )
 
-// ProtoV5ProviderFactories provides a Provider Factory to be used within
+// ProtoV6ProviderFactories provides a Provider Factory to be used within
 // acceptance tests.
-var ProtoV5ProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-	"hcp": func() (tfprotov5.ProviderServer, error) {
-		providers := []func() tfprotov5.ProviderServer{
-			providerserver.NewProtocol5(provider.NewFrameworkProvider(version.ProviderVersion)()),
+var ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"hcp": func() (tfprotov6.ProviderServer, error) {
+		providers := []func() tfprotov6.ProviderServer{
+			providerserver.NewProtocol6(provider.NewFrameworkProvider(version.ProviderVersion)()),
 		}
 
-		return tf5muxserver.NewMuxServer(context.Background(), providers...)
+		return tf6muxserver.NewMuxServer(context.Background(), providers...)
 	},
 }
 

--- a/internal/provider/iam/data_service_principal_test.go
+++ b/internal/provider/iam/data_service_principal_test.go
@@ -12,7 +12,7 @@ func TestAccServicePrincipalDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/iam/resource_service_principal_key_test.go
+++ b/internal/provider/iam/resource_service_principal_key_test.go
@@ -16,7 +16,7 @@ func TestAccServicePrincipalKeyResource(t *testing.T) {
 	var spk, spk2, spk3 models.HashicorpCloudIamServicePrincipalKey
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/iam/resource_service_principal_test.go
+++ b/internal/provider/iam/resource_service_principal_test.go
@@ -18,7 +18,7 @@ func TestAccServicePrincipalResource_Project(t *testing.T) {
 	var sp2 models.HashicorpCloudIamServicePrincipal
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{
@@ -65,7 +65,7 @@ func TestAccServicePrincipalResource_ExplicitProject(t *testing.T) {
 	var sp models.HashicorpCloudIamServicePrincipal
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{
@@ -88,7 +88,7 @@ func TestAccServicePrincipalResource_Organization(t *testing.T) {
 	var sp models.HashicorpCloudIamServicePrincipal
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resourcemanager/data_source_organization_test.go
+++ b/internal/provider/resourcemanager/data_source_organization_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccOrganizationDataSource(t *testing.T) {
 	dataSourceAddress := "data.hcp_organization.org"
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resourcemanager/data_source_project_test.go
+++ b/internal/provider/resourcemanager/data_source_project_test.go
@@ -16,7 +16,7 @@ func TestAccProjectDataSource(t *testing.T) {
 	description := acctest.RandString(64)
 
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/resourcemanager/resource_project_test.go
+++ b/internal/provider/resourcemanager/resource_project_test.go
@@ -22,7 +22,7 @@ func TestAccProjectResource(t *testing.T) {
 	projectNameUpdated := acctest.RandString(16)
 	descriptionUpdated := acctest.RandString(200)
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_app_test.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_app_test.go
@@ -56,7 +56,7 @@ func TestAcc_dataSourceVaultSecretsAppMigration(t *testing.T) {
 				),
 			},
 			{
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config: fmt.Sprintf(`
 				data "hcp_vault_secrets_app" "example" {
 					app_name    = %q
@@ -84,7 +84,7 @@ func TestAcc_dataSourceVaultSecretsApp(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create two secrets, one with an additional version and check the latest secrets from data source
 			{

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_secret_test.go
@@ -20,7 +20,7 @@ func TestAcc_dataSourceVaultSecretsSecret(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccVaultSecretsResourceApp(t *testing.T) {
 	testAppName := generateRandomSlug()
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccVaultSecretsResourceSecret(t *testing.T) {
 	testAppName := generateRandomSlug()
 	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/internal/providersdkv2/data_source_packer_bucket_names_test.go
+++ b/internal/providersdkv2/data_source_packer_bucket_names_test.go
@@ -20,7 +20,7 @@ func TestAcc_dataSourcePackerBucketNames(t *testing.T) {
 	// Must not be Parallel, requires that no buckets exist at start of test
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {

--- a/internal/providersdkv2/data_source_packer_image_test.go
+++ b/internal/providersdkv2/data_source_packer_image_test.go
@@ -63,7 +63,7 @@ func TestAcc_dataSourcePackerImage_Simple(t *testing.T) {
 			iteration, build = upsertCompleteIteration(t, bucketSlug, "1234", &buildOptions)
 			upsertChannel(t, bucketSlug, channelSlug, iteration.ID)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -124,7 +124,7 @@ func TestAcc_dataSourcePackerImage_IterationID(t *testing.T) {
 			iteration, build = upsertCompleteIteration(t, bucketSlug, "1234", &buildOptions)
 			upsertChannel(t, bucketSlug, channelSlug, iteration.ID)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -170,7 +170,7 @@ func TestAcc_dataSourcePackerImage_revokedIteration(t *testing.T) {
 			upsertChannel(t, bucketSlug, channelSlug, iteration.ID)
 			revokeIteration(t, iteration.ID, bucketSlug, revokeAt)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -208,7 +208,7 @@ func TestAcc_dataSourcePackerImage_emptyChannel(t *testing.T) {
 			upsertBucket(t, bucketSlug)
 			upsertChannel(t, bucketSlug, channelSlug, "")
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -238,7 +238,7 @@ func TestAcc_dataSourcePackerImage_channelAndIterationIDReject(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      testConfig(testAccConfigBuildersToString(config)),

--- a/internal/providersdkv2/data_source_packer_iteration_test.go
+++ b/internal/providersdkv2/data_source_packer_iteration_test.go
@@ -30,7 +30,7 @@ func TestAcc_dataSourcePackerIteration_Simple(t *testing.T) {
 			iteration, _ = upsertCompleteIteration(t, bucketSlug, "1234", nil)
 			upsertChannel(t, bucketSlug, channelSlug, iteration.ID)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -76,7 +76,7 @@ func TestAcc_dataSourcePackerIteration_revokedIteration(t *testing.T) {
 			upsertChannel(t, bucketSlug, channelSlug, unrevokedIteration.ID)
 			revokedIteration = revokeIteration(t, unrevokedIteration.ID, bucketSlug, revokeAt)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil

--- a/internal/providersdkv2/data_source_packer_run_task_test.go
+++ b/internal/providersdkv2/data_source_packer_run_task_test.go
@@ -22,7 +22,7 @@ func TestAcc_dataSourcePackerRunTask(t *testing.T) {
 			testAccPreCheck(t, map[string]bool{"aws": false, "azure": false})
 			upsertRegistry(t)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/providersdkv2/location_test.go
+++ b/internal/providersdkv2/location_test.go
@@ -113,7 +113,7 @@ var projectID = "prov-project-id-invalid"
 func TestAccMultiProject(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(t *terraform.State) error {
 			return nil
 		},
@@ -141,7 +141,7 @@ func TestAccMultiProject(t *testing.T) {
 func TestAccMultiProjectResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(t *terraform.State) error {
 			return nil
 		},

--- a/internal/providersdkv2/resource_aws_network_peering_test.go
+++ b/internal/providersdkv2/resource_aws_network_peering_test.go
@@ -36,7 +36,7 @@ resource "aws_vpc" "vpc" {
 }
 
 // This resource initially returns in a Pending state, because its provider_peering_id is required to complete acceptance of the connection.
-resource "hcp_aws_network_peering" "peering" {	
+resource "hcp_aws_network_peering" "peering" {
   peering_id                = "%[1]s"
   hvn_id                    = hcp_hvn.test.hvn_id
   peer_account_id           = aws_vpc.vpc.owner_id
@@ -69,7 +69,7 @@ resource "aws_vpc_peering_connection_accepter" "peering-accepter" {
      // an actual peering which HCP will populate with a set of tags (the ones below).
      // After succesfull "apply"" test will try to run "plan" operation
      // to make sure there are no changes to the state and if we don't specify these
-     // tags here then it will fail. 
+     // tags here then it will fail.
 	 hvn_id          = hcp_hvn.test.hvn_id
 	 organization_id = hcp_hvn.test.organization_id
 	 project_id      = hcp_hvn.test.project_id
@@ -84,7 +84,7 @@ func TestAccAwsPeering(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": true, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"aws": {VersionConstraint: "~> 4.0.0"},
 		},

--- a/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
@@ -95,7 +95,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
      // an actual peering which HCP will populate with a set of tags (the ones below).
      // After succesfull "apply"" test will try to run "plan" operation
      // to make sure there are no changes to the state and if we don't specify these
-     // tags here then it will fail. 
+     // tags here then it will fail.
 	 hvn_id          = hcp_hvn.test.hvn_id
 	 organization_id = hcp_hvn.test.organization_id
 	 project_id      = hcp_hvn.test.project_id
@@ -110,7 +110,7 @@ func TestAccTGWAttachment(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": true, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"aws": {VersionConstraint: "~> 4.0.0"},
 		},

--- a/internal/providersdkv2/resource_azure_peering_connection_test.go
+++ b/internal/providersdkv2/resource_azure_peering_connection_test.go
@@ -106,7 +106,7 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"azurerm": {VersionConstraint: "~> 3.63"},
 			"azuread": {VersionConstraint: "~> 2.39"},

--- a/internal/providersdkv2/resource_boundary_cluster_test.go
+++ b/internal/providersdkv2/resource_boundary_cluster_test.go
@@ -54,7 +54,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckBoundaryClusterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/providersdkv2/resource_consul_cluster_test.go
+++ b/internal/providersdkv2/resource_consul_cluster_test.go
@@ -39,7 +39,7 @@ var createConsulClusterCIDRExceeded = consulClusterConfig("test-failure", `
 		address = "172.25.16.0/24"
 		description = "this is a first IPV4 address"
 	}
-	
+
 	ip_allowlist {
 		address = "172.25.10.0/24"
 		description = "this is a secondIPV4 address"
@@ -63,7 +63,7 @@ func consulClusterConfig(clusterID string, opt string) string {
 		hvn_id             = hcp_hvn.test.hvn_id
 		tier               = "STANDARD"
 		min_consul_version = data.hcp_consul_versions.test.recommended
-	
+
 		%s
 	}
 	`, clusterID, opt)
@@ -81,11 +81,11 @@ func setTestAccConsulClusterConfig(consulCluster string) string {
 	data "hcp_consul_versions" "test" {}
 
 	%s
-	
+
 	data "hcp_consul_cluster" "test" {
 		cluster_id = hcp_consul_cluster.test.cluster_id
 	}
-	
+
 	resource "hcp_consul_cluster_root_token" "test" {
 		cluster_id = hcp_consul_cluster.test.cluster_id
 	}
@@ -103,7 +103,7 @@ func TestAccConsulCluster(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckConsulClusterDestroy,
 		Steps: []resource.TestStep{
 			// Tests create failure for IP Allowlist with too many CIDRs

--- a/internal/providersdkv2/resource_consul_snapshot_test.go
+++ b/internal/providersdkv2/resource_consul_snapshot_test.go
@@ -40,7 +40,7 @@ func TestAccConsulSnapshot(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckConsulSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/providersdkv2/resource_hvn_peering_connection_test.go
+++ b/internal/providersdkv2/resource_hvn_peering_connection_test.go
@@ -53,7 +53,7 @@ func TestAccHvnPeeringConnection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckHvnPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			// Tests create

--- a/internal/providersdkv2/resource_hvn_route_test.go
+++ b/internal/providersdkv2/resource_hvn_route_test.go
@@ -35,7 +35,7 @@ resource "aws_vpc" "vpc" {
   }
 }
 
-resource "hcp_aws_network_peering" "peering" {	
+resource "hcp_aws_network_peering" "peering" {
   peering_id      = "%[1]s"
   hvn_id          = hcp_hvn.test.hvn_id
   peer_account_id = aws_vpc.vpc.owner_id
@@ -68,7 +68,7 @@ resource "aws_vpc_peering_connection_accepter" "peering-accepter" {
      // an actual peering which HCP will populate with a set of tags (the ones below).
      // After succesfull "apply"" test will try to run "plan" operation
      // to make sure there are no changes to the state and if we don't specify these
-     // tags here then it will fail. 
+     // tags here then it will fail.
 	 hvn_id          = hcp_hvn.test.hvn_id
 	 organization_id = hcp_hvn.test.organization_id
 	 project_id      = hcp_hvn.test.project_id
@@ -83,7 +83,7 @@ func TestAccHvnRoute(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": true, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"aws": {VersionConstraint: "~> 4.0.0"},
 		},

--- a/internal/providersdkv2/resource_hvn_test.go
+++ b/internal/providersdkv2/resource_hvn_test.go
@@ -52,7 +52,7 @@ func TestAccAwsHvnOnly(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckHvnDestroy,
 		Steps: []resource.TestStep{
 			// Tests create
@@ -129,7 +129,7 @@ func TestAccAzureHvnOnly(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckHvnDestroy,
 		Steps: []resource.TestStep{
 			// Tests create

--- a/internal/providersdkv2/resource_packer_channel_assignment_test.go
+++ b/internal/providersdkv2/resource_packer_channel_assignment_test.go
@@ -32,7 +32,7 @@ func TestAccPackerChannelAssignment_SimpleSetUnset(t *testing.T) {
 			upsertChannel(t, bucketSlug, channelSlug, "")
 			iteration, _ = upsertCompleteIteration(t, bucketSlug, iterationFingerprint, nil)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			if err := testAccCheckAssignmentDestroyed(baseAssignment.BlockName())(state); err != nil {
 				t.Error(err)
@@ -140,7 +140,7 @@ func TestAccPackerChannelAssignment_AssignLatest(t *testing.T) {
 			upsertBucket(t, bucketSlug)
 			iteration, _ = upsertCompleteIteration(t, bucketSlug, "abc", nil)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -178,7 +178,7 @@ func TestAccPackerChannelAssignment_InvalidInputs(t *testing.T) {
 			upsertBucket(t, bucketSlug)
 			upsertChannel(t, bucketSlug, channelSlug, "")
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -244,7 +244,7 @@ func TestAccPackerChannelAssignment_CreateFailsWhenPreassigned(t *testing.T) {
 			upsertBucket(t, bucketSlug)
 			upsertCompleteIteration(t, bucketSlug, iterationFingerprint, nil)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -285,7 +285,7 @@ func TestAccPackerChannelAssignment_HCPManagedChannelErrors(t *testing.T) {
 			upsertRegistry(t)
 			upsertBucket(t, bucketSlug)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -376,7 +376,7 @@ func TestAccPackerChannelAssignment_EnforceNull(t *testing.T) {
 			iteration1, _ = upsertCompleteIteration(t, bucketSlug, "1", nil)
 			iteration2, _ = upsertCompleteIteration(t, bucketSlug, "2", nil)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil

--- a/internal/providersdkv2/resource_packer_channel_test.go
+++ b/internal/providersdkv2/resource_packer_channel_test.go
@@ -24,7 +24,7 @@ func TestAccPackerChannel(t *testing.T) {
 			upsertRegistry(t)
 			upsertBucket(t, bucketSlug)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(*terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -77,7 +77,7 @@ func TestAccPackerChannel_HCPManaged(t *testing.T) {
 			upsertRegistry(t)
 			upsertBucket(t, bucketSlug)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(*terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -130,7 +130,7 @@ func TestAccPackerChannel_RestrictionDrift(t *testing.T) {
 			upsertRegistry(t)
 			upsertBucket(t, bucketSlug)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(*terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil
@@ -176,7 +176,7 @@ func TestAccPackerChannel_RestrictionDriftHCPManaged(t *testing.T) {
 			upsertRegistry(t)
 			upsertBucket(t, bucketSlug)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy: func(*terraform.State) error {
 			deleteBucket(t, bucketSlug, true)
 			return nil

--- a/internal/providersdkv2/resource_packer_run_task_test.go
+++ b/internal/providersdkv2/resource_packer_run_task_test.go
@@ -46,7 +46,7 @@ func TestAccPackerRunTask(t *testing.T) {
 			testAccPreCheck(t, map[string]bool{"aws": false, "azure": false})
 			upsertRegistry(t)
 		},
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/internal/providersdkv2/resource_vault_cluster_perf_replication_test.go
+++ b/internal/providersdkv2/resource_vault_cluster_perf_replication_test.go
@@ -29,14 +29,14 @@ func setTestAccPerformanceReplicationE2E(t *testing.T, tfCode string, in *inputT
 		cloud_provider    = "{{ .CloudProvider }}"
 		region            = "{{ .Region }}"
 	}
-	
+
 	resource "hcp_hvn" "hvn2" {
 		hvn_id            = "{{ .Secondary.HvnName }}"
 		cidr_block        = "{{ .Secondary.GetHvnCidr }}"
 		cloud_provider    = "{{ .Secondary.CloudProvider }}"
 		region            = "{{ .Secondary.Region }}"
 	}
-	
+
 	%s
 	`, tfCode)
 
@@ -73,7 +73,7 @@ func TestAccPerformanceReplication_ValidationsAws(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVaultClusterDestroy,
 		Steps:                    performanceReplicationSteps(t, awsPerfReplicationTestInput),
 	})

--- a/internal/providersdkv2/resource_vault_cluster_test.go
+++ b/internal/providersdkv2/resource_vault_cluster_test.go
@@ -62,7 +62,7 @@ func TestAccVaultClusterAzure(t *testing.T) {
 	azureTestInput.tf = tf
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVaultClusterDestroy,
 		Steps:                    azureTestSteps(t, azureTestInput),
 	})
@@ -91,7 +91,7 @@ func TestAccVaultClusterAWS(t *testing.T) {
 	awsTestInput.tf = tf
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVaultClusterDestroy,
 		Steps:                    awsTestSteps(t, awsTestInput),
 	})

--- a/internal/providersdkv2/resource_vault_plugin_test.go
+++ b/internal/providersdkv2/resource_vault_plugin_test.go
@@ -53,7 +53,7 @@ func TestAccVaultPlugin(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": false}) },
-		ProtoV5ProviderFactories: testProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVaultPluginDestroy,
 
 		Steps: []resource.TestStep{

--- a/main.go
+++ b/main.go
@@ -9,9 +9,10 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	provider "github.com/hashicorp/terraform-provider-hcp/internal/provider"
 	providersdkv2 "github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2"
 	"github.com/hashicorp/terraform-provider-hcp/version"
@@ -38,28 +39,40 @@ func main() {
 		return
 	}
 
-	var serveOpts []tf5server.ServeOpt
+	var serveOpts []tf6server.ServeOpt
 
 	if debugMode {
-		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
+		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}
 
-	err = tf5server.Serve("registry.terraform.io/hashicorp/hcp", provider, serveOpts...)
+	err = tf6server.Serve("registry.terraform.io/hashicorp/hcp", provider, serveOpts...)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
-func New() (func() tfprotov5.ProviderServer, error) {
+func New() (func() tfprotov6.ProviderServer, error) {
 	ctx := context.Background()
-	providers := []func() tfprotov5.ProviderServer{
+
+	// Upgrade the provider sdkv2 version to protocol 6
+	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
+		context.Background(),
 		providersdkv2.New()().GRPCProvider,
-		providerserver.NewProtocol5(
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkProvider
+		},
+		providerserver.NewProtocol6(
 			provider.NewFrameworkProvider(version.ProviderVersion)(),
 		),
 	}
 
-	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
 
 	if err != nil {
 		return nil, err

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -2,7 +2,7 @@
     "version": 1,
     "metadata": {
         "protocol_versions": [
-            "5.0"
+            "6.0"
         ]
     }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Upgrade from Protocol 5 to 6. I was going to add a nested block and noticed the documentation recommends against it and instead to use nested attribute types which are only available on protocol 6.

https://developer.hashicorp.com/terraform/plugin/framework/handling-data/blocks/single-nested

### :building_construction: Acceptance tests

- [X] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

