### PR TITLE
Deprecate pre-1.1.5 support

### DIFF
--- a/.changelog/638.txt
+++ b/.changelog/638.txt
@@ -1,0 +1,4 @@
+```release-note:deprecate
+An upcoming release will deprecate support for Terraform versions before 1.1.5.
+Please upgrade to be able to use the latest releases of the provider.
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The HashiCorp Cloud Platform (HCP) Terraform Provider is a plugin for Terraform 
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.12.x
 
+> [!WARNING]
+> An upcoming release of the provider will require a Terraform with version >= 1.1.5
+> If using this provider, we recommend upgrading.
+
 ## Using the Provider
 
 See the [HashiCorp Cloud Platform (HCP) Provider documentation](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs) to get started using the provider.


### PR DESCRIPTION
### :hammer_and_wrench: Description

https://github.com/hashicorp/terraform-provider-hcp/pull/637 wil make 1.1.5 the minimum supported version of Terraform. This PR adds a changelog to preemptively inform users.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? No

Output from acceptance testing:
N/A