### PR TITLE
AWS Peering / TGW Attachment Test Update

### DIFF
--- a/internal/providersdkv2/resource_aws_network_peering_test.go
+++ b/internal/providersdkv2/resource_aws_network_peering_test.go
@@ -18,65 +18,65 @@ var (
 	// using unique names for AWS resource to make debugging easier
 	hvnPeeringUniqueAWSName = fmt.Sprintf("hcp-provider-test-%s", time.Now().Format("200601021504"))
 	testAccAwsPeeringConfig = fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
+	provider "aws" {
+	  region = "us-west-2"
+	}
 
-resource "hcp_hvn" "test" {
-	hvn_id         = "%[1]s"
-	cloud_provider = "aws"
-	region         = "us-west-2"
-}
+	resource "hcp_hvn" "test" {
+		hvn_id         = "%[1]s"
+		cloud_provider = "aws"
+		region         = "us-west-2"
+	}
 
-resource "aws_vpc" "vpc" {
-  cidr_block = "10.220.0.0/16"
-  tags = {
-     Name = "%[1]s"
-  }
-}
+	resource "aws_vpc" "vpc" {
+	  cidr_block = "10.220.0.0/16"
+	  tags = {
+		 Name = "%[1]s"
+	  }
+	}
 
-// This resource initially returns in a Pending state, because its provider_peering_id is required to complete acceptance of the connection.
-resource "hcp_aws_network_peering" "peering" {
-  peering_id                = "%[1]s"
-  hvn_id                    = hcp_hvn.test.hvn_id
-  peer_account_id           = aws_vpc.vpc.owner_id
-  peer_vpc_id               = aws_vpc.vpc.id
-  peer_vpc_region           = "us-west-2"
-}
+	// This resource initially returns in a Pending state, because its provider_peering_id is required to complete acceptance of the connection.
+	resource "hcp_aws_network_peering" "peering" {
+	  peering_id                = "%[1]s"
+	  hvn_id                    = hcp_hvn.test.hvn_id
+	  peer_account_id           = aws_vpc.vpc.owner_id
+	  peer_vpc_id               = aws_vpc.vpc.id
+	  peer_vpc_region           = "us-west-2"
+	}
 
-// This data source is the same as the resource above, but waits for the connection to be Active before returning.
-data "hcp_aws_network_peering" "peering" {
-  hvn_id                    = hcp_hvn.test.hvn_id
-  peering_id                = hcp_aws_network_peering.peering.peering_id
-  wait_for_active_state     = true
-}
+	// This data source is the same as the resource above, but waits for the connection to be Active before returning.
+	data "hcp_aws_network_peering" "peering" {
+	  hvn_id                    = hcp_hvn.test.hvn_id
+	  peering_id                = hcp_aws_network_peering.peering.peering_id
+	  wait_for_active_state     = true
+	}
 
-// The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
-resource "hcp_hvn_route" "route" {
-  hvn_route_id              = "%[1]s"
-  hvn_link                  = hcp_hvn.test.self_link
-  destination_cidr          = "172.31.0.0/16"
-  target_link               = data.hcp_aws_network_peering.peering.self_link
-}
+	// The route depends on the data source, rather than the resource, to ensure the peering is in an Active state.
+	resource "hcp_hvn_route" "route" {
+	  hvn_route_id              = "%[1]s"
+	  hvn_link                  = hcp_hvn.test.self_link
+	  destination_cidr          = "172.31.0.0/16"
+	  target_link               = data.hcp_aws_network_peering.peering.self_link
+	}
 
-resource "aws_vpc_peering_connection_accepter" "peering-accepter" {
-  vpc_peering_connection_id = hcp_aws_network_peering.peering.provider_peering_id
-  auto_accept               = true
-  tags = {
-     Name = "%[1]s"
+	resource "aws_vpc_peering_connection_accepter" "peering-accepter" {
+	  vpc_peering_connection_id = hcp_aws_network_peering.peering.provider_peering_id
+	  auto_accept               = true
+	  tags = {
+		 Name = "%[1]s"
 
-	 // we need to have these tags here because peering-accepter will turn into
-     // an actual peering which HCP will populate with a set of tags (the ones below).
-     // After succesfull "apply"" test will try to run "plan" operation
-     // to make sure there are no changes to the state and if we don't specify these
-     // tags here then it will fail.
-	 hvn_id          = hcp_hvn.test.hvn_id
-	 organization_id = hcp_hvn.test.organization_id
-	 project_id      = hcp_hvn.test.project_id
-	 peering_id      = hcp_aws_network_peering.peering.peering_id
-  }
-}
-`, hvnPeeringUniqueAWSName)
+		 // we need to have these tags here because peering-accepter will turn into
+		 // an actual peering which HCP will populate with a set of tags (the ones below).
+		 // After succesfull "apply"" test will try to run "plan" operation
+		 // to make sure there are no changes to the state and if we don't specify these
+		 // tags here then it will fail.
+		 hvn_id          = hcp_hvn.test.hvn_id
+		 organization_id = hcp_hvn.test.organization_id
+		 project_id      = hcp_hvn.test.project_id
+		 peering_id      = hcp_aws_network_peering.peering.peering_id
+	  }
+	}
+	`, hvnPeeringUniqueAWSName)
 )
 
 func TestAccAwsPeering(t *testing.T) {
@@ -125,7 +125,8 @@ func TestAccAwsPeering(t *testing.T) {
 					peerID := rs.Primary.Attributes["peering_id"]
 					return fmt.Sprintf("%s:%s", hvnID, peerID), nil
 				},
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state"},
 			},
 			// Testing running Terraform Apply for already known resource
 			{

--- a/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
+++ b/internal/providersdkv2/resource_aws_transit_gateway_attachment_test.go
@@ -19,90 +19,90 @@ var (
 	tgwAttUniqueAWSName        = fmt.Sprintf("hcp-att-unique-test-%s", time.Now().Format("200601021504"))
 	tgwAttUniqueHvnName        = fmt.Sprintf("att-hvn-name-%s", time.Now().Format("200601021504"))
 	testAccTGWAttachmentConfig = fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
+	provider "aws" {
+	  region = "us-west-2"
+	}
 
-resource "hcp_hvn" "test" {
-  hvn_id         = "%[2]s"
-  cloud_provider = "aws"
-  region         = "us-west-2"
-  cidr_block     = "172.25.16.0/20"
-}
+	resource "hcp_hvn" "test" {
+	  hvn_id         = "%[2]s"
+	  cloud_provider = "aws"
+	  region         = "us-west-2"
+	  cidr_block     = "172.25.16.0/20"
+	}
 
-resource "aws_vpc" "example" {
-  cidr_block = "172.31.0.0/16"
-  tags = {
-    Name = "%[1]s"
-  }
-}
+	resource "aws_vpc" "example" {
+	  cidr_block = "172.31.0.0/16"
+	  tags = {
+		Name = "%[1]s"
+	  }
+	}
 
-resource "aws_ec2_transit_gateway" "example" {
-  tags = {
-    Name = "%[1]s"
-  }
-}
+	resource "aws_ec2_transit_gateway" "example" {
+	  tags = {
+		Name = "%[1]s"
+	  }
+	}
 
-resource "aws_ram_resource_share" "example" {
-  name                      = "%[1]s"
-  allow_external_principals = true
-}
+	resource "aws_ram_resource_share" "example" {
+	  name                      = "%[1]s"
+	  allow_external_principals = true
+	}
 
-resource "aws_ram_principal_association" "example" {
-  resource_share_arn = aws_ram_resource_share.example.arn
-  principal          = hcp_hvn.test.provider_account_id
-}
+	resource "aws_ram_principal_association" "example" {
+	  resource_share_arn = aws_ram_resource_share.example.arn
+	  principal          = hcp_hvn.test.provider_account_id
+	}
 
-resource "aws_ram_resource_association" "example" {
-  resource_share_arn = aws_ram_resource_share.example.arn
-  resource_arn       = aws_ec2_transit_gateway.example.arn
-}
+	resource "aws_ram_resource_association" "example" {
+	  resource_share_arn = aws_ram_resource_share.example.arn
+	  resource_arn       = aws_ec2_transit_gateway.example.arn
+	}
 
-resource "hcp_aws_transit_gateway_attachment" "example" {
-  depends_on = [
-    aws_ram_principal_association.example,
-    aws_ram_resource_association.example,
-  ]
+	resource "hcp_aws_transit_gateway_attachment" "example" {
+	  depends_on = [
+		aws_ram_principal_association.example,
+		aws_ram_resource_association.example,
+	  ]
 
-  hvn_id                        = hcp_hvn.test.hvn_id
-  transit_gateway_attachment_id = "%[1]s"
-  transit_gateway_id            = aws_ec2_transit_gateway.example.id
-  resource_share_arn            = aws_ram_resource_share.example.arn
-}
+	  hvn_id                        = hcp_hvn.test.hvn_id
+	  transit_gateway_attachment_id = "%[1]s"
+	  transit_gateway_id            = aws_ec2_transit_gateway.example.id
+	  resource_share_arn            = aws_ram_resource_share.example.arn
+	}
 
-// This data source is the same as the resource above, but waits for the connection to be Active before returning.
-data "hcp_aws_transit_gateway_attachment" "example" {
-  hvn_id                               = hcp_hvn.test.hvn_id
-  transit_gateway_attachment_id        = hcp_aws_transit_gateway_attachment.example.transit_gateway_attachment_id
-  wait_for_active_state                = true
-}
+	// This data source is the same as the resource above, but waits for the connection to be Active before returning.
+	data "hcp_aws_transit_gateway_attachment" "example" {
+	  hvn_id                               = hcp_hvn.test.hvn_id
+	  transit_gateway_attachment_id        = hcp_aws_transit_gateway_attachment.example.transit_gateway_attachment_id
+	  wait_for_active_state                = true
+	}
 
-// The route depends on the data source, rather than the resource, to ensure the TGW is in an Active state.
-resource "hcp_hvn_route" "route" {
- hvn_link         = hcp_hvn.test.self_link
- hvn_route_id     = "%[1]s"
- destination_cidr = aws_vpc.example.cidr_block
- target_link      = data.hcp_aws_transit_gateway_attachment.example.self_link
-}
+	// The route depends on the data source, rather than the resource, to ensure the TGW is in an Active state.
+	resource "hcp_hvn_route" "route" {
+	 hvn_link         = hcp_hvn.test.self_link
+	 hvn_route_id     = "%[1]s"
+	 destination_cidr = aws_vpc.example.cidr_block
+	 target_link      = data.hcp_aws_transit_gateway_attachment.example.self_link
+	}
 
-resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
-  transit_gateway_attachment_id = hcp_aws_transit_gateway_attachment.example.provider_transit_gateway_attachment_id
+	resource "aws_ec2_transit_gateway_vpc_attachment_accepter" "example" {
+	  transit_gateway_attachment_id = hcp_aws_transit_gateway_attachment.example.provider_transit_gateway_attachment_id
 
-  tags = {
-     Name = "%[1]s"
+	  tags = {
+		 Name = "%[1]s"
 
-	 // we need to have these tags here because peering-accepter will turn into
-     // an actual peering which HCP will populate with a set of tags (the ones below).
-     // After succesfull "apply"" test will try to run "plan" operation
-     // to make sure there are no changes to the state and if we don't specify these
-     // tags here then it will fail.
-	 hvn_id          = hcp_hvn.test.hvn_id
-	 organization_id = hcp_hvn.test.organization_id
-	 project_id      = hcp_hvn.test.project_id
-	 tgw_attachment_id = hcp_aws_transit_gateway_attachment.example.transit_gateway_attachment_id
-  }
-}
-`, tgwAttUniqueAWSName, tgwAttUniqueHvnName)
+		 // we need to have these tags here because peering-accepter will turn into
+		 // an actual peering which HCP will populate with a set of tags (the ones below).
+		 // After succesfull "apply"" test will try to run "plan" operation
+		 // to make sure there are no changes to the state and if we don't specify these
+		 // tags here then it will fail.
+		 hvn_id            = hcp_hvn.test.hvn_id
+		 organization_id   = hcp_hvn.test.organization_id
+		 project_id        = hcp_hvn.test.project_id
+		 tgw_attachment_id = hcp_aws_transit_gateway_attachment.example.transit_gateway_attachment_id
+	  }
+	}
+	`, tgwAttUniqueAWSName, tgwAttUniqueHvnName)
 )
 
 func TestAccTGWAttachment(t *testing.T) {
@@ -147,7 +147,8 @@ func TestAccTGWAttachment(t *testing.T) {
 
 					return fmt.Sprintf("%s:%s:%s", tgwAttUniqueHvnName, tgwAttUniqueAWSName, resourceShare.Primary.Attributes["arn"]), nil
 				},
-				ImportStateVerify: true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state"},
 			},
 			// Testing running Terraform Apply for already known resource
 			{


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

* E2E tests for AWS Peering and TGW Attachment are failing [during import test](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/7168796630/job/19517751233#step:8:436) due to the state changing from PENDING_ACCEPTANCE to ACTIVE.
* This PR updates the import test to ignore that attribute.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
make testacc TESTARGS='-run=TestAccAwsPeering'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccAwsPeering -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	1.022s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.829s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	0.615s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.394s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	0.665s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	0.974s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	1.292s [no tests to run]
=== RUN   TestAccAwsPeering
--- PASS: TestAccAwsPeering (374.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	376.221s
...
```

```sh
make testacc TESTARGS='-run=TestAccTGWAttachment'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccTGWAttachment -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	0.680s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.431s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	0.905s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.768s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	0.699s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	1.053s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	1.408s [no tests to run]
=== RUN   TestAccTGWAttachment
--- PASS: TestAccTGWAttachment (616.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	618.545s
...
```