### PR TITLE
Prevent releases desyncing from `main` if push to `main` fails

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -139,7 +139,9 @@ jobs:
         run: |
           CHANGELOG_URL="https://github.com/hashicorp/terraform-provider-hcp/blob/${NEW_VERSION}/CHANGELOG.md"
           git tag -a -m "${NEW_VERSION}" -m "See changelog: ${CHANGELOG_URL}" "${NEW_VERSION}"
-          echo "Pushing new tag to remote"
+          echo "Git configuration:"
           git config -l
-          git push --tags
+          echo "Pushing new commits to remote"
           git push
+          echo "Pushing new tag to remote, which will trigger the Release workflow"
+          git push --tags


### PR DESCRIPTION
### :hammer_and_wrench: Description

- Change push order in Prerelease workflow to prevent releases desyncing from `main` if the push to `main` fails