### PR TITLE
HPR-1512: Deprecate to-be-removed Iteration attributes

### DIFF
--- a/.changelog/678.txt
+++ b/.changelog/678.txt
@@ -1,0 +1,11 @@
+```release-note:deprecation
+The `data.hcp_packer_iteration.incremental_version` attribute is now deprecated and will be removed in a future release. Use the `fingerprint`, `id` or `uuid` attributes to reference iterations instead.
+```
+
+```release-note:deprecation
+The `hcp_packer_channel_assignment.iteration_version` attribute is now deprecated and will be removed in a future release. Use the `iteration_fingerprint` attribute to reference iterations instead.
+```
+
+```release-note:deprecation
+The `hcp_packer_channel_assignment.iteration_id` attribute is now deprecated and will be removed in a future release. Use the `iteration_fingerprint` attribute to reference iterations instead.
+```

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -39,7 +39,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `created_at` (String) Creation time of this iteration
 - `fingerprint` (String) The unique fingerprint associated with this iteration; often a git sha.
 - `id` (String) The ID of this resource.
-- `incremental_version` (Number) Incremental version of this iteration
+- `incremental_version` (Number, Deprecated) Incremental version of this iteration
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `revoke_at` (String) The revocation time of this iteration. This field will be null for any iteration that has not been revoked or scheduled for revocation.
 - `ulid` (String) The ULID of this iteration.

--- a/docs/resources/packer_channel_assignment.md
+++ b/docs/resources/packer_channel_assignment.md
@@ -45,8 +45,8 @@ resource "hcp_packer_channel_assignment" "staging" {
 ### Optional
 
 - `iteration_fingerprint` (String) The fingerprint of the iteration assigned to the channel.
-- `iteration_id` (String) The ID of the iteration assigned to the channel.
-- `iteration_version` (Number) The incremental version of the iteration assigned to the channel.
+- `iteration_id` (String, Deprecated) The ID of the iteration assigned to the channel.
+- `iteration_version` (Number, Deprecated) The incremental version of the iteration assigned to the channel.
 - `project_id` (String) The ID of the HCP project where the channel is located. 
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
 If a project is not configured in the HCP Provider config block, the oldest project in the organization will be used.

--- a/internal/providersdkv2/data_source_packer_iteration.go
+++ b/internal/providersdkv2/data_source_packer_iteration.go
@@ -71,6 +71,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Description: "Incremental version of this iteration",
 				Type:        schema.TypeInt,
 				Computed:    true,
+				Deprecated:  "This attribute will be removed in a future version. Use `fingerprint` to reference iterations instead.",
 			},
 			"created_at": {
 				Description: "Creation time of this iteration",

--- a/internal/providersdkv2/resource_packer_channel_assignment.go
+++ b/internal/providersdkv2/resource_packer_channel_assignment.go
@@ -82,6 +82,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Computed:     true,
 				ExactlyOneOf: []string{"iteration_id", "iteration_fingerprint", "iteration_version"},
 				ValidateFunc: validation.StringIsNotEmpty,
+				Deprecated:   "This attribute will be removed in a future version. Use `iteration_fingerprint` to reference iterations instead.",
 			},
 			"iteration_version": {
 				Description:  "The incremental version of the iteration assigned to the channel.",
@@ -90,6 +91,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Computed:     true,
 				ExactlyOneOf: []string{"iteration_id", "iteration_fingerprint", "iteration_version"},
 				ValidateFunc: validation.IntBetween(0, math.MaxInt32),
+				Deprecated:   "This attribute will be removed in a future version. Use `iteration_fingerprint` to reference iterations instead.",
 			},
 			// Computed Values
 			"organization_id": {


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Deprecate to-be-removed Iteration attributes
  - `data.hcp_packer_iteration.incremental_version`
  - `hcp_packer_channel_assignment.iteration_version`
  - `hcp_packer_channel_assignment.iteration_id`