### PR TITLE
Redo v0.83.0 undo changelog docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,3 @@
-## v0.83.0 (February 21, 2024)
-
-FEATURES:
-
-* Add CloudWatch config option for hcp_log_streaming_destination resource. [[GH-757](https://github.com/hashicorp/terraform-provider-hcp/pull/757)]
-
-IMPROVEMENTS:
-
-* Update example for `hcp_packer_channel_assignment` resource [[GH-749](https://github.com/hashicorp/terraform-provider-hcp/pull/749)]
-
-BUG FIXES:
-
-* Do not panic if provider is configured with credentials with no project access. [[GH-748](https://github.com/hashicorp/terraform-provider-hcp/pull/748)]
-* Fixing a panic on errors when opening secrets from HCP Vault Secrets. [[GH-751](https://github.com/hashicorp/terraform-provider-hcp/pull/751)]
-* Fixing the validation rules for HCP Vault Secrets app and secret names to match
-what we have on the server side. [[GH-750](https://github.com/hashicorp/terraform-provider-hcp/pull/750)]
 ## v0.82.0 (January 30, 2024)
 BREAKING CHANGES:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.83.0"
+      version = "~> 0.82.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcp = {
       source  = "hashicorp/hcp"
-      version = "~> 0.83.0"
+      version = "~> 0.82.0"
     }
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description
Re-attempting to release v0.83.0 because it [failed to fully release](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/7993028693) due to issue that was fixed in https://github.com/hashicorp/terraform-provider-hcp/pull/761 . 

- deleted the v0.83.0 tag on github
- reverting the changelog and documentation commits so that the pre-release workflow can be re-run successfully

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
