### PR TITLE
HCPF-1673: Fix HVS ignoring default project change.

### DIFF
--- a/.changelog/808.txt
+++ b/.changelog/808.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+Fixes the case where Vault secret resources ignore provider project changes.
+```
+
+```release-note:improvement
+Vault secret resources can now be created with an optional project ID. If project ID is present, the resource will be created within that project.
+```

--- a/docs/resources/vault_secrets_app.md
+++ b/docs/resources/vault_secrets_app.md
@@ -28,9 +28,9 @@ resource "hcp_vault_secrets_app" "example" {
 ### Optional
 
 - `description` (String) The Vault Secrets app description
+- `project_id` (String) The ID of the HCP project where the HCP Vault Secrets app is located.
 
 ### Read-Only
 
 - `id` (String) Required ID field that is set to the app name.
 - `organization_id` (String) The ID of the HCP organization where the project the HCP Vault Secrets app is located.
-- `project_id` (String) The ID of the HCP project where the HCP Vault Secrets app is located.

--- a/docs/resources/vault_secrets_secret.md
+++ b/docs/resources/vault_secrets_secret.md
@@ -30,8 +30,11 @@ resource "hcp_vault_secrets_secret" "example" {
 - `secret_name` (String) The name of the secret
 - `secret_value` (String, Sensitive) The value of the secret
 
+### Optional
+
+- `project_id` (String) The ID of the HCP project where the HCP Vault Secrets secret is located.
+
 ### Read-Only
 
 - `id` (String) The id of the resource
 - `organization_id` (String) The ID of the HCP organization where the project the HCP Vault Secrets secret is located.
-- `project_id` (String) The ID of the HCP project where the HCP Vault Secrets secret is located.

--- a/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
@@ -5,7 +5,6 @@ package vaultsecrets_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,21 +13,23 @@ import (
 
 func TestAccVaultSecretsResourceApp(t *testing.T) {
 	testAppName := generateRandomSlug()
-	projectID := os.Getenv("HCP_PROJECT_ID")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
+					resource "hcp_project" "example" {
+						name        = "test-project"
+					}
 					resource "hcp_vault_secrets_app" "example" {
 						app_name = %q
 						description = "Acceptance test run"
-						project_id = %q
-				  }`, testAppName, projectID),
+						project_id = hcp_project.example.resource_id
+				  }`, testAppName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_secrets_app.example", "app_name", testAppName),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_app.example", "description", "Acceptance test run"),
-					resource.TestCheckResourceAttr("hcp_vault_secrets_app.example", "project_id", projectID),
+					resource.TestCheckResourceAttrSet("hcp_vault_secrets_app.example", "project_id"),
 				),
 			},
 			{

--- a/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
@@ -5,6 +5,7 @@ package vaultsecrets_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,9 +14,23 @@ import (
 
 func TestAccVaultSecretsResourceApp(t *testing.T) {
 	testAppName := generateRandomSlug()
+	projectID := os.Getenv("HCP_PROJECT_ID")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "hcp_vault_secrets_app" "example" {
+						app_name = %q
+						description = "Acceptance test run"
+						project_id = %q
+				  }`, testAppName, projectID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hcp_vault_secrets_app.example", "app_name", testAppName),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_app.example", "description", "Acceptance test run"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_app.example", "project_id", projectID),
+				),
+			},
 			{
 				Config: fmt.Sprintf(`
 					resource "hcp_vault_secrets_app" "example" {

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
@@ -12,10 +12,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+	"github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers"
 )
+
+var _ resource.Resource = &resourceVaultsecretsSecret{}
+var _ resource.ResourceWithConfigure = &resourceVaultsecretsSecret{}
+var _ resource.ResourceWithModifyPlan = &resourceVaultsecretsSecret{}
 
 func NewVaultSecretsSecretResource() resource.Resource {
 	return &resourceVaultsecretsSecret{}
@@ -78,6 +85,11 @@ func (r *resourceVaultsecretsSecret) Schema(_ context.Context, _ resource.Schema
 			"project_id": schema.StringAttribute{
 				Description: "The ID of the HCP project where the HCP Vault Secrets secret is located.",
 				Computed:    true,
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"organization_id": schema.StringAttribute{
 				Description: "The ID of the HCP organization where the project the HCP Vault Secrets secret is located.",
@@ -103,6 +115,10 @@ func (r *resourceVaultsecretsSecret) Configure(_ context.Context, req resource.C
 	r.client = client
 }
 
+func (r *resourceVaultsecretsSecret) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifiers.ModifyPlanForDefaultProjectChange(ctx, r.client.Config.ProjectID, req.State, req.Config, req.Plan, resp)
+}
+
 func (r *resourceVaultsecretsSecret) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan VaultSecretsSecret
 	diags := req.Plan.Get(ctx, &plan)
@@ -111,9 +127,14 @@ func (r *resourceVaultsecretsSecret) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
+	projectID := r.client.Config.ProjectID
+	if !plan.ProjectID.IsUnknown() {
+		projectID = plan.ProjectID.ValueString()
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: r.client.Config.OrganizationID,
-		ProjectID:      r.client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 
 	res, err := clients.CreateVaultSecretsAppSecret(ctx, r.client, loc, plan.AppName.ValueString(), plan.SecretName.ValueString(), plan.SecretValue.ValueString())
@@ -138,9 +159,14 @@ func (r *resourceVaultsecretsSecret) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	projectID := r.client.Config.ProjectID
+	if !state.ProjectID.IsUnknown() {
+		projectID = state.ProjectID.ValueString()
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: r.client.Config.OrganizationID,
-		ProjectID:      r.client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 
 	res, err := clients.OpenVaultSecretsAppSecret(ctx, r.client, loc, state.AppName.ValueString(), state.SecretName.ValueString())
@@ -162,9 +188,14 @@ func (r *resourceVaultsecretsSecret) Update(ctx context.Context, req resource.Up
 		return
 	}
 
+	projectID := r.client.Config.ProjectID
+	if !plan.ProjectID.IsUnknown() {
+		projectID = plan.ProjectID.ValueString()
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: r.client.Config.OrganizationID,
-		ProjectID:      r.client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 
 	res, err := clients.CreateVaultSecretsAppSecret(ctx, r.client, loc, plan.AppName.ValueString(), plan.SecretName.ValueString(), plan.SecretValue.ValueString())
@@ -189,9 +220,14 @@ func (r *resourceVaultsecretsSecret) Delete(ctx context.Context, req resource.De
 		return
 	}
 
+	projectID := r.client.Config.ProjectID
+	if !state.ProjectID.IsUnknown() {
+		projectID = state.ProjectID.ValueString()
+	}
+
 	loc := &sharedmodels.HashicorpCloudLocationLocation{
 		OrganizationID: r.client.Config.OrganizationID,
-		ProjectID:      r.client.Config.ProjectID,
+		ProjectID:      projectID,
 	}
 
 	err := clients.DeleteVaultSecretsAppSecret(ctx, r.client, loc, state.AppName.ValueString(), state.SecretName.ValueString())

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -5,6 +5,7 @@ package vaultsecrets_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,24 +13,44 @@ import (
 )
 
 func TestAccVaultSecretsResourceSecret(t *testing.T) {
-	testAppName := generateRandomSlug()
+	testAppName1 := generateRandomSlug()
+	testAppName2 := generateRandomSlug()
+	projectID := os.Getenv("HCP_PROJECT_ID")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+
 			{
 				PreConfig: func() {
-					createTestApp(t, testAppName)
+					createTestApp(t, testAppName1)
 				},
 				Config: fmt.Sprintf(`
 				resource "hcp_vault_secrets_secret" "example" {
 					app_name = %q
 					secret_name = "test_secret"
 					secret_value = "super secret"
-				}`, testAppName),
+				}`, testAppName1),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName1),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "test_secret"),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
+				),
+			},
+			{
+				PreConfig: func() {
+					createTestApp(t, testAppName2)
+				},
+				Config: fmt.Sprintf(`
+				resource "hcp_vault_secrets_secret" "example" {
+					app_name = %q
+					secret_name = "test_secret"
+					secret_value = "super secret"
+				}`, testAppName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName2),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "test_secret"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "project_id", projectID),
 				),
 			},
 		},


### PR DESCRIPTION
This change fixes parts of the [ issue](https://github.com/hashicorp/terraform-provider-hcp/issues/742) where resources are not sensitive to default project ID changes. It also fixes [VAULT-25738](https://hashicorp.atlassian.net/browse/VAULT-25738).

This fix is only for HVS. The other resources that have this issue will be incrementally fixed.
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$  make testacc TESTARGS='-run=TestAccVaultSecretsResourceApp'

==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultSecretsResourceApp -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/artifact	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/version	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	(cached) [no tests to run]
=== RUN   TestAccVaultSecretsResourceApp
--- PASS: TestAccVaultSecretsResourceApp (3.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	4.188s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	(cached) [no tests to run]
```

```sh
$  make testacc TESTARGS='-run=TestAccVaultSecretsResourceSecret'

==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultSecretsResourceSecret -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/artifact	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/version	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	(cached) [no tests to run]
=== RUN   TestAccVaultSecretsResourceSecret
--- PASS: TestAccVaultSecretsResourceSecret (4.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	5.240s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	(cached) [no tests to run]
```
[VAULT-25738]: https://hashicorp.atlassian.net/browse/VAULT-25738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ