### PR TITLE
Run prerelease without running e2e test suite

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,8 +20,9 @@ permissions: write-all
 jobs:
   run-tests:
     name: Run Tests
-    if: ${{ !inputs.skip-tests }}
     uses: ./.github/workflows/test.yml
+    with:
+      skip-e2e-tests: ${{ inputs.skip-tests }}
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,19 @@ on:
       acc-test-pattern:
         type: string
         default: 'Test.*'
+      skip-e2e-tests:
+        description: "Skip the E2E test suite"
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       acc-test-pattern:
         type: string
         default: 'Test.*'
+      skip-e2e-tests:
+        description: "Skip the E2E test suite"
+        type: boolean
+        default: false
 
 concurrency: acceptance-testing-environment
 
@@ -60,6 +68,7 @@ jobs:
           echo "The default acceptance test pattern is \`Test.*\`, but it was overridden with \`${{ inputs.acc-test-pattern }}\`." >> $GITHUB_STEP_SUMMARY
 
       - name: Run E2E Tests
+        if: ${{ !inputs.skip-e2e-tests }}
         env:
           HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
           HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fix the "skipping E2E tests" flag in prerelease job. Enabling that was skipping the `run-tests` job which would skip the prerelease job making that argument unusable. Fixed that by delegating that argument to test workflow which will run unit tests but skip the E2E tests based on the flag. Since `run-tests` job runs, the `prerelease` job also runs. [Link](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/7922134372) to successful run.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
