### PR TITLE
update tests to use real tf no-code modules

### DIFF
--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -130,12 +130,12 @@ resource "hcp_waypoint_add_on_definition" "test" {
   summary = "some summary for fun"
   description = "some description for fun"
   terraform_no_code_module = {
-    source  = "some source"
-    version = "some version"
+    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+    version = "0.0.2"
   }
   terraform_cloud_workspace_details = {
-    name                 = "some name"
-    terraform_project_id = "some id"
+    name                 = "Default Project"
+    terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
 }`, name)
 }

--- a/internal/provider/waypoint/resource_waypoint_application_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_application_template_test.go
@@ -132,16 +132,16 @@ func testAccCheckWaypointAppTemplateDestroy(t *testing.T, appTemplateModel *wayp
 func testAppTemplateConfig(name string) string {
 	return fmt.Sprintf(`
 resource "hcp_waypoint_application_template" "test" {
-  name    = "%s"
-  summary = "some summary for fun"
+  name                     = "%s"
+  summary                  = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module = {
-    source  = "some source"
-    version = "some version"
+    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+    version = "0.0.2"
   }
   terraform_cloud_workspace_details = {
-    name                 = "some name"
-    terraform_project_id = "some id"
+    name                 = "Default Project"
+    terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
   labels = ["one", "two"]
 }`, name)


### PR DESCRIPTION
HCP waypoint now tries to validate the no code modules being used, so we need to update our tests