### PR TITLE
Handle multiple organizations for credentials

### DIFF
--- a/.changelog/793.txt
+++ b/.changelog/793.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Handle multiple organizations for credentials
+Handle the case when multiple organizations are associated with the configured credentials. Now, it instead prompts an error, requiring users to specify a particular organization in the HCP provider config block.
 ```

--- a/.changelog/793.txt
+++ b/.changelog/793.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Handle multiple organizations for credentials
+```

--- a/internal/provider/project_helpers.go
+++ b/internal/provider/project_helpers.go
@@ -36,7 +36,7 @@ func getProjectFromCredentialsFramework(ctx context.Context, client *clients.Cli
 		return nil, diags
 	}
 	if orgLen > 1 {
-		diags.AddError("There is more than one organization associated with the configured credentials.", "Please configure a specific organization in the HCP provider config block.")
+		diags.AddError("There is more than one organization associated with the configured credentials.", "Please configure a specific project in the HCP provider config block.")
 		return nil, diags
 	}
 

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -221,7 +221,7 @@ func getProjectFromCredentials(ctx context.Context, client *clients.Client) (pro
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "There is more than one organization associated with the configured credentials.",
-			Detail:   "Please configure a specific organization in the HCP provider config block",
+			Detail:   "Please configure a specific project in the HCP provider config block",
 		})
 		return nil, diags
 	}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
Updated the provider's logic to handle zero or multiple organizations associated with configured credentials. Added diagnostics to inform the user when no organizations or multiple organizations are found. Now, it prompts an error, requiring users to specify a particular organization in the HCP provider config block.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
