### PR TITLE
update log streaming destination test

### DIFF
--- a/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
+++ b/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
@@ -42,7 +42,7 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", spName),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.token"),
-					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://tenant.splunkcloud.com:8088/services/collector/event"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com:443/services/collector/event"),
 					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.token", "splunk-authentication-token"),
 				),
 			},
@@ -54,7 +54,7 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", spNameUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.token"),
-					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://tenant.splunkcloud.com:8088/services/collector/event"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com:443/services/collector/event"),
 					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.token", "splunk-authentication-token"),
 					func(_ *terraform.State) error {
 						if sp.Resource.ID == sp2.Resource.ID {
@@ -73,7 +73,7 @@ func testAccSplunkConfig(name string) string {
   		resource "hcp_log_streaming_destination" "test_splunk_cloud" {
   			name = "%[1]s"
   			splunk_cloud = {
-  				endpoint = "https://tenant.splunkcloud.com:8088/services/collector/event"
+  				endpoint = "https://http-inputs-hcptest.splunkcloud.com:443/services/collector/event"
   				token = "splunk-authentication-token"
   			}
   		}

--- a/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
+++ b/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
@@ -42,7 +42,7 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", spName),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.token"),
-					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com:443/services/collector/event"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com/services/collector/event"),
 					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.token", "splunk-authentication-token"),
 				),
 			},
@@ -54,7 +54,7 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", spNameUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.token"),
-					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com:443/services/collector/event"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com/services/collector/event"),
 					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.token", "splunk-authentication-token"),
 					func(_ *terraform.State) error {
 						if sp.Resource.ID == sp2.Resource.ID {
@@ -73,7 +73,7 @@ func testAccSplunkConfig(name string) string {
   		resource "hcp_log_streaming_destination" "test_splunk_cloud" {
   			name = "%[1]s"
   			splunk_cloud = {
-  				endpoint = "https://http-inputs-hcptest.splunkcloud.com:443/services/collector/event"
+  				endpoint = "https://http-inputs-hcptest.splunkcloud.com/services/collector/event"
   				token = "splunk-authentication-token"
   			}
   		}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

updating the test endpoint in the `hcp log streaming destination` tests to pass tls validation

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
<details>
  <summary>TestAccHCPLogStreamingDestinationSplunk</summary>

```sh
$ make testacc TESTARGS='-run=TestAccHCPLogStreamingDestinationSplunk'

==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccHCPLogStreamingDestinationSplunk -timeout 360m -parallel=10
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       (cached) [no tests to run]
=== RUN   TestAccHCPLogStreamingDestinationSplunk
--- PASS: TestAccHCPLogStreamingDestinationSplunk (5.79s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming      6.292s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2      (cached) [no tests to run]
...
```

</details>

