### PR TITLE
Fix project import

### DIFF
--- a/.changelog/642.txt
+++ b/.changelog/642.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix hcp_project import
+```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -44,7 +44,4 @@ Import is supported using the following syntax:
 ```shell
 # Project can be imported by specifying the project id
 terraform import hcp_project.example 840e3701-55b6-4f86-8c17-b1fe397303c5
-
-# Project can be imported by specifying the project resource name
-terraform import hcp_project.example project/840e3701-55b6-4f86-8c17-b1fe397303c5
 ```

--- a/examples/resources/hcp_project/import.sh
+++ b/examples/resources/hcp_project/import.sh
@@ -1,6 +1,2 @@
 # Project can be imported by specifying the project id
 terraform import hcp_project.example 840e3701-55b6-4f86-8c17-b1fe397303c5
-
-# Project can be imported by specifying the project resource name
-terraform import hcp_project.example project/840e3701-55b6-4f86-8c17-b1fe397303c5
-

--- a/internal/provider/resourcemanager/resource_project.go
+++ b/internal/provider/resourcemanager/resource_project.go
@@ -267,5 +267,5 @@ func (r *resourceProject) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 func (r *resourceProject) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("resource_name"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("resource_id"), req, resp)
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixes a bug in project import where it was setting the resource_name instead of the resource_id

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ TF_ACC=1 go test -v -run TestAccProjectResource
=== RUN   TestAccProjectResource
--- PASS: TestAccProjectResource (21.89s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager   22.301s

```
