### PR TITLE
HPR-1516: Remove Deprecated Iteration Attributes

### DIFF
--- a/.changelog/679.txt
+++ b/.changelog/679.txt
@@ -1,0 +1,11 @@
+```release-note:breaking-change
+Removed the `data.hcp_packer_iteration.incremental_version` attribute. Use the `fingerprint`, `id` or `uuid` attributes to reference iterations instead.
+```
+
+```release-note:breaking-change
+Removed the `hcp_packer_channel_assignment.iteration_version` attribute. Use the `iteration_fingerprint` attribute to reference iterations instead.
+```
+
+```release-note:breaking-change
+Removed the `hcp_packer_channel_assignment.iteration_id` attribute. Use the `iteration_fingerprint` attribute to reference iterations instead.
+```

--- a/docs/data-sources/packer_iteration.md
+++ b/docs/data-sources/packer_iteration.md
@@ -39,7 +39,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `created_at` (String) Creation time of this iteration
 - `fingerprint` (String) The unique fingerprint associated with this iteration; often a git sha.
 - `id` (String) The ID of this resource.
-- `incremental_version` (Number, Deprecated) Incremental version of this iteration
 - `organization_id` (String) The ID of the organization this HCP Packer registry is located in.
 - `revoke_at` (String) The revocation time of this iteration. This field will be null for any iteration that has not been revoked or scheduled for revocation.
 - `ulid` (String) The ULID of this iteration.

--- a/docs/resources/packer_channel_assignment.md
+++ b/docs/resources/packer_channel_assignment.md
@@ -41,12 +41,10 @@ resource "hcp_packer_channel_assignment" "staging" {
 
 - `bucket_name` (String) The slug of the HCP Packer Registry bucket where the channel is located.
 - `channel_name` (String) The name of the HCP Packer channel being managed.
+- `iteration_fingerprint` (String) The fingerprint of the iteration assigned to the channel.
 
 ### Optional
 
-- `iteration_fingerprint` (String) The fingerprint of the iteration assigned to the channel.
-- `iteration_id` (String, Deprecated) The ID of the iteration assigned to the channel.
-- `iteration_version` (Number, Deprecated) The incremental version of the iteration assigned to the channel.
 - `project_id` (String) The ID of the HCP project where the channel is located. 
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
 If a project is not configured in the HCP Provider config block, the oldest project in the organization will be used.

--- a/internal/clients/packer.go
+++ b/internal/clients/packer.go
@@ -147,8 +147,12 @@ func UpdatePackerChannel(ctx context.Context, client *Client, loc *sharedmodels.
 	return channel.GetPayload().Channel, nil
 }
 
-func UpdatePackerChannelAssignment(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, bucketSlug string, channelSlug string,
-	iteration *packermodels.HashicorpCloudPackerIteration) (*packermodels.HashicorpCloudPackerChannel, error) {
+func UpdatePackerChannelAssignment(
+	ctx context.Context, client *Client,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	bucketSlug string, channelSlug string,
+	iterationFingerprint string,
+) (*packermodels.HashicorpCloudPackerChannel, error) {
 	params := packer_service.NewPackerServiceUpdateChannelParamsWithContext(ctx)
 	params.LocationOrganizationID = loc.OrganizationID
 	params.LocationProjectID = loc.ProjectID
@@ -157,19 +161,9 @@ func UpdatePackerChannelAssignment(ctx context.Context, client *Client, loc *sha
 
 	maskPaths := []string{}
 
-	if iteration != nil {
-		if iteration.ID != "" {
-			params.Body.IterationID = iteration.ID
-			maskPaths = append(maskPaths, "iterationId")
-		}
-		if iteration.Fingerprint != "" {
-			params.Body.Fingerprint = iteration.Fingerprint
-			maskPaths = append(maskPaths, "fingerprint")
-		}
-		if iteration.IncrementalVersion > 0 {
-			params.Body.IncrementalVersion = iteration.IncrementalVersion
-			maskPaths = append(maskPaths, "incrementalVersion")
-		}
+	if iterationFingerprint != "" {
+		params.Body.Fingerprint = iterationFingerprint
+		maskPaths = append(maskPaths, "fingerprint")
 	}
 
 	if len(maskPaths) == 0 {

--- a/internal/providersdkv2/data_source_packer_iteration.go
+++ b/internal/providersdkv2/data_source_packer_iteration.go
@@ -67,12 +67,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"incremental_version": {
-				Description: "Incremental version of this iteration",
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Deprecated:  "This attribute will be removed in a future version. Use `fingerprint` to reference iterations instead.",
-			},
 			"created_at": {
 				Description: "Creation time of this iteration",
 				Type:        schema.TypeString,
@@ -130,9 +124,6 @@ func dataSourcePackerIterationRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	if err := d.Set("ulid", iteration.ID); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("incremental_version", iteration.IncrementalVersion); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("updated_at", iteration.UpdatedAt.String()); err != nil {

--- a/internal/providersdkv2/data_source_packer_iteration_test.go
+++ b/internal/providersdkv2/data_source_packer_iteration_test.go
@@ -129,7 +129,6 @@ func testAccCheckIterationStateMatchesIteration(resourceName string, iterationPt
 			resource.TestCheckResourceAttr(resourceName, "bucket_name", iteration.BucketSlug),
 			resource.TestCheckResourceAttr(resourceName, "ulid", iteration.ID),
 			resource.TestCheckResourceAttr(resourceName, "fingerprint", iteration.Fingerprint),
-			resource.TestCheckResourceAttr(resourceName, "incremental_version", fmt.Sprintf("%d", iteration.IncrementalVersion)),
 			resource.TestCheckResourceAttr(resourceName, "author_id", iteration.AuthorID),
 			resource.TestCheckResourceAttr(resourceName, "created_at", iteration.CreatedAt.String()),
 			resource.TestCheckResourceAttr(resourceName, "updated_at", iteration.UpdatedAt.String()),

--- a/internal/providersdkv2/resource_packer_channel_assignment_test.go
+++ b/internal/providersdkv2/resource_packer_channel_assignment_test.go
@@ -44,7 +44,7 @@ func TestAccPackerChannelAssignment_SimpleSetUnset(t *testing.T) {
 			{ // Set channel assignment to the iteration
 				Config: testConfig(testAccConfigBuildersToString(testAccPackerAssignmentBuilderFromAssignment(
 					baseAssignment,
-					``, fmt.Sprintf("%q", iterationFingerprint), ``,
+					fmt.Sprintf("%q", iterationFingerprint),
 				))),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAssignmentStateBucketAndChannelName(baseAssignment.BlockName(), bucketSlug, channelSlug),
@@ -61,7 +61,7 @@ func TestAccPackerChannelAssignment_SimpleSetUnset(t *testing.T) {
 			{ // Set channel assignment to null
 				Config: testConfig(testAccConfigBuildersToString(testAccPackerAssignmentBuilderFromAssignment(
 					baseAssignment,
-					``, fmt.Sprintf("%q", unassignString), ``,
+					fmt.Sprintf("%q", unassignString),
 				))),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAssignmentStateBucketAndChannelName(baseAssignment.BlockName(), bucketSlug, channelSlug),
@@ -98,7 +98,7 @@ func TestAccPackerChannelAssignment_AssignLatest(t *testing.T) {
 	beforeAssignment := testAccPackerAssignmentBuilderWithChannelReference(
 		uniqueName,
 		beforeChannel,
-		beforeIteration.AttributeRef("id"), ``, ``,
+		beforeIteration.AttributeRef("fingerprint"),
 	)
 
 	// This config creates a data source that is read after apply time,
@@ -116,7 +116,7 @@ func TestAccPackerChannelAssignment_AssignLatest(t *testing.T) {
 	afterAssignment := testAccPackerAssignmentBuilderWithChannelReference(
 		uniqueName,
 		afterChannel,
-		afterIteration.AttributeRef("id"), ``, ``,
+		afterIteration.AttributeRef("fingerprint"),
 	)
 
 	var iteration *models.HashicorpCloudPackerIteration
@@ -159,13 +159,13 @@ func TestAccPackerChannelAssignment_InvalidInputs(t *testing.T) {
 	bucketSlug := testAccCreateSlug("AssignmentInvalidInputs")
 	channelSlug := bucketSlug // No need for a different slug
 
-	generateStep := func(iterID string, iterFingerprint string, iterVersion string, errorRegex string) resource.TestStep {
+	generateStep := func(iterFingerprint string, errorRegex string) resource.TestStep {
 		return resource.TestStep{
 			Config: testConfig(testAccConfigBuildersToString(testAccPackerAssignmentBuilder(
 				"InvalidInputs",
 				fmt.Sprintf("%q", bucketSlug),
 				fmt.Sprintf("%q", channelSlug),
-				iterID, iterFingerprint, iterVersion,
+				iterFingerprint,
 			))),
 			ExpectError: regexp.MustCompile(errorRegex),
 		}
@@ -185,36 +185,12 @@ func TestAccPackerChannelAssignment_InvalidInputs(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			generateStep(
-				`""`, ``, ``,
-				`.*expected "iteration_id" to not be an empty string.*`,
-			),
-			generateStep(
-				``, `""`, ``,
+				`""`,
 				`.*expected "iteration_fingerprint" to not be an empty string.*`,
 			),
 			generateStep(
-				`"abcd"`, `"efgh"`, ``,
-				`.*only one of.*\n.*can be specified.*`,
-			),
-			generateStep(
-				`"1234"`, ``, `5678`,
-				`.*only one of.*\n.*can be specified.*`,
-			),
-			generateStep(
-				``, `"jamesBond"`, `007`,
-				`.*only one of.*\n.*can be specified.*`,
-			),
-			generateStep(
-				`"doesNotExist"`, ``, ``,
-				`.*iteration with attributes \(id: doesNotExist\) does not exist.*`,
-			),
-			generateStep(
-				``, `"alsoDoesNotExist"`, ``,
-				`.*iteration with attributes \(fingerprint: alsoDoesNotExist\) does not exist.*`,
-			),
-			generateStep(
-				``, ``, `99`,
-				`.*iteration with attributes \(incremental_version: 99\) does not exist.*`,
+				`"doesNotExist"`,
+				`.*iteration with attributes \(fingerprint: doesNotExist\) does not exist.*`,
 			),
 		},
 	})
@@ -234,7 +210,7 @@ func TestAccPackerChannelAssignment_CreateFailsWhenPreassigned(t *testing.T) {
 	assignment := testAccPackerAssignmentBuilderWithChannelReference(
 		"CreateFailsWhenPreassigned",
 		channel,
-		``, ``, `0`,
+		`"2"`,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -276,7 +252,7 @@ func TestAccPackerChannelAssignment_HCPManagedChannelErrors(t *testing.T) {
 		"HCPManagedChannelErrors",
 		fmt.Sprintf("%q", bucketSlug),
 		fmt.Sprintf("%q", channelSlug),
-		``, ``, `0`,
+		`1`,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -324,47 +300,19 @@ func TestAccPackerChannelAssignment_EnforceNull(t *testing.T) {
 
 	baseAssignment := testAccPackerAssignmentBuilderBaseWithChannelReference("EnforceNull", channel)
 
-	generateEnforceNullCheckSteps := func(iterID string, iterFingerprint string, iterVersion string) []resource.TestStep {
-		assignment := testAccPackerAssignmentBuilderFromAssignment(
-			baseAssignment,
-			iterID, iterFingerprint, iterVersion,
-		)
+	assignment := testAccPackerAssignmentBuilderFromAssignment(
+		baseAssignment,
+		fmt.Sprintf("%q", unassignString),
+	)
 
-		config := testConfig(testAccConfigBuildersToString(channel, assignment))
+	config := testConfig(testAccConfigBuildersToString(channel, assignment))
 
-		checks := resource.ComposeAggregateTestCheckFunc(
-			testAccCheckAssignmentStateBucketAndChannelName(assignment.BlockName(), bucketSlug, channelSlug),
-			testAccCheckAssignmentStateMatchesIteration(assignment.BlockName(), nil),
-			testAccCheckAssignmentStateMatchesChannelState(assignment.BlockName(), channel.BlockName()),
-			testAccCheckAssignmentStateMatchesAPI(assignment.BlockName()),
-		)
-
-		return []resource.TestStep{
-			{ // Set up channel and set the assignment using Terraform
-				// This should be a no-op unless it is the first step, where the channel and null assignment are
-				// initially created. However, this step is included every time to make sure we've applied the
-				// assignment to the state at least once before checking if it is properly enforced against OOB changes.
-				Config: config,
-				Check:  checks,
-			},
-			{ // Change assignment OOB, then test with assignment set by Terraform
-				PreConfig: func() {
-					updateChannelAssignment(t, bucketSlug, channelSlug, &models.HashicorpCloudPackerIteration{ID: iteration1.ID})
-					updateChannelAssignment(t, bucketSlug, channelSlug, &models.HashicorpCloudPackerIteration{ID: iteration2.ID})
-				},
-				Config: config,
-				Check:  checks,
-			},
-		}
-	}
-
-	var generatedSteps []resource.TestStep
-	// Add null ID steps
-	generatedSteps = append(generatedSteps, generateEnforceNullCheckSteps(fmt.Sprintf("%q", unassignString), ``, ``)...)
-	// Add null Fingerprint steps
-	generatedSteps = append(generatedSteps, generateEnforceNullCheckSteps(``, fmt.Sprintf("%q", unassignString), ``)...)
-	// Add null Version steps
-	generatedSteps = append(generatedSteps, generateEnforceNullCheckSteps(``, ``, `0`)...)
+	checks := resource.ComposeAggregateTestCheckFunc(
+		testAccCheckAssignmentStateBucketAndChannelName(assignment.BlockName(), bucketSlug, channelSlug),
+		testAccCheckAssignmentStateMatchesIteration(assignment.BlockName(), nil),
+		testAccCheckAssignmentStateMatchesChannelState(assignment.BlockName(), channel.BlockName()),
+		testAccCheckAssignmentStateMatchesAPI(assignment.BlockName()),
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -381,7 +329,23 @@ func TestAccPackerChannelAssignment_EnforceNull(t *testing.T) {
 			deleteBucket(t, bucketSlug, true)
 			return nil
 		},
-		Steps: generatedSteps,
+		Steps: []resource.TestStep{
+			{ // Set up channel and set the assignment using Terraform
+				// This should be a no-op unless it is the first step, where the channel and null assignment are
+				// initially created. However, this step is included every time to make sure we've applied the
+				// assignment to the state at least once before checking if it is properly enforced against OOB changes.
+				Config: config,
+				Check:  checks,
+			},
+			{ // Change assignment OOB, then test with assignment set by Terraform
+				PreConfig: func() {
+					updateChannelAssignment(t, bucketSlug, channelSlug, &models.HashicorpCloudPackerIteration{ID: iteration1.ID})
+					updateChannelAssignment(t, bucketSlug, channelSlug, &models.HashicorpCloudPackerIteration{ID: iteration2.ID})
+				},
+				Config: config,
+				Check:  checks,
+			},
+		},
 	})
 }
 
@@ -392,7 +356,7 @@ func testAccPackerAssignmentBuilderBase(uniqueName string, bucketName string, ch
 		uniqueName,
 		bucketName,
 		channelName,
-		``, ``, ``,
+		``,
 	)
 }
 
@@ -404,37 +368,33 @@ func testAccPackerAssignmentBuilderBaseWithChannelReference(uniqueName string, c
 	)
 }
 
-func testAccPackerAssignmentBuilder(uniqueName string, bucketName string, channelName string, iterID string, iterFingerprint string, iterVersion string) testAccConfigBuilderInterface {
+func testAccPackerAssignmentBuilder(uniqueName string, bucketName string, channelName string, iterFingerprint string) testAccConfigBuilderInterface {
 	return &testAccResourceConfigBuilder{
 		resourceType: "hcp_packer_channel_assignment",
 		uniqueName:   uniqueName,
 		attributes: map[string]string{
 			"bucket_name":           bucketName,
 			"channel_name":          channelName,
-			"iteration_id":          iterID,
 			"iteration_fingerprint": iterFingerprint,
-			"iteration_version":     iterVersion,
 		},
 	}
 }
 
-func testAccPackerAssignmentBuilderFromAssignment(oldAssignment testAccConfigBuilderInterface, iterID string, iterFingerprint string, iterVersion string) testAccConfigBuilderInterface {
+func testAccPackerAssignmentBuilderFromAssignment(oldAssignment testAccConfigBuilderInterface, iterFingerprint string) testAccConfigBuilderInterface {
 	return testAccPackerAssignmentBuilder(
 		oldAssignment.UniqueName(),
 		oldAssignment.Attributes()["bucket_name"],
 		oldAssignment.Attributes()["channel_name"],
-		iterID,
 		iterFingerprint,
-		iterVersion,
 	)
 }
 
-func testAccPackerAssignmentBuilderWithChannelReference(uniqueName string, channel testAccConfigBuilderInterface, iterID string, iterFingerprint string, iterVersion string) testAccConfigBuilderInterface {
+func testAccPackerAssignmentBuilderWithChannelReference(uniqueName string, channel testAccConfigBuilderInterface, iterFingerprint string) testAccConfigBuilderInterface {
 	return testAccPackerAssignmentBuilder(
 		uniqueName,
 		channel.AttributeRef("bucket_name"),
 		channel.AttributeRef("name"),
-		iterID, iterFingerprint, iterVersion,
+		iterFingerprint,
 	)
 }
 
@@ -465,20 +425,13 @@ func testAccCheckAssignmentStateMatchesIteration(resourceName string, iterationP
 			iteration = &models.HashicorpCloudPackerIteration{}
 		}
 
-		iterID := iteration.ID
-		if iterID == "" {
-			iterID = unassignString
-		}
-
 		iterFingerprint := iteration.Fingerprint
 		if iterFingerprint == "" {
 			iterFingerprint = unassignString
 		}
 
 		return resource.ComposeAggregateTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceName, "iteration_id", iterID),
 			resource.TestCheckResourceAttr(resourceName, "iteration_fingerprint", iterFingerprint),
-			resource.TestCheckResourceAttr(resourceName, "iteration_version", fmt.Sprintf("%d", iteration.IncrementalVersion)),
 		)(state)
 	}
 }

--- a/internal/providersdkv2/resource_packer_channel_assignment_test.go
+++ b/internal/providersdkv2/resource_packer_channel_assignment_test.go
@@ -192,6 +192,9 @@ func TestAccPackerChannelAssignment_InvalidInputs(t *testing.T) {
 				`"doesNotExist"`,
 				`.*iteration with attributes \(fingerprint: doesNotExist\) does not exist.*`,
 			),
+			{ // Create a dummy non-empty state so that `CheckDestroy` will run.
+				Config: testAccConfigDummyNonemptyState,
+			},
 		},
 	})
 }

--- a/internal/providersdkv2/test_helpers_packer_test.go
+++ b/internal/providersdkv2/test_helpers_packer_test.go
@@ -250,6 +250,8 @@ func revokeIteration(t *testing.T, iterationID, bucketSlug string, revokeAt strf
 	}
 	if resp == nil {
 		t.Fatal("expected non-nil response from UpdateIteration, got nil")
+	} else if resp.Payload == nil {
+		t.Fatal("expected non-nil Payload in response from UpdateIteration, got nil")
 	}
 
 	return resp.Payload.Iteration
@@ -318,11 +320,15 @@ func upsertCompleteBuild(t *testing.T, bucketSlug, fingerprint, iterationID stri
 		}
 		if getResp == nil {
 			t.Fatalf("unexpected GetBuild response, expected non nil. Got nil.")
+		} else if getResp.Payload == nil {
+			t.Fatalf("unexpected GetBuild response payload, expected non nil. Got nil.")
 		}
 		build = getResp.Payload.Build
 	} else {
 		if createResp == nil {
 			t.Fatalf("unexpected CreateBuild response, expected non nil. Got nil.")
+		} else if createResp.Payload == nil {
+			t.Fatalf("unexpected CreateBuild response payload, expected non nil. Got nil.")
 		}
 		build = createResp.Payload.Build
 	}
@@ -346,6 +352,8 @@ func upsertCompleteBuild(t *testing.T, bucketSlug, fingerprint, iterationID stri
 	}
 	if updateResp == nil {
 		t.Fatalf("unexpected UpdateBuild response, expected non nil. Got nil.")
+	} else if updateResp.Payload == nil {
+		t.Fatalf("unexpected UpdateBuild response payload, expected non nil. Got nil.")
 	}
 	return updateResp.Payload.Build
 }


### PR DESCRIPTION
# DO NOT MERGE Please contact @hashicorp/cloud-packer before merging, as this PR will be coordinated to be merged alongside several other changes.

### :hammer_and_wrench: Description

- Removes previously deprecated Iteration attributes
  - `data.hcp_packer_iteration.incremental_version`
  - `hcp_packer_channel_assignment.iteration_version`
  - `hcp_packer_channel_assignment.iteration_id`
- Fixes some minor test-related linting issues

### :building_construction: Acceptance tests

- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=Test.*Packer.* -test.v'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=Test.*Packer.* -test.v -timeout 360m -parallel=10
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets      (cached) [no tests to run]
--- PASS: TestAcc_dataSourcePackerBucketNames (13.68s)
--- PASS: TestAcc_dataSourcePackerRunTask (6.89s)
--- PASS: TestAccPackerRunTask (16.03s)
--- PASS: TestAcc_dataSourcePackerImage_emptyChannel (2.11s)
--- PASS: TestAccPackerChannelAssignment_InvalidInputs (3.35s)
--- PASS: TestAcc_dataSourcePackerIteration_revokedIteration (6.16s)
--- PASS: TestAcc_dataSourcePackerImage_revokedIteration (6.28s)
--- PASS: TestAcc_dataSourcePackerImage_IterationID (5.21s)
--- PASS: TestAcc_dataSourcePackerIteration_Simple (9.52s)
--- PASS: TestAcc_dataSourcePackerImage_channelAndIterationIDReject (0.11s)
--- PASS: TestAccPackerChannelAssignment_HCPManagedChannelErrors (3.55s)
--- PASS: TestAcc_dataSourcePackerImage_Simple (11.17s)
--- PASS: TestAccPackerChannelAssignment_SimpleSetUnset (12.12s)
--- PASS: TestAccPackerChannelAssignment_CreateFailsWhenPreassigned (7.87s)
--- PASS: TestAccPackerChannelAssignment_AssignLatest (16.44s)
--- PASS: TestAccPackerChannel (16.57s)
--- PASS: TestAccPackerChannelAssignment_EnforceNull (10.54s)
--- PASS: TestAccPackerChannel_RestrictionDrift (17.69s)
--- PASS: TestAccPackerChannel_RestrictionDriftHCPManaged (18.05s)
--- PASS: TestAccPackerChannel_HCPManaged (15.00s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2      61.639s
```
