### PR TITLE
Update example for hcp_packer_channel_assignment

### DIFF
--- a/.changelog/749.txt
+++ b/.changelog/749.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update example for `hcp_packer_channel_assignment` resource
+```

--- a/docs/resources/packer_channel_assignment.md
+++ b/docs/resources/packer_channel_assignment.md
@@ -13,24 +13,16 @@ The Packer Channel Assignment resource allows you to manage the version assigned
 
 ```terraform
 resource "hcp_packer_channel_assignment" "staging" {
-  bucket_name  = "alpine"
-  channel_name = "staging"
-
-  # Exactly one of version, id, or fingerprint must be set:
-  iteration_version = 12
-  # iteration_id = "01H1SF9NWAK8AP25PAWDBGZ1YD"
-  # iteration_fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
+  bucket_name         = "alpine"
+  channel_name        = "staging"
+  version_fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
 }
 
-# To set the channel to have no assignment, use one of the iteration attributes with their zero value.
-# The two string-typed iteration attributes, id and fingerprint, use "none" as their zero value.
+# To set the channel to have no assignment, use "none" as the version_fingerprint value.
 resource "hcp_packer_channel_assignment" "staging" {
-  bucket_name  = "alpine"
-  channel_name = "staging"
-
-  iteration_version = 0
-  # iteration_id = "none"
-  # iteration_fingerprint = "none"
+  bucket_name         = "alpine"
+  channel_name        = "staging"
+  version_fingerprint = "none"
 }
 ```
 

--- a/examples/resources/hcp_packer_channel_assignment/resource.tf
+++ b/examples/resources/hcp_packer_channel_assignment/resource.tf
@@ -1,20 +1,12 @@
 resource "hcp_packer_channel_assignment" "staging" {
-  bucket_name  = "alpine"
-  channel_name = "staging"
-
-  # Exactly one of version, id, or fingerprint must be set:
-  iteration_version = 12
-  # iteration_id = "01H1SF9NWAK8AP25PAWDBGZ1YD"
-  # iteration_fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
+  bucket_name         = "alpine"
+  channel_name        = "staging"
+  version_fingerprint = "01H1ZMW0Q2W6FT4FK27FQJCFG7"
 }
 
-# To set the channel to have no assignment, use one of the iteration attributes with their zero value.
-# The two string-typed iteration attributes, id and fingerprint, use "none" as their zero value.
+# To set the channel to have no assignment, use "none" as the version_fingerprint value.
 resource "hcp_packer_channel_assignment" "staging" {
-  bucket_name  = "alpine"
-  channel_name = "staging"
-
-  iteration_version = 0
-  # iteration_id = "none"
-  # iteration_fingerprint = "none"
+  bucket_name         = "alpine"
+  channel_name        = "staging"
+  version_fingerprint = "none"
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Docs-only change:
Updates the `hcp_packer_channel_assignment` resource example to the current syntax (removing/replacing deprecated attributes).