### PR TITLE
Group Data Source 

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/stable/2021-02-04/client/consul_service"
 
 	cloud_iam "github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/groups_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/iam_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/service_principals_service"
 
@@ -73,6 +74,7 @@ type Client struct {
 	PackerV2          packer_service_v2.ClientService
 	Project           project_service.ClientService
 	ServicePrincipals service_principals_service.ClientService
+	Groups            groups_service.ClientService
 	Vault             vault_service.ClientService
 	VaultSecrets      secret_service.ClientService
 	Webhook           webhook_service.ClientService
@@ -163,6 +165,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 		PackerV2:          cloud_packer_v2.New(httpClient, nil).PackerService,
 		Project:           cloud_resource_manager.New(httpClient, nil).ProjectService,
 		ServicePrincipals: cloud_iam.New(httpClient, nil).ServicePrincipalsService,
+		Groups:            cloud_iam.New(httpClient, nil).GroupsService,
 		Vault:             cloud_vault.New(httpClient, nil).VaultService,
 		VaultSecrets:      cloud_vault_secrets.New(httpClient, nil).SecretService,
 		LogService:        cloud_log_service.New(httpClient, nil).LogService,

--- a/internal/provider/iam/data_group.go
+++ b/internal/provider/iam/data_group.go
@@ -1,0 +1,119 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"strings"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/groups_service"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	clients "github.com/hashicorp/terraform-provider-hcp/internal/clients"
+)
+
+type DataSourceGroup struct {
+	client *clients.Client
+}
+
+type DataSourceGroupModel struct {
+	DisplayName  types.String `tfsdk:"display_name"`
+	ResourceName types.String `tfsdk:"resource_name"`
+	ResourceID   types.String `tfsdk:"resource_id"`
+	Description  types.String `tfsdk:"description"`
+}
+
+func NewGroupDataSource() datasource.DataSource {
+	return &DataSourceGroup{}
+}
+
+func (d *DataSourceGroup) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_group"
+}
+
+func (d *DataSourceGroup) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "The group data source retrieves the given group.",
+		Attributes: map[string]schema.Attribute{
+			"display_name": schema.StringAttribute{
+				Description: "The group's display name",
+				Computed:    true,
+			},
+			"resource_name": schema.StringAttribute{
+				Description: fmt.Sprintf("The group's resource name in format `%s` or shortened `%s`",
+					"iam/organization/<organization_id>/group/<resource_name>", "<resource_name>"),
+				Required: true,
+			},
+			"resource_id": schema.StringAttribute{
+				Description: "The group's unique identifier",
+				Computed:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "The group's description",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *DataSourceGroup) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*clients.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *clients.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
+
+func (d *DataSourceGroup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data DataSourceGroupModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if d.client == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured HCP Client",
+			"Expected configured HCP client. Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	getParams := groups_service.NewGroupsServiceGetGroupParams()
+	getParams.ResourceName = data.ResourceName.ValueString()
+
+	// if shorthand resourceName was provided, generate full resourceName
+	if !strings.HasPrefix(getParams.ResourceName, "iam/") {
+		orgID := d.client.Config.OrganizationID
+		getParams.ResourceName = fmt.Sprintf("iam/organization/%s/group/%s", orgID, data.ResourceName.ValueString())
+	}
+
+	res, err := d.client.Groups.GroupsServiceGetGroup(getParams, nil)
+
+	if err != nil {
+		var getErr *groups_service.GroupsServiceGetGroupDefault
+
+		if errors.As(err, &getErr) && getErr.IsCode(http.StatusNotFound) {
+			resp.Diagnostics.AddError("Group does not exist", fmt.Sprintf("unknown group %q", data.ResourceName.ValueString()))
+			return
+		}
+
+		resp.Diagnostics.AddError("Error retrieving group", err.Error())
+		return
+	}
+
+	group := res.GetPayload().Group
+	data.DisplayName = types.StringValue(group.DisplayName)
+	data.ResourceName = types.StringValue(group.ResourceName)
+	data.ResourceID = types.StringValue(group.ResourceID)
+	data.Description = types.StringValue(group.Description)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/iam/data_group_test.go
+++ b/internal/provider/iam/data_group_test.go
@@ -16,7 +16,7 @@ func TestAccGroupDataSource(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig("jolisa-group-test-2"),
+				Config: testAccGroupConfig("int-tooling-e2e-test-group"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceAddress, "resource_id"),
 					resource.TestCheckResourceAttrSet(dataSourceAddress, "description"),
@@ -34,7 +34,7 @@ func TestAccGroupDataSourceFullResourceName(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig("iam/organization/07151b8a-4081-4602-abe4-288e78636831/group/jolisa-group-test-2"),
+				Config: testAccGroupConfig("iam/organization/d11d7309-5072-44f9-aaea-c8f37c09a8b5/group/int-tooling-e2e-test-group"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceAddress, "resource_id"),
 					resource.TestCheckResourceAttrSet(dataSourceAddress, "description"),

--- a/internal/provider/iam/data_group_test.go
+++ b/internal/provider/iam/data_group_test.go
@@ -1,0 +1,54 @@
+package iam_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"
+)
+
+// TODO : update the below tests to use a created group resource via Terraform
+func TestAccGroupDataSource(t *testing.T) {
+	dataSourceAddress := "data.hcp_group.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupConfig("jolisa-group-test-2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceAddress, "resource_id"),
+					resource.TestCheckResourceAttrSet(dataSourceAddress, "description"),
+					resource.TestCheckResourceAttrSet(dataSourceAddress, "display_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGroupDataSourceFullResourceName(t *testing.T) {
+	dataSourceAddress := "data.hcp_group.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupConfig("iam/organization/07151b8a-4081-4602-abe4-288e78636831/group/jolisa-group-test-2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceAddress, "resource_id"),
+					resource.TestCheckResourceAttrSet(dataSourceAddress, "description"),
+					resource.TestCheckResourceAttrSet(dataSourceAddress, "display_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGroupConfig(resourceName string) string {
+	return fmt.Sprintf(`
+	data "hcp_group" "test" { 
+		resource_name = %q
+	}
+`, resourceName)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,6 +161,7 @@ func (p *ProviderFramework) DataSources(ctx context.Context) []func() datasource
 		vaultsecrets.NewVaultSecretsSecretDataSource,
 		// IAM
 		iam.NewServicePrincipalDataSource,
+		iam.NewGroupDataSource,
 	}, packer.DataSourceSchemaBuilders...)
 }
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

This PR includes changes to implement a groups data source and test coverage. Once implementation of the groups resource is completed, test coverage will be updated to CRUD a group with terraform, then point the data source to the generated resource.

### 🔗  Relevant Links

Jira 🎟️ : Data Source: Group - [HCPIE-1020](https://hashicorp.atlassian.net/browse/HCPIE-1020)

### :building_construction: Acceptance tests

- [ ❌ ] Are there any feature flags that are required to use this functionality?
- [✅  ] Have you added an acceptance test for the functionality being added?
- [✅ ] Have you run the acceptance tests on this branch?

Test coverage will be updated to point to a generated resource as per standard convention once groups resource implementation is completed. Currently test coverage points to my personal group as a proof of concept and to allow parallelizing on other provider work on our feature branch if needed. To test locally, replace the group `jolisa-brown-test` with the resource name of a group you have created in the HCP portal.

The established convention for testing data sources implemented in the provider that don't have a corresponding resource is no test coverage at all (e.g. boundary clusters, vault clusters, etc). I've elected to include stubbed test coverage of my own group in this PR since in the coming days a resource for groups will be implemented as well.

To test, ensure that an organization level `HCP_CLIENT_ID` and `HCP_CLIENT_SECRET` are set in your environment, as well as the `HCP_API_ADDRESS`, `HCP_AUTH_URL`, an `HCP_PROJECT_ID`, and `HCP_OAUTH_CLIENT_ID`.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccGroupDataSource' 
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccGroupDataSource -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv1	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
=== RUN   TestAccGroupDataSource
--- PASS: TestAccGroupDataSource (1.55s)
```

```sh
$ make testacc TESTARGS='-run=TestAccGroupDataSourceFullResourceName' 
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccGroupDataSourceFullResourceName -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv1	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location	[no test files]
=== RUN   TestAccGroupDataSourceFullResourceName
--- PASS: TestAccGroupDataSourceFullResourceName (1.48s)
```


[HCPIE-1020]: https://hashicorp.atlassian.net/browse/HCPIE-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ