### PR TITLE
Error out if creds has no project access

### DIFF
--- a/.changelog/748.txt
+++ b/.changelog/748.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Do not panic if provider is configured with credentials with no project access.
+```

--- a/internal/provider/project_helpers.go
+++ b/internal/provider/project_helpers.go
@@ -46,9 +46,12 @@ func getProjectFromCredentialsFramework(ctx context.Context, client *clients.Cli
 		diags.AddError(fmt.Sprintf("unable to fetch project id: %v", err), "")
 		return nil, diags
 	}
+	if len(listProjResp.Payload.Projects) == 0 {
+		diags.AddError("The configured credentials does not have access to any project.", "Please assign at least one project to the configured credentials to use this provider.")
+		return nil, diags
+	}
 	if len(listProjResp.Payload.Projects) > 1 {
 		diags.AddWarning("There is more than one project associated with the organization of the configured credentials.", `The oldest project has been selected as the default. To configure which project is used as default, set a project in the HCP provider config block. Resources may also be configured with different projects.`)
-
 		return getOldestProject(listProjResp.Payload.Projects), diags
 	}
 	project = listProjResp.Payload.Projects[0]


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

We recently introduced no-role access which allows a user to become member of the org without access to any project. If such a user tries to use the provider then it will panic because the provider expects to have at least one project in `project.List` response which in this case will be empty array. Instead of panicing, error out saying the provider needs access to at least one project.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
