### PR TITLE
Gracefully handle rate limiting error on `hcp_vault_secrets_secret` resource.

### DIFF
--- a/.changelog/812.txt
+++ b/.changelog/812.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Documentation: Gracefully handle rate limiting error on `hcp_vault_secrets_secret` resource.
+```

--- a/internal/clients/vault_secrets.go
+++ b/internal/clients/vault_secrets.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
@@ -140,7 +141,7 @@ func OpenVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedm
 			}
 			if shouldRetryErrorCode(serviceErr.Code(), []int{429}) {
 				backOffDuration := getAPIBackoffDuration(serviceErr)
-				fmt.Printf("The api rate limit exceeded, attempt: %d trying in %d seconds", (attempt + 1), int64(backOffDuration.Seconds()))
+				tflog.Debug(ctx, fmt.Sprintf("The api rate limit has been exceeded, retrying in %d seconds, attempt: %d", int64(backOffDuration.Seconds()), (attempt+1)))
 				time.Sleep(backOffDuration)
 				continue
 			}

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -28,7 +28,7 @@ func TestAccVaultSecretsResourceSecret(t *testing.T) {
 				}`, testAppName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName),
-					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "a_long_and_complicated_secret_name_but_less_than_64_characters"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "test_secret"),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
 				),
 			},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
This PR does two things:
1. Add retries for HTTP status code 429 errors received on the OpenVaultSecretsAppSecret api.
2. Fixes the already broken `TestAccVaultSecretsResourceSecret` acceptance test.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
Fri Apr 12 11:23:25 EDT 2024 hashicorp/terraform-provider-hcp > make testacc TESTARGS='-run=TestAccVaultSecrets'  
TF_ACC=1 go test ./internal/... -v -run=TestAccVaultSecrets -timeout 360m -parallel=10 -count 1
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy  [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    0.375s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     0.638s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator       0.815s [no tests to run]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      0.987s [no tests to run]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils  [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder    [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck        [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils      [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location     [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       1.241s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming      2.260s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/artifact   2.650s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/version    2.818s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager   2.668s [no tests to run]
=== RUN   TestAccVaultSecretsResourceApp
--- PASS: TestAccVaultSecretsResourceApp (2.74s)
=== RUN   TestAccVaultSecretsResourceSecret
The api rate limit exceeded, attempt: 1 trying in 19 seconds--- PASS: TestAccVaultSecretsResourceSecret (21.65s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets      27.500s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint  3.888s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook   4.513s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator 3.577s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2      4.874s [no tests to run]
...
```

Modified rate limit to 1 / minute
 
# HCP provider that is public (current behavior when api rate limit is hit)
```
terraform {
  required_providers {
    hcp = {
      source  = "hashicorp/hcp"
    }
  }
}

resource "hcp_vault_secrets_app" "example" {
  app_name    = "example-app-name"
  description = "My new app!"
}

resource "hcp_vault_secrets_secret" "example" {
  app_name     = hcp_vault_secrets_app.example.app_name
  secret_name  = "example_secret"
  secret_value = "hashi123"
}
```
```
> terraform init

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of localhost/providers/hcp from the dependency lock file
- Finding latest version of hashicorp/hcp...
- Installing hashicorp/hcp v0.86.0...
- Installed hashicorp/hcp v0.86.0 (signed by HashiCorp)
- Using previously-installed localhost/providers/hcp v0.0.1

Terraform has made some changes to the provider dependency selections recorded
in the .terraform.lock.hcl file. Review those changes and commit them to your
version control system if they represent changes you intended to make.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
Thu Apr 11 17:50:19 EDT 2024 terraform-provider-hcp/test - (codergs-22398) > terraform paln
Terraform has no command named "paln". Did you mean "plan"?

To see all of Terraform's top-level commands, run:
  terraform -help

> terraform plan
hcp_vault_secrets_app.example: Refreshing state... [id=example-app-name]
hcp_vault_secrets_secret.example: Refreshing state... [id=example-app-name]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

> terraform plan
hcp_vault_secrets_app.example: Refreshing state... [id=example-app-name]
hcp_vault_secrets_secret.example: Refreshing state... [id=example-app-name]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: [GET /secrets/2023-06-13/organizations/{location.organization_id}/projects/{location.project_id}/apps/{app_name}/open/{secret_name}][429] OpenAppSecret default  &{Code:8 Details:[] Message:this request has exceeded the rate limit of 1 requests per minute for your org, try again in 54 seconds}
│ 
│   with hcp_vault_secrets_secret.example,
│   on main.tf line 15, in resource "hcp_vault_secrets_secret" "example":
│   15: resource "hcp_vault_secrets_secret" "example" {
│ 
│ Error reading secret

```

# HCP provider with this PR fix (latest behavior)
```
terraform {
  required_providers {
    hcp = {
      source  = "localhost/providers/hcp"
    }
  }
}

resource "hcp_vault_secrets_app" "example" {
  app_name    = "example-app-name"
  description = "My new app!"
}

resource "hcp_vault_secrets_secret" "example" {
  app_name     = hcp_vault_secrets_app.example.app_name
  secret_name  = "example_secret"
  secret_value = "hashi123"
}
```
```
> terraform init

Initializing the backend...

Initializing provider plugins...
- Finding latest version of localhost/providers/hcp...
- Installing localhost/providers/hcp v0.0.1...
- Installed localhost/providers/hcp v0.0.1 (unauthenticated)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally for the following providers:
│   - localhost/providers/hcp
│ 
│ The current .terraform.lock.hcl file only includes checksums for darwin_amd64, so Terraform running on another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Thu Apr 11 17:57:06 EDT 2024 terraform-provider-hcp/test  > terraform plan
hcp_vault_secrets_app.example: Refreshing state... [id=example-app-name]
hcp_vault_secrets_secret.example: Refreshing state... [id=example-app-name]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
Thu Apr 11 17:57:58 EDT 2024 terraform-provider-hcp/test > terraform plan
hcp_vault_secrets_app.example: Refreshing state... [id=example-app-name]
hcp_vault_secrets_secret.example: Refreshing state... [id=example-app-name]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

# Newly added DEBUG log line.
```
# rate limited
Fri Apr 12 11:45:56 EDT 2024 terraform-provider-hcp/test > TF_LOG=DEBUG terraform plan 2>&1 | grep -C 4 "api rate limit"
2024-04-12T11:46:01.620-0400 [DEBUG] provider.terraform-provider-hcp: X-Ratelimit-Remaining: 0
2024-04-12T11:46:01.620-0400 [DEBUG] provider.terraform-provider-hcp: X-Ratelimit-Reset: 23
2024-04-12T11:46:01.621-0400 [DEBUG] provider.terraform-provider-hcp
2024-04-12T11:46:01.621-0400 [DEBUG] provider.terraform-provider-hcp: {"code":8,"message":"this request has exceeded the rate limit of 1 requests per minute for your org, try again in 23 seconds","details":[]}
2024-04-12T11:46:01.621-0400 [DEBUG] provider.terraform-provider-hcp: The api rate limit has been exceeded, retrying in 23 seconds, attempt: 1: @caller=/Users/gsharma/go/src/github.com/hashicorp/terraform-provider-hcp/internal/clients/vault_secrets.go:144 tf_resource_type=hcp_vault_secrets_secret tf_rpc=ReadResource @module=hcp tf_mux_provider="*proto6server.Server" tf_provider_addr=registry.terraform.io/hashicorp/hcp tf_req_id=86b439c7-cd93-cea5-7b0a-6f0b0225bbf8 timestamp=2024-04-12T11:46:01.621-0400

2024-04-12T11:46:24.623-0400 [DEBUG] provider.terraform-provider-hcp: 2024/04/12 11:46:24 [DEBUG] GET /secrets/2023-06-13/organizations/9f3ec4ed-26be-4a6d-a81f-175dbd2ee9aa/projects/1f045511-3018-4b65-beb7-e6c93d79807a/apps/example-app-name/open/example_secret HTTP/1.1
2024-04-12T11:46:24.623-0400 [DEBUG] provider.terraform-provider-hcp: Host: gaurav02-cxkef6v7.dev.pedp-remote.hashicorp.services
2024-04-12T11:46:24.623-0400 [DEBUG] provider.terraform-provider-hcp: User-Agent: Go-http-client/1.1
2024-04-12T11:46:24.623-0400 [DEBUG] provider.terraform-provider-hcp: Accept: application/json

# rate limit reset after 1 min
Fri Apr 12 11:46:24 EDT 2024 terraform-provider-hcp/test  > TF_LOG=DEBUG terraform plan 2>&1 | grep -C 4 "api rate limit"
```
