### PR TITLE
Deprecate support for Terraform < 1.1.5 (protocol v5) in advance of v6 support

### DIFF
--- a/.changelog/644.txt
+++ b/.changelog/644.txt
@@ -1,4 +1,4 @@
-```release-note:deprecate
+```release-note:deprecation
 An upcoming release will deprecate support for Terraform versions before 1.1.5.
 Please upgrade to be able to use the latest releases of the provider.
 ```

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -38,6 +38,9 @@ jobs:
             # "Enhancement is not a valid type of changelog entry, but it's a common mistake.
             echo "::error::Found invalid type (enhancement) in changelog - did you mean improvement?"
             exit 1
+          elif grep -q ':deprecate$' $changelog_files; then
+            echo "::error::Found invalid type (deprecate) in changelog - did you mean deprecation?"
+            exit 1
           elif grep -q ':bugs$' $changelog_files; then
             echo "::error::Found invalid type (bugs) in changelog - did you mean bug?"
             exit 1


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Fixes incorrect changelog entry so deprecation will actually appear in generated changelog. 