### PR TITLE
[HCP Vault Secrets] fix app & secret name validation

### DIFF
--- a/.changelog/750.txt
+++ b/.changelog/750.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+Fixing the validation rules for HCP Vault Secrets app and secret names to match
+what we have on the server side.
+```

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
@@ -50,9 +50,11 @@ func (r *resourceVaultsecretsSecret) Schema(_ context.Context, _ resource.Schema
 				Description: "The name of the application the secret can be found in",
 				Required:    true,
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(3),
+					stringvalidator.LengthAtMost(36),
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[-\da-zA-Z]{3,36}$`),
-						"must contain only letters, numbers or hyphens",
+						regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-]+[a-zA-Z0-9]$`),
+						"must contain only ASCII letters, numbers, and hyphens; must not start or end with a hyphen",
 					),
 				},
 			},
@@ -60,9 +62,11 @@ func (r *resourceVaultsecretsSecret) Schema(_ context.Context, _ resource.Schema
 				Description: "The name of the secret",
 				Required:    true,
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+					stringvalidator.LengthAtMost(64),
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[_\da-zA-Z]{3,36}$`),
-						"must contain only letters, numbers or underscores",
+						regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`),
+						"must contain only ASCII letters, numbers, and underscores; must not start with a number",
 					),
 				},
 			},
@@ -163,7 +167,6 @@ func (r *resourceVaultsecretsSecret) Update(ctx context.Context, req resource.Up
 	}
 
 	res, err := clients.CreateVaultSecretsAppSecret(ctx, r.client, loc, plan.AppName.ValueString(), plan.SecretName.ValueString(), plan.SecretValue.ValueString())
-
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating secret", err.Error())
 		return

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -28,7 +28,7 @@ func TestAccVaultSecretsResourceSecret(t *testing.T) {
 				}`, testAppName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName),
-					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "test_secret"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "a_long_and_complicated_secret_name_but_less_than_64_characters"),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
 				),
 			},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Fixing the validation rules for HCP Vault Secrets app and secret names to match what we have on the server.

Fixes #728

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?
