### PR TITLE
Azure Peering Connection Test Updates

### DIFF
--- a/internal/providersdkv2/resource_azure_peering_connection_test.go
+++ b/internal/providersdkv2/resource_azure_peering_connection_test.go
@@ -179,7 +179,7 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 }
 
 func TestAccAzurePeeringConnectionInternal(t *testing.T) {
-	// t.Skip("Internal test should not be run on CI.")
+	t.Skip("Internal test should not be run on CI.")
 
 	testAccAzurePeeringConnection(t, "")
 }
@@ -235,7 +235,8 @@ func testAccAzurePeeringConnection(t *testing.T, adConfig string) {
 
 					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
 				},
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state", "azure_peering_id"},
 			},
 			// Tests read
 			{
@@ -269,7 +270,7 @@ func TestAccAzurePeeringConnectionNVA(t *testing.T) {
 }
 
 func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
-	// t.Skip("Internal test should not be run on CI.")
+	t.Skip("Internal test should not be run on CI.")
 
 	testAccAzurePeeringConnectionNVA(t, "")
 }
@@ -322,7 +323,8 @@ func testAccAzurePeeringConnectionNVA(t *testing.T, adConfig string) {
 					peerID := rs.Primary.Attributes["peering_id"]
 					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
 				},
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state", "azure_peering_id"},
 			},
 			// Tests read
 			{
@@ -356,7 +358,7 @@ func TestAccAzurePeeringConnectionGateway(t *testing.T) {
 }
 
 func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
-	// t.Skip("Internal test should not be run on CI.")
+	t.Skip("Internal test should not be run on CI.")
 
 	testAccAzurePeeringConnectionGateway(t, "")
 }
@@ -409,7 +411,8 @@ func testAccAzurePeeringConnectionGateway(t *testing.T, adConfig string) {
 					peerID := rs.Primary.Attributes["peering_id"]
 					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
 				},
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state", "azure_peering_id"},
 			},
 			// Tests read
 			{
@@ -443,7 +446,7 @@ func TestAccAzurePeeringConnectionNVAandGateway(t *testing.T) {
 }
 
 func TestAccAzurePeeringConnectionNVAandGatewayInternal(t *testing.T) {
-	// t.Skip("Internal test should not be run on CI.")
+	t.Skip("Internal test should not be run on CI.")
 
 	testAccAzurePeeringConnectionNVAandGateway(t, "")
 }
@@ -496,7 +499,8 @@ func testAccAzurePeeringConnectionNVAandGateway(t *testing.T, adConfig string) {
 					peerID := rs.Primary.Attributes["peering_id"]
 					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
 				},
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state", "azure_peering_id"},
 			},
 			// Tests read
 			{

--- a/internal/providersdkv2/resource_azure_peering_connection_test.go
+++ b/internal/providersdkv2/resource_azure_peering_connection_test.go
@@ -42,42 +42,6 @@ var peeringHubSpokeNVAandGatewayConfig = `
 	  use_remote_gateways     = true
 `
 
-// gatewayConfig is the additional components required for Hub and Spoke architecture
-// using a Gateway.
-func gatewayConfig() string {
-	return fmt.Sprintf(`
-	resource "azurerm_subnet" "subnet" {
-	  name                 = "GatewaySubnet"
-	  resource_group_name  = azurerm_resource_group.rg.name
-	  virtual_network_name = azurerm_virtual_network.vnet.name
-	  address_prefixes     = ["10.0.1.0/24"]
-	}
-
-	resource "azurerm_public_ip" "ip" {
-	  name                = "%[1]s"
-	  location            = azurerm_resource_group.rg.location
-	  resource_group_name = azurerm_resource_group.rg.name
-	  allocation_method   = "Dynamic"
-	}
-
-	resource "azurerm_virtual_network_gateway" "gateway" {
-	  name                = "%[1]s"
-	  location            = azurerm_resource_group.rg.location
-	  resource_group_name = azurerm_resource_group.rg.name
-	  type                = "Vpn"
-	  enable_bgp          = false
-      sku                 = "Basic"
-
-	  ip_configuration {
-		name                          = "%[1]s"
-		public_ip_address_id          = azurerm_public_ip.ip.id
-		private_ip_address_allocation = "Dynamic"
-		subnet_id                     = azurerm_subnet.subnet.id
-	  }
-	}
-	`, uniqueAzurePeeringTestID)
-}
-
 // azureAdConfig is the config required to allow HCP to peer from the Remote VNet to HCP HVN
 var azureAdConfig = `
 	resource "azuread_service_principal" "principal" {
@@ -108,37 +72,6 @@ var azureAdConfig = `
 	}
 `
 
-// standardConfig is the configuration for a basic Azure peering.
-func standardConfig() string {
-	return baseConfig("", azureAdConfig)
-}
-
-// nvaConfigWithAd is the configuration for a Hub / Spoke architecture using the
-// NVA model, including Service Principal components.
-func nvaConfigWithAd() string {
-	return baseConfig(peeringHubSpokeNVAConfig, azureAdConfig)
-}
-
-// gatewayConfigWithAd is the configuration for a Hub / Spoke architecture using
-// the Gateway model, including Service Principal components.
-func gatewayConfigWithAd() string {
-	return baseConfig(peeringHubSpokeGatewayConfig, fmt.Sprintf(`
-    %s
-
-    %s
-    `, azureAdConfig, gatewayConfig()))
-}
-
-// nvaGatewayConfigWithAd is the configuration for a Hub / Spoke architecture using
-// NVA and the Gateway model, including Service Principal components.
-func nvaGatewayConfigWithAd() string {
-	return baseConfig(peeringHubSpokeNVAandGatewayConfig, fmt.Sprintf(`
-    %s
-
-    %s
-    `, azureAdConfig, gatewayConfig()))
-}
-
 // baseConfig is the config excluding the authorization components (SP, Role, Role assignment).
 // This is used to support HashiCorp internal engineers.
 func baseConfig(hubSpokeConfig, optConfig string) string {
@@ -158,9 +91,9 @@ func baseConfig(hubSpokeConfig, optConfig string) string {
 	resource "hcp_azure_peering_connection" "peering" {
 	  hvn_link                 = hcp_hvn.test.self_link
 	  peering_id               = "%[1]s"
-	  peer_vnet_name           = azurerm_virtual_network.vnet.name
 	  peer_subscription_id     = "%[2]s"
 	  peer_tenant_id           = "%[3]s"
+	  peer_vnet_name           = azurerm_virtual_network.vnet.name
 	  peer_resource_group_name = azurerm_resource_group.rg.name
 	  peer_vnet_region         = "eastus"
 
@@ -170,17 +103,17 @@ func baseConfig(hubSpokeConfig, optConfig string) string {
 
 	// This data source is the same as the resource above, but waits for the connection to be Active before returning.
 	data "hcp_azure_peering_connection" "peering" {
-	  hvn_link                 = hcp_hvn.test.self_link
-	  peering_id               = hcp_azure_peering_connection.peering.peering_id
-	  wait_for_active_state    = true
+	  hvn_link              = hcp_hvn.test.self_link
+	  peering_id            = hcp_azure_peering_connection.peering.peering_id
+	  wait_for_active_state = true
 	}
 
 	// The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
 	resource "hcp_hvn_route" "route" {
-	  hvn_route_id = "%[1]s"
-	  hvn_link = hcp_hvn.test.self_link
+	  hvn_route_id     = "%[1]s"
+	  hvn_link         = hcp_hvn.test.self_link
 	  destination_cidr = "172.31.0.0/16"
-	  target_link = data.hcp_azure_peering_connection.peering.self_link
+	  target_link      = data.hcp_azure_peering_connection.peering.self_link
 	}
 
 	resource "azurerm_resource_group" "rg" {
@@ -202,8 +135,58 @@ func baseConfig(hubSpokeConfig, optConfig string) string {
 	`, uniqueAzurePeeringTestID, subscriptionID, tenantID, hubSpokeConfig, optConfig)
 }
 
+// gatewayConfig is the additional components required for Hub and Spoke architecture
+// using a Gateway.
+func gatewayConfig(optConfig string) string {
+	return fmt.Sprintf(`
+	resource "azurerm_subnet" "subnet" {
+	  name                 = "GatewaySubnet"
+	  resource_group_name  = azurerm_resource_group.rg.name
+	  virtual_network_name = azurerm_virtual_network.vnet.name
+	  address_prefixes     = ["10.0.1.0/24"]
+	}
+
+	resource "azurerm_public_ip" "ip" {
+	  name                = "%[1]s"
+	  location            = azurerm_resource_group.rg.location
+	  resource_group_name = azurerm_resource_group.rg.name
+	  allocation_method   = "Dynamic"
+	}
+
+	resource "azurerm_virtual_network_gateway" "gateway" {
+	  name                = "%[1]s"
+	  location            = azurerm_resource_group.rg.location
+	  resource_group_name = azurerm_resource_group.rg.name
+	  type                = "Vpn"
+	  enable_bgp          = false
+      sku                 = "Basic"
+
+	  ip_configuration {
+		name                          = "%[1]s"
+		public_ip_address_id          = azurerm_public_ip.ip.id
+		private_ip_address_allocation = "Dynamic"
+		subnet_id                     = azurerm_subnet.subnet.id
+	  }
+	}
+
+	%[2]s
+	`, uniqueAzurePeeringTestID, optConfig)
+}
+
+// TestAccAzurePeeringConnection tests Azure peering with no hub / spoke config
 func TestAccAzurePeeringConnection(t *testing.T) {
+	testAccAzurePeeringConnection(t, azureAdConfig)
+}
+
+func TestAccAzurePeeringConnectionInternal(t *testing.T) {
+	// t.Skip("Internal test should not be run on CI.")
+
+	testAccAzurePeeringConnection(t, "")
+}
+
+func testAccAzurePeeringConnection(t *testing.T, adConfig string) {
 	resourceName := "hcp_azure_peering_connection.peering"
+	tfConfig := baseConfig("", adConfig)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
@@ -217,11 +200,10 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Tests create
-				Config: testConfig(standardConfig()),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -233,73 +215,11 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 					// Note: azure_peering_id is not set until the peering is accepted after creation.
 				),
 			},
-			{
-				// Tests create / Enables Hub/Spoke with NVA connectivity
-				Config: testConfig(nvaConfigWithAd()),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAzurePeeringExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
-					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
-					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
-					resource.TestCheckResourceAttr(resourceName, "allow_forwarded_traffic", "true"),
-					resource.TestCheckResourceAttr(resourceName, "use_remote_gateways", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
-				),
-			},
-			{
-				// Tests create / Enables Hub/Spoke with Gateway connectivity
-				Config: testConfig(gatewayConfigWithAd()),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAzurePeeringExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
-					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
-					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
-					resource.TestCheckResourceAttr(resourceName, "allow_forwarded_traffic", "false"),
-					resource.TestCheckResourceAttr(resourceName, "use_remote_gateways", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
-				),
-			},
-			{
-				// Tests create / Enables Hub/Spoke with NVA and Gateway connectivity
-				Config: testConfig(nvaGatewayConfigWithAd()),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAzurePeeringExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
-					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
-					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
-					resource.TestCheckResourceAttr(resourceName, "allow_forwarded_traffic", "true"),
-					resource.TestCheckResourceAttr(resourceName, "use_remote_gateways", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
-				),
-			},
 			// Tests import
 			{
 				ResourceName: resourceName,
@@ -312,20 +232,22 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 
 					hvnID := s.RootModule().Resources["hcp_hvn.test"].Primary.Attributes["hvn_id"]
 					peerID := rs.Primary.Attributes["peering_id"]
+
 					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
 				},
 				ImportStateVerify: true,
 			},
 			// Tests read
 			{
-				Config: testConfig(standardConfig()),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
+					resource.TestCheckResourceAttr(resourceName, "allow_forwarded_traffic", "false"),
+					resource.TestCheckResourceAttr(resourceName, "use_remote_gateways", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
 					resource.TestCheckResourceAttrSet(resourceName, "azure_peering_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
@@ -333,6 +255,7 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
@@ -340,90 +263,20 @@ func TestAccAzurePeeringConnection(t *testing.T) {
 	})
 }
 
-// TestAccAzurePeeringConnectionStandardInternal is almost identical to the standard
-// TestAccAzurePeeringConnection test, but does not include the Azure Service Principal
-// components which allow permission for HCP to peer from the "Customer" account to HCP dataplane.
-// This modified test exists for HashiCorp internal contributors to adhere to on-demand
-// service principal creation via doormat.
-func TestAccAzurePeeringConnectionStandardInternal(t *testing.T) {
-	t.Skip("This should not be run on CI, only locally.")
-
-	resourceName := "hcp_azure_peering_connection.peering"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
-		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"azurerm": {VersionConstraint: "~> 3.63"},
-			"azuread": {VersionConstraint: "~> 2.39"},
-		},
-		CheckDestroy: testAccCheckAzurePeeringDestroy,
-		Steps: []resource.TestStep{
-			{
-				// Tests create
-				Config: testConfig(baseConfig("", "")),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAzurePeeringExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
-					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
-					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
-					resource.TestCheckResourceAttr(resourceName, "allow_forwarded_traffic", "false"),
-					resource.TestCheckResourceAttr(resourceName, "use_remote_gateways", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
-				),
-			},
-			// Tests import
-			{
-				ResourceName: resourceName,
-				ImportState:  true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					rs, ok := s.RootModule().Resources[resourceName]
-					if !ok {
-						return "", fmt.Errorf("not found: %s", resourceName)
-					}
-
-					hvnID := s.RootModule().Resources["hcp_hvn.test"].Primary.Attributes["hvn_id"]
-					peerID := rs.Primary.Attributes["peering_id"]
-					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
-				},
-				ImportStateVerify: true,
-			},
-			// Tests read
-			{
-				Config: testConfig(baseConfig("", "")),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAzurePeeringExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
-					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
-					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
-					resource.TestCheckResourceAttrSet(resourceName, "peer_vnet_region"),
-					resource.TestCheckResourceAttrSet(resourceName, "azure_peering_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
-				),
-			},
-		},
-	})
+// TestAccAzurePeeringConnectionNVA tests Azure peering with NVA hub / spoke networking
+func TestAccAzurePeeringConnectionNVA(t *testing.T) {
+	testAccAzurePeeringConnectionNVA(t, azureAdConfig)
 }
 
 func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
-	t.Skip("This should not be run on CI, only locally.")
+	// t.Skip("Internal test should not be run on CI.")
 
+	testAccAzurePeeringConnectionNVA(t, "")
+}
+
+func testAccAzurePeeringConnectionNVA(t *testing.T, adConfig string) {
 	resourceName := "hcp_azure_peering_connection.peering"
+	tfConfig := baseConfig(peeringHubSpokeNVAConfig, adConfig)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
@@ -436,11 +289,10 @@ func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Tests create / Enables Hub/Spoke with NVA connectivity
-				Config: testConfig(baseConfig(peeringHubSpokeNVAConfig, "")),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -452,6 +304,7 @@ func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
@@ -473,11 +326,10 @@ func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
 			},
 			// Tests read
 			{
-				Config: testConfig(baseConfig("", "")),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -490,6 +342,7 @@ func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
@@ -497,10 +350,20 @@ func TestAccAzurePeeringConnectionNVAInternal(t *testing.T) {
 	})
 }
 
-func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
-	t.Skip("This should not be run on CI, only locally.")
+// TestAccAzurePeeringConnectionGateway tests Azure peering with hub / spoke Gateway
+func TestAccAzurePeeringConnectionGateway(t *testing.T) {
+	testAccAzurePeeringConnectionGateway(t, azureAdConfig)
+}
 
+func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
+	// t.Skip("Internal test should not be run on CI.")
+
+	testAccAzurePeeringConnectionGateway(t, "")
+}
+
+func testAccAzurePeeringConnectionGateway(t *testing.T, adConfig string) {
 	resourceName := "hcp_azure_peering_connection.peering"
+	tfConfig := baseConfig(peeringHubSpokeGatewayConfig, gatewayConfig(adConfig))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
@@ -513,11 +376,10 @@ func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Tests create - Enables Hub/Spoke with Gateway transit
-				Config: testConfig(baseConfig(peeringHubSpokeGatewayConfig, gatewayConfig())),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -529,6 +391,7 @@ func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
@@ -550,11 +413,10 @@ func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
 			},
 			// Tests read
 			{
-				Config: testConfig(baseConfig("", "")),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -567,6 +429,7 @@ func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
@@ -574,10 +437,20 @@ func TestAccAzurePeeringConnectionGatewayInternal(t *testing.T) {
 	})
 }
 
-func TestAccAzurePeeringConnectionNVAGatewayInternal(t *testing.T) {
-	t.Skip("This should not be run on CI, only locally.")
+// TestAccAzurePeeringConnectionNVAandGateway tests Azure peering with hub / spoke NVA and Gateway
+func TestAccAzurePeeringConnectionNVAandGateway(t *testing.T) {
+	testAccAzurePeeringConnectionNVAandGateway(t, azureAdConfig)
+}
 
+func TestAccAzurePeeringConnectionNVAandGatewayInternal(t *testing.T) {
+	// t.Skip("Internal test should not be run on CI.")
+
+	testAccAzurePeeringConnectionNVAandGateway(t, "")
+}
+
+func testAccAzurePeeringConnectionNVAandGateway(t *testing.T, adConfig string) {
 	resourceName := "hcp_azure_peering_connection.peering"
+	tfConfig := baseConfig(peeringHubSpokeNVAandGatewayConfig, gatewayConfig(adConfig))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
@@ -590,11 +463,10 @@ func TestAccAzurePeeringConnectionNVAGatewayInternal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Tests create - Enables Hub/Spoke with NVA and Gateway transit
-				Config: testConfig(baseConfig(peeringHubSpokeNVAandGatewayConfig, gatewayConfig())),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -606,6 +478,7 @@ func TestAccAzurePeeringConnectionNVAGatewayInternal(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},
@@ -627,11 +500,10 @@ func TestAccAzurePeeringConnectionNVAGatewayInternal(t *testing.T) {
 			},
 			// Tests read
 			{
-				Config: testConfig(baseConfig("", "")),
+				Config: testConfig(tfConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAzurePeeringExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peering_id", uniqueAzurePeeringTestID),
-					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "peer_subscription_id", subscriptionID),
 					resource.TestCheckResourceAttr(resourceName, "peer_tenant_id", tenantID),
 					resource.TestCheckResourceAttr(resourceName, "peer_vnet_name", uniqueAzurePeeringTestID),
@@ -644,6 +516,7 @@ func TestAccAzurePeeringConnectionNVAGatewayInternal(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					testLink(resourceName, "hvn_link", uniqueAzurePeeringTestID, HvnResourceType, resourceName),
 					testLink(resourceName, "self_link", uniqueAzurePeeringTestID, PeeringResourceType, "hcp_hvn.test"),
 				),
 			},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
* Prerelease pipeline is failing during azure peering test(s). Due to the tests not closely matching between CI / Internal tests, this PR refactors them to share as much of the same logic as possible. (The only difference should be the Azure AD service principal resources not being used for Internal tests.)
* Separates the tests to be individually-named go tests rather than test steps running the same test.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
make testacc TESTARGS='-run=TestAccAzurePeeringConnectionInternal'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccAzurePeeringConnectionInternal -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	(cached) [no tests to run]
=== RUN   TestAccAzurePeeringConnectionInternal
--- PASS: TestAccAzurePeeringConnectionInternal (753.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	754.404s
...
```

```sh
make testacc TESTARGS='-run=TestAccAzurePeeringConnectionNVAInternal'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccAzurePeeringConnectionNVAInternal -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	(cached) [no tests to run]
=== RUN   TestAccAzurePeeringConnectionNVAInternal
--- PASS: TestAccAzurePeeringConnectionNVAInternal (2001.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	2002.011s
```

```sh
make testacc TESTARGS='-run=TestAccAzurePeeringConnectionGatewayInternal'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccAzurePeeringConnectionGatewayInternal -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	0.715s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.493s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	0.797s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	0.726s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	1.065s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	1.424s [no tests to run]
=== RUN   TestAccAzurePeeringConnectionGatewayInternal
--- PASS: TestAccAzurePeeringConnectionGatewayInternal (1847.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	1848.843s
```

```sh
make testacc TESTARGS='-run=TestAccAzurePeeringConnectionNVAandGatewayInternal'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccAzurePeeringConnectionNVAandGatewayInternal -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	0.731s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.404s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	0.495s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.809s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	0.551s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	1.183s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	0.866s [no tests to run]
=== RUN   TestAccAzurePeeringConnectionNVAandGatewayInternal
--- PASS: TestAccAzurePeeringConnectionNVAandGatewayInternal (1985.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	1987.393s
```
