### PR TITLE
Upgrade release github action to use actions/download-artifact@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [go-version, release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v3
     secrets:
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
       hc-releases-host-staging: '${{ secrets.HC_RELEASES_HOST_STAGING }}'


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description
Github actions `upload-artifact` and `download-artifact` require the same major version for compatibility. With changes from https://github.com/hashicorp/terraform-provider-hcp/pull/747, only `upload-artifact` was upgraded, which caused issues when trying to run the `download-artifact` action [example](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/7993028693).

https://github.com/hashicorp/terraform-provider-hcp/pull/747 upgraded `actions/upload-artifact` from v3 -> v4, but `hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2` uses `actions/download-artifact` v3. We are upgrading to `hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v3` because it uses `actions/download-artifact` v4. 

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
