### PR TITLE
[HCP Vault Secrets] Fix panic on read errors

### DIFF
--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
@@ -114,7 +114,7 @@ func (r *resourceVaultsecretsSecret) Create(ctx context.Context, req resource.Cr
 
 	res, err := clients.CreateVaultSecretsAppSecret(ctx, r.client, loc, plan.AppName.ValueString(), plan.SecretName.ValueString(), plan.SecretValue.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating Vault Secrets Secret", err.Error())
+		resp.Diagnostics.AddError("Error creating secret", err.Error())
 		return
 	}
 
@@ -141,7 +141,8 @@ func (r *resourceVaultsecretsSecret) Read(ctx context.Context, req resource.Read
 
 	res, err := clients.OpenVaultSecretsAppSecret(ctx, r.client, loc, state.AppName.ValueString(), state.SecretName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(err.Error(), "Unable to get secret")
+		resp.Diagnostics.AddError(err.Error(), "Error reading secret")
+		return
 	}
 
 	state.SecretValue = types.StringValue(res.Version.Value)
@@ -163,7 +164,6 @@ func (r *resourceVaultsecretsSecret) Update(ctx context.Context, req resource.Up
 	}
 
 	res, err := clients.CreateVaultSecretsAppSecret(ctx, r.client, loc, plan.AppName.ValueString(), plan.SecretName.ValueString(), plan.SecretValue.ValueString())
-
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating secret", err.Error())
 		return


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Fixing the panics related Read requests, a return was missing after reporting the error.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
