### PR TITLE
Add support for credential files

### DIFF
--- a/.changelog/672.txt
+++ b/.changelog/672.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add support to authenticate the provider using credential files.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ resource "hcp_vault_cluster" "example" {
 
 - `client_id` (String) The OAuth2 Client ID for API operations.
 - `client_secret` (String) The OAuth2 Client Secret for API operations.
+- `credential_file` (String) The path to an HCP credential file to use to authenticate the provider to HCP. You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. Using a credential file allows you to authenticate the provider as a service principal via client credentials or dynamically based on Workload Identity Federation.
 - `project_id` (String) The default project in which resources should be created.
 -> **Note:** See the [authentication guide](guides/auth.md) about a use case when specifying `project_id` is needed.
 

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -67,8 +67,9 @@ type Client struct {
 
 // ClientConfig specifies configuration for the client that interacts with HCP
 type ClientConfig struct {
-	ClientID     string
-	ClientSecret string
+	ClientID       string
+	ClientSecret   string
+	CredentialFile string
 
 	// OrganizationID (optional) is the organization unique identifier to launch resources in.
 	OrganizationID string
@@ -83,13 +84,18 @@ type ClientConfig struct {
 
 // NewClient creates a new Client that is capable of making HCP requests
 func NewClient(config ClientConfig) (*Client, error) {
-	hcp, err := hcpConfig.NewHCPConfig(
-		hcpConfig.FromEnv(),
-		hcpConfig.WithClientCredentials(
-			config.ClientID,
-			config.ClientSecret,
-		),
-	)
+	// Build the HCP Config options
+	var opts []hcpConfig.HCPConfigOption
+	if config.ClientID != "" && config.ClientSecret != "" {
+		opts = append(opts, hcpConfig.WithClientCredentials(config.ClientID, config.ClientSecret))
+	} else if config.CredentialFile != "" {
+		opts = append(opts, hcpConfig.WithCredentialFilePath(config.CredentialFile))
+	} else {
+		opts = append(opts, hcpConfig.FromEnv())
+	}
+
+	// Create the HCP Config
+	hcp, err := hcpConfig.NewHCPConfig(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid HCP config: %w", err)
 	}
@@ -108,14 +114,12 @@ func NewClient(config ClientConfig) (*Client, error) {
 	}
 
 	httpClient.SetLogger(logger{})
-
 	if ShouldLog() {
 		httpClient.Debug = true
 	}
 
 	client := &Client{
-		Config: config,
-
+		Config:            config,
 		Billing:           cloud_billing.New(httpClient, nil).BillingAccountService,
 		Boundary:          cloud_boundary.New(httpClient, nil).BoundaryService,
 		Consul:            cloud_consul.New(httpClient, nil).ConsulService,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,9 +34,10 @@ type ProviderFrameworkConfiguration struct {
 }
 
 type ProviderFrameworkModel struct {
-	ClientSecret types.String `tfsdk:"client_secret"`
-	ClientID     types.String `tfsdk:"client_id"`
-	ProjectID    types.String `tfsdk:"project_id"`
+	ClientSecret   types.String `tfsdk:"client_secret"`
+	ClientID       types.String `tfsdk:"client_id"`
+	CredentialFile types.String `tfsdk:"credential_file"`
+	ProjectID      types.String `tfsdk:"project_id"`
 }
 
 func (p *ProviderFramework) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -58,6 +59,13 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 			"project_id": schema.StringAttribute{
 				Optional:    true,
 				Description: "The default project in which resources should be created.",
+			},
+			"credential_file": schema.StringAttribute{
+				Optional: true,
+				Description: "The path to an HCP credential file to use to authenticate the provider to HCP. " +
+					"You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. " +
+					"Using a credential file allows you to authenticate the provider as a service principal via client " +
+					"credentials or dynamically based on Workload Identity Federation.",
 			},
 		},
 	}
@@ -132,9 +140,10 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 	}
 
 	client, err := clients.NewClient(clients.ClientConfig{
-		ClientID:      clientID,
-		ClientSecret:  clientSecret,
-		SourceChannel: "terraform-provider-hcp",
+		ClientID:       clientID,
+		ClientSecret:   clientSecret,
+		CredentialFile: data.CredentialFile.ValueString(),
+		SourceChannel:  "terraform-provider-hcp",
 	})
 
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,10 +9,13 @@ import (
 	"os"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/project_service"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 
@@ -51,10 +54,17 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 			"client_id": schema.StringAttribute{
 				Optional:    true,
 				Description: "The OAuth2 Client ID for API operations.",
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("client_secret")),
+					stringvalidator.ConflictsWith(path.MatchRoot("credential_file")),
+				},
 			},
 			"client_secret": schema.StringAttribute{
 				Optional:    true,
 				Description: "The OAuth2 Client Secret for API operations.",
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("client_id")),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				Optional:    true,

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -75,6 +75,14 @@ func New() func() *schema.Provider {
 					ValidateFunc: validation.IsUUID,
 					Description:  "The default project in which resources should be created.",
 				},
+				"credential_file": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Description: "The path to an HCP credential file to use to authenticate the provider to HCP. " +
+						"You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. " +
+						"Using a credential file allows you to authenticate the provider as a service principal via client " +
+						"credentials or dynamically based on Workload Identity Federation.",
+				},
 			},
 			ProviderMetaSchema: map[string]*schema.Schema{
 				"module_name": {
@@ -116,9 +124,10 @@ func configure(p *schema.Provider) func(context.Context, *schema.ResourceData) (
 		}
 
 		client, err := clients.NewClient(clients.ClientConfig{
-			ClientID:      clientID,
-			ClientSecret:  clientSecret,
-			SourceChannel: userAgent,
+			ClientID:       clientID,
+			ClientSecret:   clientSecret,
+			CredentialFile: d.Get("credential_file").(string),
+			SourceChannel:  userAgent,
 		})
 		if err != nil {
 			diags = append(diags, diag.Errorf("unable to create HCP api client: %v", err)...)


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add support for authenticating the provider using credential files. This will allow future integration with [Terraform Cloud Dynamic Credentials](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials).

### :building_construction: Acceptance tests

- [X] Are there any feature flags that are required to use this functionality? No
- [ ] Have you added an acceptance test for the functionality being added? No
- [ ] Have you run the acceptance tests on this branch? No

Output from acceptance testing:

Ran the provider with and confirmed it was authenticated:

* A valid credential file
* Client ID  / Client Secret
* Nothing set and browser was opened.
* Tested the new validation rules work.
