### PR TITLE
Always check env when building HCP Client

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -85,13 +85,11 @@ type ClientConfig struct {
 // NewClient creates a new Client that is capable of making HCP requests
 func NewClient(config ClientConfig) (*Client, error) {
 	// Build the HCP Config options
-	var opts []hcpConfig.HCPConfigOption
+	opts := []hcpConfig.HCPConfigOption{hcpConfig.FromEnv()}
 	if config.ClientID != "" && config.ClientSecret != "" {
 		opts = append(opts, hcpConfig.WithClientCredentials(config.ClientID, config.ClientSecret))
 	} else if config.CredentialFile != "" {
 		opts = append(opts, hcpConfig.WithCredentialFilePath(config.CredentialFile))
-	} else {
-		opts = append(opts, hcpConfig.FromEnv())
 	}
 
 	// Create the HCP Config


### PR DESCRIPTION
### :hammer_and_wrench: Description

The HCP integration tests set config via Env vars. This change brings back the old behavior, where we always source from env vars and then apply any explicit configuration.

### :building_construction: Acceptance tests

- [X] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$  TF_ACC=1 go test -v
=== RUN   TestAccServicePrincipalDataSource
--- PASS: TestAccServicePrincipalDataSource (15.67s)
=== RUN   TestAccServicePrincipalKeyResource
--- PASS: TestAccServicePrincipalKeyResource (35.46s)
=== RUN   TestAccServicePrincipalResource_Project
--- PASS: TestAccServicePrincipalResource_Project (8.91s)
=== RUN   TestAccServicePrincipalResource_ExplicitProject
--- PASS: TestAccServicePrincipalResource_ExplicitProject (5.27s)
=== RUN   TestAccServicePrincipalResource_Organization
--- PASS: TestAccServicePrincipalResource_Organization (5.73s)
=== RUN   TestAccWorkloadIdentityProviderResource
--- PASS: TestAccWorkloadIdentityProviderResource (8.41s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       79.892s

```
