### PR TITLE
Fix changelog not re-checked when `pr/no-changelog` label is removed

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -10,6 +10,7 @@ on:
       - opened
       - synchronize
       - labeled
+      - unlabeled
     branches:
       - main
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Fix changelog not re-checked when `pr/no-changelog` label is removed