### PR TITLE
Revert "Add support for newrelic observability on vault_cluster resource"

### DIFF
--- a/.changelog/639.txt
+++ b/.changelog/639.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-Add NewRelic as an observability provider for streaming audit logs and metrics from HCP Vault clusters.
-```

--- a/.changelog/650.txt
+++ b/.changelog/650.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Revert pull request that adds new relic provider support to terraform for vault audit logs/metrics.
+```

--- a/docs/data-sources/vault_cluster.md
+++ b/docs/data-sources/vault_cluster.md
@@ -81,9 +81,6 @@ Read-Only:
 - `elasticsearch_user` (String) ElasticSearch user for streaming audit logs
 - `grafana_endpoint` (String) Grafana endpoint for streaming audit logs
 - `grafana_user` (String) Grafana user for streaming audit logs
-- `newrelic_account_id` (String) NewRelic Account ID for streaming audit logs
-- `newrelic_license_key` (String) NewRelic license key for streaming audit logs
-- `newrelic_region` (String) NewRelic region for streaming audit logs, allowed values are "US" and "EU"
 - `splunk_hecendpoint` (String) Splunk endpoint for streaming audit logs
 
 
@@ -113,7 +110,4 @@ Read-Only:
 - `elasticsearch_user` (String) ElasticSearch user for streaming metrics
 - `grafana_endpoint` (String) Grafana endpoint for streaming metrics
 - `grafana_user` (String) Grafana user for streaming metrics
-- `newrelic_account_id` (String) NewRelic Account ID for streaming metrics
-- `newrelic_license_key` (String) NewRelic license key for streaming metrics
-- `newrelic_region` (String) NewRelic region for streaming metrics, allowed values are "US" and "EU"
 - `splunk_hecendpoint` (String) Splunk endpoint for streaming metrics

--- a/docs/resources/vault_cluster.md
+++ b/docs/resources/vault_cluster.md
@@ -94,9 +94,6 @@ Optional:
 - `grafana_endpoint` (String) Grafana endpoint for streaming audit logs
 - `grafana_password` (String, Sensitive) Grafana password for streaming audit logs
 - `grafana_user` (String) Grafana user for streaming audit logs
-- `newrelic_account_id` (String) NewRelic Account ID for streaming audit logs
-- `newrelic_license_key` (String, Sensitive) NewRelic license key for streaming audit logs
-- `newrelic_region` (String) NewRelic region for streaming audit logs, allowed values are "US" and "EU"
 - `splunk_hecendpoint` (String) Splunk endpoint for streaming audit logs
 - `splunk_token` (String, Sensitive) Splunk token for streaming audit logs
 
@@ -136,9 +133,6 @@ Optional:
 - `grafana_endpoint` (String) Grafana endpoint for streaming metrics
 - `grafana_password` (String, Sensitive) Grafana password for streaming metrics
 - `grafana_user` (String) Grafana user for streaming metrics
-- `newrelic_account_id` (String) NewRelic Account ID for streaming metrics
-- `newrelic_license_key` (String, Sensitive) NewRelic license key for streaming metrics
-- `newrelic_region` (String) NewRelic region for streaming metrics, allowed values are "US" and "EU"
 - `splunk_hecendpoint` (String) Splunk endpoint for streaming metrics
 - `splunk_token` (String, Sensitive) Splunk token for streaming metrics
 

--- a/internal/providersdkv2/data_source_vault_cluster.go
+++ b/internal/providersdkv2/data_source_vault_cluster.go
@@ -201,21 +201,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
-						"newrelic_account_id": {
-							Description: "NewRelic Account ID for streaming metrics",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"newrelic_license_key": {
-							Description: "NewRelic license key for streaming metrics",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"newrelic_region": {
-							Description: "NewRelic region for streaming metrics, allowed values are \"US\" and \"EU\"",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
 					},
 				},
 			},
@@ -288,21 +273,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 						},
 						"elasticsearch_password": {
 							Description: "ElasticSearch password for streaming audit logs",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"newrelic_account_id": {
-							Description: "NewRelic Account ID for streaming audit logs",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"newrelic_license_key": {
-							Description: "NewRelic license key for streaming audit logs",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"newrelic_region": {
-							Description: "NewRelic region for streaming audit logs, allowed values are \"US\" and \"EU\"",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},

--- a/internal/providersdkv2/resource_vault_cluster.go
+++ b/internal/providersdkv2/resource_vault_cluster.go
@@ -232,22 +232,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 							Optional:    true,
 							Sensitive:   true,
 						},
-						"newrelic_account_id": {
-							Description: "NewRelic Account ID for streaming metrics",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"newrelic_license_key": {
-							Description: "NewRelic license key for streaming metrics",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Sensitive:   true,
-						},
-						"newrelic_region": {
-							Description: "NewRelic region for streaming metrics, allowed values are \"US\" and \"EU\"",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
 					},
 				},
 			},
@@ -342,22 +326,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 							Type:        schema.TypeString,
 							Optional:    true,
 							Sensitive:   true,
-						},
-						"newrelic_account_id": {
-							Description: "NewRelic Account ID for streaming audit logs",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"newrelic_license_key": {
-							Description: "NewRelic license key for streaming audit logs",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Sensitive:   true,
-						},
-						"newrelic_region": {
-							Description: "NewRelic region for streaming audit logs, allowed values are \"US\" and \"EU\"",
-							Type:        schema.TypeString,
-							Optional:    true,
 						},
 					},
 				},
@@ -1188,21 +1156,6 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 				}
 			}
 		}
-
-		if newrelic := config.Newrelic; newrelic != nil {
-			configMap["newrelic_account_id"] = newrelic.AccountID
-			configMap["newrelic_region"] = newrelic.Region
-
-			// Since the API return this sensitive fields as redacted, we don't update it on the config in this situations
-			if newrelic.LicenseKey != "redacted" {
-				configMap["newrelic_license_key"] = newrelic.LicenseKey
-			} else {
-				if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
-					config := configParam.([]interface{})[0].(map[string]interface{})
-					configMap["newrelic_license_key"] = config["newrelic_license_key"].(string)
-				}
-			}
-		}
 	}
 
 	return []interface{}{configMap}
@@ -1219,7 +1172,6 @@ func getObservabilityConfig(propertyName string, d *schema.ResourceData) (*vault
 		Datadog:       &vaultmodels.HashicorpCloudVault20201125Datadog{},
 		Cloudwatch:    &vaultmodels.HashicorpCloudVault20201125CloudWatch{},
 		Elasticsearch: &vaultmodels.HashicorpCloudVault20201125Elasticsearch{},
-		Newrelic:      &vaultmodels.HashicorpCloudVault20201125NewRelic{},
 	}
 
 	// If we don't find the property we return the empty object to be updated and delete the configuration.
@@ -1253,9 +1205,6 @@ func getValidObservabilityConfig(config map[string]interface{}) (*vaultmodels.Ha
 	elasticsearchEndpoint, _ := config["elasticsearch_endpoint"].(string)
 	elasticsearchUser, _ := config["elasticsearch_user"].(string)
 	elasticsearchPassword, _ := config["elasticsearch_password"].(string)
-	newrelicAccountID, _ := config["newrelic_account_id"].(string)
-	newrelicLicenseKey, _ := config["newrelic_license_key"].(string)
-	newrelicRegion, _ := config["newrelic_region"].(string)
 
 	var observabilityConfig *vaultmodels.HashicorpCloudVault20201125ObservabilityConfig
 	// only return an error about a missing field for a specific provider after ensuring there's a single provider
@@ -1337,24 +1286,6 @@ func getValidObservabilityConfig(config map[string]interface{}) (*vaultmodels.Ha
 				Endpoint: elasticsearchEndpoint,
 				User:     elasticsearchUser,
 				Password: elasticsearchPassword,
-			},
-		}
-	}
-
-	if newrelicAccountID != "" || newrelicLicenseKey != "" || newrelicRegion != "" {
-		if observabilityConfig != nil {
-			return nil, tooManyProvidersErr
-		}
-
-		if newrelicAccountID == "" || newrelicLicenseKey == "" || newrelicRegion == "" {
-			missingParamErr = diag.Errorf("newrelic configuration is invalid: configuration information missing")
-		}
-
-		observabilityConfig = &vaultmodels.HashicorpCloudVault20201125ObservabilityConfig{
-			Newrelic: &vaultmodels.HashicorpCloudVault20201125NewRelic{
-				AccountID:  newrelicAccountID,
-				LicenseKey: newrelicLicenseKey,
-				Region:     (*vaultmodels.HashicorpCloudVault20201125NewRelicRegion)(&newrelicRegion),
 			},
 		}
 	}

--- a/internal/providersdkv2/resource_vault_cluster_config_test.go
+++ b/internal/providersdkv2/resource_vault_cluster_config_test.go
@@ -27,9 +27,6 @@ func TestGetValidObservabilityConfig(t *testing.T) {
 				"elasticsearch_user":     "test",
 				"elasticsearch_password": "test_elasticsearch",
 				"elasticsearch_endpoint": "https://elasticsearch",
-				"newrelic_account_id":    "123456",
-				"newrelic_license_key":   "abcdefg",
-				"newrelic_region":        "US",
 			},
 			expectedError: "multiple configurations found: must contain configuration for only one provider",
 		},
@@ -62,12 +59,6 @@ func TestGetValidObservabilityConfig(t *testing.T) {
 				"elasticsearch_user": "test",
 			},
 			expectedError: "elasticsearch configuration is invalid: configuration information missing",
-		},
-		"newrelic missing params": {
-			config: map[string]interface{}{
-				"newrelic_account_id": "123456",
-			},
-			expectedError: "newrelic configuration is invalid: configuration information missing",
 		},
 		"too many providers takes precedence over missing params": {
 			config: map[string]interface{}{


### PR DESCRIPTION
The original PR that adds support for New Relic as an observability provider was merged before the provider was released. This PR reverts the original PR so that these changes aren't in `main` while the provider is not yet available