### PR TITLE
Fix code ownership for vault secrets files

### DIFF
--- a/.changelog/814.txt
+++ b/.changelog/814.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+CODEOWNERS: Fix vault-secrets resource ownership to @hashicorp/cloud-vault-secrets team.
+```

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,11 +18,12 @@
 # all Packer resources and clients are owned by the cloud-packer team
 *packer* @hashicorp/cloud-packer
 
-# all Vault resources and clients are owned by the vault-cloud team
-*vault* @hashicorp/vault-cloud
-
 # all Vault Secrets resources and clients are owned by cloud-vault-secrets team
 *vaultsecrets* @hashicorp/cloud-vault-secrets
+*vault_secrets* @hashicorp/cloud-vault-secrets
+
+# all Vault resources and clients are owned by the vault-cloud team
+*vault* @hashicorp/vault-cloud
 
 # all Boundary resources and clients are owned by the boundary-cloud team
 *boundary* @hashicorp/boundary-cloud


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

This PR attempts to fix the incorrect code attribution of vault secrets files to vault-cloud team, and moves them to vault-secrets team.

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
