### PR TITLE
Update hcp-sdk-go and enable environment variable based configuration

### DIFF
--- a/.changelog/666.txt
+++ b/.changelog/666.txt
@@ -1,0 +1,7 @@
+ ```release-note:improvement
+ The new version of the hcp-sdk-go did remove the implicit login on initialization. This change re-introduce the login by explicitly fetching credentials during the client initialization.
+```
+
+```release-note:improvement
+ The change introduces the ability to provide configuration via environment variables, which will allow credentials to be provided via environment variable (either directly or via a creds file).
+ ```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcp-sdk-go v0.71.0
+	github.com/hashicorp/hcp-sdk-go v0.72.0
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/hashicorp/hc-install v0.6.1 h1:IGxShH7AVhPaSuSJpKtVi/EFORNjO+OYVJJrAt
 github.com/hashicorp/hc-install v0.6.1/go.mod h1:0fW3jpg+wraYSnFDJ6Rlie3RvLf1bIqVIkzoon4KoVE=
 github.com/hashicorp/hcl/v2 v2.18.1 h1:6nxnOJFku1EuSawSD81fuviYUV8DxFr3fp2dUi3ZYSo=
 github.com/hashicorp/hcl/v2 v2.18.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.71.0 h1:6ZECmkamuI6zIxrk4kYgdiABwN0Ph9/8fnly9ThkGoY=
-github.com/hashicorp/hcp-sdk-go v0.71.0/go.mod h1:xP7wmWAmdMxs/7+ovH3jZn+MCDhHRj50Rn+m7JIY3Ck=
+github.com/hashicorp/hcp-sdk-go v0.72.0 h1:OSDBUqdlklg9yKBZll5KmHAxQlVJnVSPhgaObyuGCd0=
+github.com/hashicorp/hcp-sdk-go v0.72.0/go.mod h1:k/wgUsKSa2OzWBM5/Pj5ST0YwFGpgC4O5EtCq882jSw=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.19.0 h1:FpqZ6n50Tk95mItTSS9BjeOVUb4eg81SpgVtZNNtFSM=

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -93,6 +93,11 @@ func NewClient(config ClientConfig) (*Client, error) {
 		return nil, fmt.Errorf("invalid HCP config: %w", err)
 	}
 
+	// Fetch a token to verify that we have valid credentials
+	if _, err := hcp.Token(); err != nil {
+		return nil, fmt.Errorf("no valid credentials available: %w", err)
+	}
+
 	httpClient, err := sdk.New(sdk.Config{
 		HCPConfig:     hcp,
 		SourceChannel: config.SourceChannel,

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -43,6 +43,7 @@ import (
 	cloud_vault_secrets "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 
+	hcpConfig "github.com/hashicorp/hcp-sdk-go/config"
 	sdk "github.com/hashicorp/hcp-sdk-go/httpclient"
 )
 
@@ -82,9 +83,18 @@ type ClientConfig struct {
 
 // NewClient creates a new Client that is capable of making HCP requests
 func NewClient(config ClientConfig) (*Client, error) {
+	hcp, err := hcpConfig.NewHCPConfig(
+		hcpConfig.WithClientCredentials(
+			config.ClientID,
+			config.ClientSecret,
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid HCP config: %w", err)
+	}
+
 	httpClient, err := sdk.New(sdk.Config{
-		ClientID:      config.ClientID,
-		ClientSecret:  config.ClientSecret,
+		HCPConfig:     hcp,
 		SourceChannel: config.SourceChannel,
 	})
 	if err != nil {

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -84,6 +84,7 @@ type ClientConfig struct {
 // NewClient creates a new Client that is capable of making HCP requests
 func NewClient(config ClientConfig) (*Client, error) {
 	hcp, err := hcpConfig.NewHCPConfig(
+		hcpConfig.FromEnv(),
 		hcpConfig.WithClientCredentials(
 			config.ClientID,
 			config.ClientSecret,


### PR DESCRIPTION
### :hammer_and_wrench: Description

The new version of the hcp-sdk-go did remove the implicit login on initialization. This change re-introduce the login by explicitly fetching credentials during the client initialization.

The change also introduces the ability to provide configuration via environment variables, which will allow credentials to be provided via environment variable (either directly or via a creds file).

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality? - no
- [x] Have you added an acceptance test for the functionality being added? - no, n/a
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing: 

(Any acceptance test should suffice to verify the functionality).

```
➜ make testacc TESTARGS='-run=TestAccProjectResource'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccProjectResource -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	(cached) [no tests to run]
=== RUN   TestAccProjectResource
--- PASS: TestAccProjectResource (12.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	(cached)
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	(cached) [no tests to run]```
