### PR TITLE
HCPIE-1244: Improve Identity-Specific Testing

### DIFF
--- a/.changelog/810.txt
+++ b/.changelog/810.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ Add GitHub Action to run identity-specific tests
+ ```

--- a/.github/workflows/test-identity.yml
+++ b/.github/workflows/test-identity.yml
@@ -6,87 +6,40 @@ on:
       - 'internal/provider/iam/**'
 
 jobs:
-  # ensure go.mod and go.sum are updated
-  depscheck:
-    name: Check Dependencies
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-      with:
-        cache: true
-        go-version-file: 'go.mod'
-      id: go
-
-
-    - name: Run 'go mod tidy' and check for differences
-      run: |
-        make depscheck
-
-  # ensure the code builds
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-      with:
-        cache: true
-        go-version-file: 'go.mod'
-      id: go
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: Build
-      run: |
-        go build -v .
-
-  # run identity acceptance tests
   identity_tests:
-    name: Run Identity specific tests
-    needs: build
+    name: Run identity specific tests
     runs-on: ubuntu-latest
     steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-      with:
-        cache: true
-        go-version-file: 'go.mod'
-      id: go
-
-    - name: Get dependencies
-      run: |
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
-        go mod download
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         
-    - name: Run identity tests
-      env:
-        HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
-        HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
-        HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
-        HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
-        HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
-        HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
-      run: |
-          make testacc-ci TEST=./internal/provider/iam
-    
-    - name: Upload Coverage Artifacts
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-      with:
-        name: Identity Test Coverage
-        path: identity-coverage.html
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          cache: true
+          go-version-file: 'go.mod'
+          cache-dependency-path: go.sum
+        id: go
+
+      - name: Run 'go mod tidy' and check for differences
+        run: |
+          make depscheck
+
+      - name: Get dependencies
+        run: |
+          go mod download
+
+      - name: Build
+        run: |
+          go build -v .
+
+      - name: Run identity tests
+        env:
+          HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
+          HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
+          HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+          HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+          HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
+          HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
+        run: |
+            make testacc-ci TEST=./internal/provider/iam

--- a/.github/workflows/test-identity.yml
+++ b/.github/workflows/test-identity.yml
@@ -75,8 +75,15 @@ jobs:
         go mod download
         
     - name: Run identity tests
+      env:
+        HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
+        HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
+        HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+        HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+        HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
+        HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
       run: |
-        make testacc-ci TEST=./internal/provider/iam
+          make testacc-ci TEST=./internal/provider/iam
     
     - name: Upload Coverage Artifacts
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/.github/workflows/test-identity.yml
+++ b/.github/workflows/test-identity.yml
@@ -1,0 +1,85 @@
+name: Run Identity Tests on Identity Code Changes
+
+on:
+  pull_request:
+    paths:
+      - 'internal/provider/iam/**'
+
+jobs:
+  # ensure go.mod and go.sum are updated
+  depscheck:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        cache: true
+        go-version-file: 'go.mod'
+      id: go
+
+
+    - name: Run 'go mod tidy' and check for differences
+      run: |
+        make depscheck
+
+  # ensure the code builds
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        cache: true
+        go-version-file: 'go.mod'
+      id: go
+
+    - name: Get dependencies
+      run: |
+        go mod download
+
+    - name: Build
+      run: |
+        go build -v .
+
+  # run identity acceptance tests
+  identity_tests:
+    name: Run Identity specific tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        cache: true
+        go-version-file: 'go.mod'
+      id: go
+
+    - name: Get dependencies
+      run: |
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
+        go mod download
+        
+    - name: Run identity tests
+      run: |
+        make testacc-ci TEST=./internal/provider/iam
+    
+    - name: Upload Coverage Artifacts
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: Identity Test Coverage
+        path: identity-coverage.html

--- a/.github/workflows/test-identity.yml
+++ b/.github/workflows/test-identity.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Get dependencies
         run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
           go mod download
 
       - name: Build

--- a/contributing/writing-tests.md
+++ b/contributing/writing-tests.md
@@ -62,6 +62,21 @@ PASS
 ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	539.112s
 ```
 
+Running a specific test package:
+```sh
+$ make testacc TEST="./internal/provider/iam"
+==> Checking that code complies with gofmt requirements...
+golangci-lint run --config ./golangci-config.yml 
+TF_ACC=1 go test ./internal/provider/iam -v  -timeout 360m -parallel=10
+=== RUN   TestAccGroupDataSource
+--- PASS: TestAccGroupDataSource (8.69s)
+...
+=== RUN   TestAccWorkloadIdentityProviderResource
+--- PASS: TestAccWorkloadIdentityProviderResource (11.67s)
+PASS
+ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       125.260s
+```
+
 Entire resource test suites can be targeted by using the naming convention to
 write the regular expression.
 

--- a/internal/provider/iam/data_group_test.go
+++ b/internal/provider/iam/data_group_test.go
@@ -40,5 +40,3 @@ func testAccGroupConfig(name, description string) string {
 	}
 `, name, description)
 }
-
-// This is a test to see if the identity test action works as expected. Do not merge!

--- a/internal/provider/iam/data_group_test.go
+++ b/internal/provider/iam/data_group_test.go
@@ -40,3 +40,5 @@ func testAccGroupConfig(name, description string) string {
 	}
 `, name, description)
 }
+
+// This is a test to see if the identity test action works as expected. Do not merge!


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR aims to improve how identity-specific tests are run.

- [x] Ensure identity tests run within 10 minutes.
- [x] Make it easy to run identity tests locally. Added a section in the `contributing.md` docs that explains how to run a specific package.
- [x] Add a GitHub Action that only runs identity tests when identity-related files are changed.

I've added a comment line in one of the identity files to trigger the test workflow. This of course can't be merged to main so I've removed it now after confirming that the action did indeed run on a change. Reviewers can check the commit history to see the checks that passed when this comment was still present. Specifically this commit: https://github.com/hashicorp/terraform-provider-hcp/actions/runs/8649951887/job/23717371696?pr=810

Output from acceptance testing:

```sh
>make testacc TEST=./internal/provider/iam
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/provider/iam -v  -timeout 360m -parallel=10
=== RUN   TestAccGroupDataSource
--- PASS: TestAccGroupDataSource (8.69s)
=== RUN   TestAccServicePrincipalDataSource
--- PASS: TestAccServicePrincipalDataSource (5.76s)
=== RUN   TestAccUserPrincipalDataSource
--- PASS: TestAccUserPrincipalDataSource (8.79s)
=== RUN   TestAccGroupMembersResource
--- PASS: TestAccGroupMembersResource (24.92s)
=== RUN   TestAccGroupResource
--- PASS: TestAccGroupResource (15.57s)
=== RUN   TestAccServicePrincipalKeyResource
--- PASS: TestAccServicePrincipalKeyResource (24.06s)
=== RUN   TestAccServicePrincipalResource_Project
--- PASS: TestAccServicePrincipalResource_Project (11.57s)
=== RUN   TestAccServicePrincipalResource_ExplicitProject
--- PASS: TestAccServicePrincipalResource_ExplicitProject (6.01s)
=== RUN   TestAccServicePrincipalResource_Organization
--- PASS: TestAccServicePrincipalResource_Organization (7.68s)
=== RUN   TestAccWorkloadIdentityProviderResource
--- PASS: TestAccWorkloadIdentityProviderResource (11.67s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       125.260s
```
