### PR TITLE
Don't require trailing slash on issuer_uri

### DIFF
--- a/.changelog/656.txt
+++ b/.changelog/656.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+Removed unnecessary validation of a trailing slash on the `oidc.issuer_uri`
+field for the `hcp_iam_workload_identity_provider` resource.
+```

--- a/internal/provider/iam/resource_workload_identity_provider.go
+++ b/internal/provider/iam/resource_workload_identity_provider.go
@@ -116,8 +116,8 @@ func (r *resourceWorkloadIdentityProvider) Schema(_ context.Context, _ resource.
 						Description: "The URL of the OIDC Issuer that is allowed to exchange workload identities.",
 						Validators: []validator.String{
 							stringvalidator.RegexMatches(
-								regexp.MustCompile(`^https://.*\..+/$`),
-								"must be a valid URL starting with https:// and must end in /",
+								regexp.MustCompile(`^https://.+$`),
+								"must be a valid URL starting with https://",
 							),
 						},
 					},


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixes an issue where we required a trailing slash on the issuer_uri. This is an unnecessary restriction as the issuer can include or not include it. For example the HCP issuer includes it but the TFC issuer doesn't.

https://hashicorp.atlassian.net/browse/HCPIE-809

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ TF_ACC=1 go test -v
=== RUN   TestAccServicePrincipalDataSource
--- PASS: TestAccServicePrincipalDataSource (10.84s)
=== RUN   TestAccServicePrincipalKeyResource
--- PASS: TestAccServicePrincipalKeyResource (42.48s)
=== RUN   TestAccServicePrincipalResource_Project
--- PASS: TestAccServicePrincipalResource_Project (21.88s)
=== RUN   TestAccServicePrincipalResource_ExplicitProject
--- PASS: TestAccServicePrincipalResource_ExplicitProject (11.78s)
=== RUN   TestAccServicePrincipalResource_Organization
--- PASS: TestAccServicePrincipalResource_Organization (13.29s)
=== RUN   TestAccWorkloadIdentityProviderResource
--- PASS: TestAccWorkloadIdentityProviderResource (19.05s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       119.773s

```
