### PR TITLE
Add in-place update to HCP Log Streaming Destination

### DIFF
--- a/.changelog/802.txt
+++ b/.changelog/802.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ Add in-place update functionality to `hcp_log_streaming_destination` resource.
+ ```

--- a/internal/clients/logs.go
+++ b/internal/clients/logs.go
@@ -63,3 +63,26 @@ func DeleteLogStreamingDestination(ctx context.Context, client *Client, loc *sha
 
 	return nil
 }
+
+func UpdateLogStreamingDestination(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, updatePaths []string, destination *models.LogService20210330Destination) error {
+	updateParams := log_service.NewLogServiceUpdateStreamingDestinationParams()
+	updateParams.Context = ctx
+	updateParams.DestinationResourceID = destination.Resource.ID
+	updateParams.DestinationResourceLocationOrganizationID = loc.OrganizationID
+	updateParams.DestinationResourceLocationProjectID = loc.ProjectID
+
+	updateBody := &models.LogService20210330UpdateStreamingDestinationRequest{
+		Destination: destination,
+		Mask: &models.ProtobufFieldMask{
+			Paths: updatePaths,
+		},
+	}
+
+	updateParams.Body = updateBody
+	_, err := client.LogService.LogServiceUpdateStreamingDestination(updateParams, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
+++ b/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -21,8 +21,6 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 	resourceName := "hcp_log_streaming_destination.test_splunk_cloud"
 	spName := "splunk-resource-name-1"
 	spNameUpdated := "splunk-resource-name-2"
-	var sp models.LogService20210330Destination
-	var sp2 models.LogService20210330Destination
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -39,7 +37,7 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 			{
 				Config: testAccSplunkConfig(spName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccHCPLogStreamingDestinationExists(t, resourceName, &sp),
+					testAccHCPLogStreamingDestinationExists(t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", spName),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.token"),
@@ -48,95 +46,20 @@ func TestAccHCPLogStreamingDestinationSplunk(t *testing.T) {
 				),
 			},
 			{
-				// Update the name
-				Config: testAccSplunkConfig(spNameUpdated),
+				// Update the name and token and expect in-place update
+				Config: testAccSplunkConfigUpdated(spNameUpdated),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
-					testAccHCPLogStreamingDestinationExists(t, resourceName, &sp2),
+					testAccHCPLogStreamingDestinationExists(t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", spNameUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "splunk_cloud.token"),
 					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.endpoint", "https://http-inputs-hcptest.splunkcloud.com/services/collector/event"),
-					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.token", "splunk-authentication-token"),
-					func(_ *terraform.State) error {
-						if sp.Resource.ID == sp2.Resource.ID {
-							return fmt.Errorf("resource_ids match, indicating resource wasn't recreated")
-						}
-						return nil
-					},
-				),
-			},
-		},
-	})
-}
-
-func TestAccHCPLogStreamingDestinationCloudWatch(t *testing.T) {
-	resourceName := "hcp_log_streaming_destination.test_cloudwatch"
-	cwName := "cloudwatch-resource-name-1"
-	cwNameUpdated := "cloudwatch-resource-name-2"
-	cwNameLogGroup := "cloudwatch-resource-name-3"
-	var cw models.LogService20210330Destination
-	var cw2 models.LogService20210330Destination
-	var cw3 models.LogService20210330Destination
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy: func(s *terraform.State) error {
-			err := testAccHCPLogStreamingDestinationDestroy(t, s)
-			if err != nil {
-				return err
-			}
-			return nil
-		},
-		Steps: []resource.TestStep{
-			// Tests create
-			{
-				Config: testAccCloudWatchLogsConfig(cwName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccHCPLogStreamingDestinationExists(t, resourceName, &cw),
-					resource.TestCheckResourceAttr(resourceName, "name", cwName),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.region"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.role_arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.external_id"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.region", "us-west-2"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.external_id", "superSecretExternalID"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.role_arn", "arn:aws:iam::000000000000:role/cloud_watch_role"),
-				),
-			},
-			{
-				// Update the name
-				Config: testAccCloudWatchLogsConfig(cwNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccHCPLogStreamingDestinationExists(t, resourceName, &cw2),
-					resource.TestCheckResourceAttr(resourceName, "name", cwNameUpdated),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.region"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.role_arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.external_id"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.region", "us-west-2"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.external_id", "superSecretExternalID"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.role_arn", "arn:aws:iam::000000000000:role/cloud_watch_role"),
-					func(_ *terraform.State) error {
-						if cw.Resource.ID == cw2.Resource.ID {
-							return fmt.Errorf("resource_ids match, indicating resource wasn't recreated")
-						}
-						return nil
-					},
-				),
-			},
-			{
-				// test with a log group name
-				Config: testAccCloudWatchLogsConfigLogGroupName(cwNameLogGroup),
-				Check: resource.ComposeTestCheckFunc(
-					testAccHCPLogStreamingDestinationExists(t, resourceName, &cw3),
-					resource.TestCheckResourceAttr(resourceName, "name", cwNameLogGroup),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.region"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.role_arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.external_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.log_group_name"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.region", "us-west-2"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.external_id", "superSecretExternalID"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.role_arn", "arn:aws:iam::000000000000:role/cloud_watch_role"),
-					resource.TestCheckResourceAttr(resourceName, "cloudwatch.log_group_name", "a-log-group-name"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_cloud.token", "splunk-authentication-token234"),
 				),
 			},
 		},
@@ -155,6 +78,73 @@ func testAccSplunkConfig(name string) string {
   		`, name)
 }
 
+func testAccSplunkConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+  		resource "hcp_log_streaming_destination" "test_splunk_cloud" {
+  			name = "%[1]s"
+  			splunk_cloud = {
+  				endpoint = "https://http-inputs-hcptest.splunkcloud.com/services/collector/event"
+  				token = "splunk-authentication-token234"
+  			}
+  		}
+  		`, name)
+}
+
+func TestAccHCPLogStreamingDestinationCloudWatch(t *testing.T) {
+	resourceName := "hcp_log_streaming_destination.test_cloudwatch"
+	cwName := "cloudwatch-resource-name-1"
+	cwNameUpdated := "cloudwatch-resource-name-2"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			err := testAccHCPLogStreamingDestinationDestroy(t, s)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Tests create
+			{
+				Config: testAccCloudWatchLogsConfig(cwName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccHCPLogStreamingDestinationExists(t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", cwName),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.region"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.role_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.external_id"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.region", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.external_id", "superSecretExternalID"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.role_arn", "arn:aws:iam::000000000000:role/cloud_watch_role"),
+				),
+			},
+			{
+				// Update the name, log group name and externalID and expect in-place update
+				Config: testAccCloudWatchLogsConfigUpdated(cwNameUpdated),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testAccHCPLogStreamingDestinationExists(t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", cwNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.region"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.role_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwatch.log_group_name"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.region", "us-west-2"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.external_id", "superSecretExternalID789"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.role_arn", "arn:aws:iam::000000000000:role/cloud_watch_role"),
+					resource.TestCheckResourceAttr(resourceName, "cloudwatch.log_group_name", "a-log-group-name"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCloudWatchLogsConfig(name string) string {
 	return fmt.Sprintf(`
   		resource "hcp_log_streaming_destination" "test_cloudwatch" {
@@ -168,21 +158,21 @@ func testAccCloudWatchLogsConfig(name string) string {
   		`, name)
 }
 
-func testAccCloudWatchLogsConfigLogGroupName(name string) string {
+func testAccCloudWatchLogsConfigUpdated(name string) string {
 	return fmt.Sprintf(`
   		resource "hcp_log_streaming_destination" "test_cloudwatch" {
   			name = "%[1]s"
   			cloudwatch = {
   				region = "us-west-2"
   				role_arn = "arn:aws:iam::000000000000:role/cloud_watch_role"
-				external_id = "superSecretExternalID"
+				external_id = "superSecretExternalID789"
 				log_group_name = "a-log-group-name"
   			}
   		}
   		`, name)
 }
 
-func testAccHCPLogStreamingDestinationExists(t *testing.T, name string, destination *models.LogService20210330Destination) resource.TestCheckFunc {
+func testAccHCPLogStreamingDestinationExists(t *testing.T, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -209,8 +199,6 @@ func testAccHCPLogStreamingDestinationExists(t *testing.T, name string, destinat
 			return fmt.Errorf("log Streaming Destination (%s) not found", streamingDestinationID)
 		}
 
-		// assign the response to the pointer
-		*destination = *res
 		return nil
 	}
 }


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

Adding in-place update functionality to the `HCP Log Streaming Destination` resource.  [IFACE-2608](https://hashicorp.atlassian.net/browse/IFACE-2608)

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
<details>
  <summary>TestAccHCPLogStreamingDestinationCloudwatch</summary>

```sh
$ make testacc TESTARGS='-run=TestAccHCPLogStreamingDestinationCloudwatch'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccHCPLogStreamingDestinationCloudWatch -timeout 360m -parallel=10

=== RUN   TestAccHCPLogStreamingDestinationCloudWatch
--- PASS: TestAccHCPLogStreamingDestinationCloudWatch (6.36s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming      7.483s
```

</details>

<details>
  <summary>TestAccHCPLogStreamingDestinationSplunk</summary>

```sh
$ make testacc TESTARGS='-run=TestAccHCPLogStreamingDestinationSplunk'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccHCPLogStreamingDestinationSplunk -timeout 360m -parallel=10

=== RUN   TestAccHCPLogStreamingDestinationSplunk
--- PASS: TestAccHCPLogStreamingDestinationSplunk (5.53s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming      6.067s
```

</details>




[IFACE-2608]: https://hashicorp.atlassian.net/browse/IFACE-2608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ