### PR TITLE
Provider accepts workload identity token via filepath HCPID2-1948

### DIFF
--- a/.changelog/691.txt
+++ b/.changelog/691.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+Allow authenticating the provider using Workload Identity Federation via a
+token_file in the provider configuration.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ resource "hcp_vault_cluster" "example" {
 - `client_secret` (String) The OAuth2 Client Secret for API operations.
 - `credential_file` (String) The path to an HCP credential file to use to authenticate the provider to HCP. You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. Using a credential file allows you to authenticate the provider as a service principal via client credentials or dynamically based on Workload Identity Federation.
 - `project_id` (String) The default project in which resources should be created.
-- `workload_identity` (Block List) Allows authenticating the provider by exchanging the token specified in the `token_file` for a HCP service principal using Workload Identity Federation. (see [below for nested schema](#nestedblock--workload_identity))
+- `workload_identity` (Block List) Allows authenticating the provider by exchanging the OAuth 2.0 access token or OpenID Connect token specified in the `token_file` for a HCP service principal using Workload Identity Federation. (see [below for nested schema](#nestedblock--workload_identity))
 
 <a id="nestedblock--workload_identity"></a>
 ### Nested Schema for `workload_identity`
@@ -134,7 +134,7 @@ resource "hcp_vault_cluster" "example" {
 Required:
 
 - `resource_name` (String) The resource_name of the Workload Identity Provider to exchange the token with.
-- `token_file` (String) The path to a file containing an identity token.
+- `token_file` (String) The path to a file containing a JWT token retrieved from an OpenID Connect (OIDC) or OAuth2 provider.
 -> **Note:** See the [authentication guide](guides/auth.md) about a use case when specifying `project_id` is needed.
 
 For more information about HCP, please review our [documentation page](https://cloud.hashicorp.com/docs/hcp).

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,15 @@ resource "hcp_vault_cluster" "example" {
 - `client_secret` (String) The OAuth2 Client Secret for API operations.
 - `credential_file` (String) The path to an HCP credential file to use to authenticate the provider to HCP. You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. Using a credential file allows you to authenticate the provider as a service principal via client credentials or dynamically based on Workload Identity Federation.
 - `project_id` (String) The default project in which resources should be created.
+- `workload_identity` (Block List) Allows authenticating the provider by exchanging the token specified in the `token_file` for a HCP service principal using Workload Identity Federation. (see [below for nested schema](#nestedblock--workload_identity))
+
+<a id="nestedblock--workload_identity"></a>
+### Nested Schema for `workload_identity`
+
+Required:
+
+- `resource_name` (String) The resource_name of the Workload Identity Provider to exchange the token with.
+- `token_file` (String) The path to a file containing an identity token.
 -> **Note:** See the [authentication guide](guides/auth.md) about a use case when specifying `project_id` is needed.
 
 For more information about HCP, please review our [documentation page](https://cloud.hashicorp.com/docs/hcp).

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -74,7 +74,7 @@ type ClientConfig struct {
 	CredentialFile string
 
 	// WorkloadIdentityTokenFile and WorkloadIdentityResourceName can be set to
-	// indicate that authentication should occure by using workload identity
+	// indicate that authentication should occur by using workload identity
 	// federation. WorloadIdentityTokenFile indicates a file containing the
 	// token content and WorkloadIdentityResourceName is the workload identity
 	// provider resource name to authenticate against.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/hcp-sdk-go/auth"
+	"github.com/hashicorp/hcp-sdk-go/auth/workload"
 	cloud_billing "github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/preview/2020-11-05/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/preview/2020-11-05/client/billing_account_service"
 
@@ -71,6 +73,14 @@ type ClientConfig struct {
 	ClientSecret   string
 	CredentialFile string
 
+	// WorkloadIdentityTokenFile and WorkloadIdentityResourceName can be set to
+	// indicate that authentication should occure by using workload identity
+	// federation. WorloadIdentityTokenFile indicates a file containing the
+	// token content and WorkloadIdentityResourceName is the workload identity
+	// provider resource name to authenticate against.
+	WorloadIdentityTokenFile     string
+	WorkloadIdentityResourceName string
+
 	// OrganizationID (optional) is the organization unique identifier to launch resources in.
 	OrganizationID string
 
@@ -90,6 +100,18 @@ func NewClient(config ClientConfig) (*Client, error) {
 		opts = append(opts, hcpConfig.WithClientCredentials(config.ClientID, config.ClientSecret))
 	} else if config.CredentialFile != "" {
 		opts = append(opts, hcpConfig.WithCredentialFilePath(config.CredentialFile))
+	} else if config.WorloadIdentityTokenFile != "" && config.WorkloadIdentityResourceName != "" {
+		// Build a credential file that points at the passed token file
+		cf := &auth.CredentialFile{
+			Scheme: auth.CredentialFileSchemeWorkload,
+			Workload: &workload.IdentityProviderConfig{
+				ProviderResourceName: config.WorkloadIdentityResourceName,
+				File: &workload.FileCredentialSource{
+					Path: config.WorloadIdentityTokenFile,
+				},
+			},
+		}
+		opts = append(opts, hcpConfig.WithCredentialFile(cf))
 	}
 
 	// Create the HCP Config

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -98,7 +98,7 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 					Attributes: map[string]schema.Attribute{
 						"token_file": schema.StringAttribute{
 							Required:    true,
-							Description: "The path to a file containing an identity token.",
+							Description: "The path to a file containing a JWT token retrieved from an OpenID Connect (OIDC) or OAuth2 provider.",
 							Validators: []validator.String{
 								stringvalidator.LengthAtLeast(1),
 							},
@@ -115,8 +115,8 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 						},
 					},
 				},
-				Description: "Allows authenticating the provider by exchanging the token specified in the `token_file` for " +
-					"a HCP service principal using Workload Identity Federation.",
+				Description: "Allows authenticating the provider by exchanging the OAuth 2.0 access token or OpenID Connect " +
+					"token specified in the `token_file` for a HCP service principal using Workload Identity Federation.",
 				Validators: []validator.List{
 					listvalidator.SizeBetween(1, 1),
 				},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/project_service"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -37,10 +39,16 @@ type ProviderFrameworkConfiguration struct {
 }
 
 type ProviderFrameworkModel struct {
-	ClientSecret   types.String `tfsdk:"client_secret"`
-	ClientID       types.String `tfsdk:"client_id"`
-	CredentialFile types.String `tfsdk:"credential_file"`
-	ProjectID      types.String `tfsdk:"project_id"`
+	ClientSecret     types.String `tfsdk:"client_secret"`
+	ClientID         types.String `tfsdk:"client_id"`
+	CredentialFile   types.String `tfsdk:"credential_file"`
+	ProjectID        types.String `tfsdk:"project_id"`
+	WorkloadIdentity types.List   `tfsdk:"workload_identity"`
+}
+
+type WorkloadIdentityFrameworkModel struct {
+	TokenFile    types.String `tfsdk:"token_file"`
+	ResourceName types.String `tfsdk:"resource_name"`
 }
 
 func (p *ProviderFramework) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -57,6 +65,7 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 				Validators: []validator.String{
 					stringvalidator.AlsoRequires(path.MatchRoot("client_secret")),
 					stringvalidator.ConflictsWith(path.MatchRoot("credential_file")),
+					stringvalidator.ConflictsWith(path.MatchRoot("workload_identity")),
 				},
 			},
 			"client_secret": schema.StringAttribute{
@@ -76,6 +85,41 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 					"You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. " +
 					"Using a credential file allows you to authenticate the provider as a service principal via client " +
 					"credentials or dynamically based on Workload Identity Federation.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("workload_identity")),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			// TODO migrate to SingleNestedAttribute once the providersdkv2 is
+			// fully migrated.
+			"workload_identity": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"token_file": schema.StringAttribute{
+							Required:    true,
+							Description: "The path to a file containing an identity token.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+						},
+						"resource_name": schema.StringAttribute{
+							Required:    true,
+							Description: "The resource_name of the Workload Identity Provider to exchange the token with.",
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`^iam/project/.+/service-principal/.+/workload-identity-provider/.+$`),
+									"must be a workload identity provider resource_name",
+								),
+							},
+						},
+					},
+				},
+				Description: "Allows authenticating the provider by exchanging the token specified in the `token_file` for " +
+					"a HCP service principal using Workload Identity Federation.",
+				Validators: []validator.List{
+					listvalidator.SizeBetween(1, 1),
+				},
 			},
 		},
 	}
@@ -135,27 +179,34 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 	var data ProviderFrameworkModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
-	clientID := ""
-	if data.ClientID.ValueString() != "" {
-		clientID = data.ClientID.ValueString()
-	} else {
-		clientID = os.Getenv("HCP_CLIENT_ID")
-	}
-
-	clientSecret := ""
-	if data.ClientSecret.ValueString() != "" {
-		clientSecret = data.ClientSecret.ValueString()
-	} else {
-		clientSecret = os.Getenv("HCP_CLIENT_SECRET")
-	}
-
-	client, err := clients.NewClient(clients.ClientConfig{
-		ClientID:       clientID,
-		ClientSecret:   clientSecret,
+	clientConfig := clients.ClientConfig{
+		ClientID:       data.ClientID.ValueString(),
+		ClientSecret:   data.ClientSecret.ValueString(),
 		CredentialFile: data.CredentialFile.ValueString(),
 		SourceChannel:  "terraform-provider-hcp",
-	})
+	}
 
+	// Check the environment for an HCP Service Principal
+	if clientConfig.ClientID == "" {
+		clientConfig.ClientID = os.Getenv("HCP_CLIENT_ID")
+	}
+	if clientConfig.ClientSecret == "" {
+		clientConfig.ClientSecret = os.Getenv("HCP_CLIENT_SECRET")
+	}
+
+	// Read the workload_identity configuration.
+	if len(data.WorkloadIdentity.Elements()) == 1 {
+		elements := make([]WorkloadIdentityFrameworkModel, 0, 1)
+		resp.Diagnostics.Append(data.WorkloadIdentity.ElementsAs(ctx, &elements, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		clientConfig.WorloadIdentityTokenFile = elements[0].TokenFile.ValueString()
+		clientConfig.WorkloadIdentityResourceName = elements[0].ResourceName.ValueString()
+	}
+
+	client, err := clients.NewClient(clientConfig)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("unable to create HCP api client: %v", err), "")
 		return

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -86,14 +86,14 @@ func New() func() *schema.Provider {
 				"workload_identity": {
 					Type:     schema.TypeList,
 					Optional: true,
-					Description: "Allows authenticating the provider by exchanging the token specified in the `token_file` for " +
-						"a HCP service principal using Workload Identity Federation.",
+					Description: "Allows authenticating the provider by exchanging the OAuth 2.0 access token or OpenID Connect " +
+						"token specified in the `token_file` for a HCP service principal using Workload Identity Federation.",
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"token_file": {
 								Type:        schema.TypeString,
 								Required:    true,
-								Description: "The path to a file containing an identity token.",
+								Description: "The path to a file containing a JWT token retrieved from an OpenID Connect (OIDC) or OAuth2 provider.",
 							},
 							"resource_name": {
 								Type:        schema.TypeString,


### PR DESCRIPTION
### :hammer_and_wrench: Description

Support authenticating the provider using workload identity token's passed via file. This avoids the need to create a credential file to simplify the UX in certain scenarios.

I have tested the changes manually by having the provider authenticate using the new configuration block and tested that the provider errors if given conflicting ways to authenticate. 