### PR TITLE
[WAYP-2172] Set variable options for add-on definitions

### DIFF
--- a/.changelog/819.txt
+++ b/.changelog/819.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Support setting variable options on HCP Waypoint add-on definitions.
+Support setting variable options in `Support setting variable options in `hcp_waypoint_add_on_definition`.
 ```

--- a/.changelog/819.txt
+++ b/.changelog/819.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Support setting variable options on HCP Waypoint add-on definitions.
+```

--- a/docs/data-sources/waypoint_add_on_definition.md
+++ b/docs/data-sources/waypoint_add_on_definition.md
@@ -19,6 +19,7 @@ The Waypoint Add-on Definition data source retrieves information on a given Add-
 - `id` (String) The ID of the Add-on Definition.
 - `name` (String) The name of the Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
+- `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 
@@ -29,6 +30,16 @@ The Waypoint Add-on Definition data source retrieves information on a given Add-
 - `summary` (String) A short summary of the Add-on Definition.
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+
+<a id="nestedatt--variable_options"></a>
+### Nested Schema for `variable_options`
+
+Required:
+
+- `name` (String) Variable name
+- `options` (List of String) List of options
+- `variable_type` (String) Variable type
+
 
 <a id="nestedatt--terraform_cloud_workspace_details"></a>
 ### Nested Schema for `terraform_cloud_workspace_details`

--- a/docs/data-sources/waypoint_add_on_definition.md
+++ b/docs/data-sources/waypoint_add_on_definition.md
@@ -19,7 +19,6 @@ The Waypoint Add-on Definition data source retrieves information on a given Add-
 - `id` (String) The ID of the Add-on Definition.
 - `name` (String) The name of the Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
-- `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 
@@ -30,16 +29,7 @@ The Waypoint Add-on Definition data source retrieves information on a given Add-
 - `summary` (String) A short summary of the Add-on Definition.
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
-
-<a id="nestedatt--variable_options"></a>
-### Nested Schema for `variable_options`
-
-Required:
-
-- `name` (String) Variable name
-- `options` (List of String) List of options
-- `variable_type` (String) Variable type
-
+- `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 <a id="nestedatt--terraform_cloud_workspace_details"></a>
 ### Nested Schema for `terraform_cloud_workspace_details`
@@ -57,3 +47,14 @@ Read-Only:
 
 - `source` (String) Terraform Cloud no-code Module Source
 - `version` (String) Terraform Cloud no-code Module Version
+
+
+<a id="nestedatt--variable_options"></a>
+### Nested Schema for `variable_options`
+
+Read-Only:
+
+- `name` (String) Variable name
+- `options` (List of String) List of options
+- `user_editable` (Boolean) Whether the variable is editable by the user creating an add-on
+- `variable_type` (String) Variable type

--- a/docs/data-sources/waypoint_application_template.md
+++ b/docs/data-sources/waypoint_application_template.md
@@ -52,7 +52,7 @@ Read-Only:
 <a id="nestedatt--variable_options"></a>
 ### Nested Schema for `variable_options`
 
-Read-Only:
+Required:
 
 - `name` (String) Variable name
 - `options` (List of String) List of options

--- a/docs/data-sources/waypoint_application_template.md
+++ b/docs/data-sources/waypoint_application_template.md
@@ -52,7 +52,7 @@ Read-Only:
 <a id="nestedatt--variable_options"></a>
 ### Nested Schema for `variable_options`
 
-Required:
+Read-Only:
 
 - `name` (String) Variable name
 - `options` (List of String) List of options

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -59,5 +59,8 @@ Required:
 
 - `name` (String) Variable name
 - `options` (List of String) List of options
-- `user_editable` (Boolean) Whether the variable is editable by the user creating an add-on
 - `variable_type` (String) Variable type
+
+Optional:
+
+- `user_editable` (Boolean) Whether the variable is editable by the user creating an add-on

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -27,6 +27,7 @@ Waypoint Add-on Definition resource
 - `labels` (List of String) List of labels attached to this Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
 - `readme_markdown_template` (String) The markdown template for the Add-on Definition README.
+- `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 
@@ -49,3 +50,13 @@ Required:
 
 - `source` (String) Terraform Cloud no-code Module Source
 - `version` (String) Terraform Cloud no-code Module Version
+
+
+<a id="nestedatt--variable_options"></a>
+### Nested Schema for `variable_options`
+
+Required:
+
+- `name` (String) Variable name
+- `options` (List of String) List of options
+- `variable_type` (String) Variable type

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -59,4 +59,5 @@ Required:
 
 - `name` (String) Variable name
 - `options` (List of String) List of options
+- `user_editable` (Boolean) Whether the variable is editable by the user creating an add-on
 - `variable_type` (String) Variable type

--- a/docs/resources/waypoint_application_template.md
+++ b/docs/resources/waypoint_application_template.md
@@ -63,4 +63,4 @@ Required:
 
 Optional:
 
-- `user_editable` (Boolean) Whether the variable is editable by the user creating an application.
+- `user_editable` (Boolean) Whether the variable is editable by the user creating an application

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -125,22 +125,26 @@ func (d *DataSourceAddOnDefinition) Schema(ctx context.Context, req datasource.S
 				},
 			},
 			"variable_options": schema.ListNestedAttribute{
-				Optional:    true,
+				Computed:    true,
 				Description: "List of variable options for the template",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": &schema.StringAttribute{
-							Required:    true,
+							Computed:    true,
 							Description: "Variable name",
 						},
 						"variable_type": &schema.StringAttribute{
-							Required:    true,
+							Computed:    true,
 							Description: "Variable type",
 						},
 						"options": &schema.ListAttribute{
 							ElementType: types.StringType,
-							Required:    true,
+							Computed:    true,
 							Description: "List of options",
+						},
+						"user_editable": &schema.BoolAttribute{
+							Computed:    true,
+							Description: "Whether the variable is editable by the user creating an add-on",
 						},
 					},
 				},
@@ -249,6 +253,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 			varOptsState := &tfcVariableOption{
 				Name:         types.StringValue(v.Name),
 				VariableType: types.StringValue(v.VariableType),
+				UserEditable: types.BoolValue(v.UserEditable),
 			}
 
 			vOpts, diags := types.ListValueFrom(ctx, types.StringType, v.Options)

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypointModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -193,7 +193,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 		ProjectID:      projectID,
 	}
 
-	var definition *waypoint_models.HashicorpCloudWaypointAddOnDefinition
+	var definition *waypointModels.HashicorpCloudWaypointAddOnDefinition
 	var err error
 
 	if state.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
@@ -40,6 +40,10 @@ func TestAccWaypointData_Add_On_Definition_basic(t *testing.T) {
 				Config: testDataAddOnDefinitionConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.name", "string_variable"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.variable_type", "string"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.0", "b"),
 				),
 			},
 			{
@@ -48,6 +52,10 @@ func TestAccWaypointData_Add_On_Definition_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.name", "string_variable"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.variable_type", "string"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.0", "b"),
 				),
 			},
 		},

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
@@ -44,6 +44,7 @@ func TestAccWaypointData_Add_On_Definition_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.variable_type", "string"),
 					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.0", "b"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.user_editable", "false"),
 				),
 			},
 			{
@@ -56,6 +57,7 @@ func TestAccWaypointData_Add_On_Definition_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.variable_type", "string"),
 					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.options.0", "b"),
+					resource.TestCheckResourceAttr(dataSourceName, "variable_options.0.user_editable", "false"),
 				),
 			},
 		},

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -154,6 +154,10 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 							Required:    true,
 							Description: "List of options",
 						},
+						"user_editable": &schema.BoolAttribute{
+							Required:    true,
+							Description: "Whether the variable is editable by the user creating an add-on",
+						},
 					},
 				},
 			},
@@ -243,7 +247,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
-			UserEditable: false,
+			UserEditable: v.UserEditable.ValueBool(),
 		})
 	}
 
@@ -329,6 +333,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		varOptsState := &tfcVariableOption{
 			Name:         types.StringValue(v.Name),
 			VariableType: types.StringValue(v.VariableType),
+			UserEditable: types.BoolValue(v.UserEditable),
 		}
 		varOptsState.Options, diags = types.ListValueFrom(ctx, types.StringType, v.Options)
 
@@ -429,6 +434,7 @@ func (r *AddOnDefinitionResource) Read(ctx context.Context, req resource.ReadReq
 			varOptsState := &tfcVariableOption{
 				Name:         types.StringValue(v.Name),
 				VariableType: types.StringValue(v.VariableType),
+				UserEditable: types.BoolValue(v.UserEditable),
 			}
 
 			vOpts, diags := types.ListValueFrom(ctx, types.StringType, v.Options)
@@ -511,7 +517,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
-			UserEditable: false,
+			UserEditable: v.UserEditable.ValueBool(),
 		})
 	}
 
@@ -599,6 +605,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		varOptsState := &tfcVariableOption{
 			Name:         types.StringValue(v.Name),
 			VariableType: types.StringValue(v.VariableType),
+			UserEditable: types.BoolValue(v.UserEditable),
 		}
 		varOptsState.Options, diags = types.ListValueFrom(ctx, types.StringType, v.Options)
 

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -328,23 +328,6 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		plan.TerraformNoCodeModule = tfcNoCode
 	}
 
-	var actualVars []*tfcVariableOption
-	for _, v := range addOnDefinition.VariableOptions {
-		varOptsState := &tfcVariableOption{
-			Name:         types.StringValue(v.Name),
-			VariableType: types.StringValue(v.VariableType),
-			UserEditable: types.BoolValue(v.UserEditable),
-		}
-		varOptsState.Options, diags = types.ListValueFrom(ctx, types.StringType, v.Options)
-
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		actualVars = append(actualVars, varOptsState)
-	}
-
 	plan.TerraformVariableOptions, err = readVarOpts(ctx, addOnDefinition.VariableOptions, &resp.Diagnostics)
 	if err != nil {
 		tflog.Error(ctx, err.Error())
@@ -588,22 +571,6 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		plan.TerraformNoCodeModule = tfcNoCode
 	}
 
-	var actualVars []*tfcVariableOption
-	for _, v := range addOnDefinition.VariableOptions {
-		varOptsState := &tfcVariableOption{
-			Name:         types.StringValue(v.Name),
-			VariableType: types.StringValue(v.VariableType),
-			UserEditable: types.BoolValue(v.UserEditable),
-		}
-		varOptsState.Options, diags = types.ListValueFrom(ctx, types.StringType, v.Options)
-
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		actualVars = append(actualVars, varOptsState)
-	}
 	plan.TerraformVariableOptions, err = readVarOpts(ctx, addOnDefinition.VariableOptions, &resp.Diagnostics)
 	if err != nil {
 		tflog.Error(ctx, err.Error())

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -531,6 +531,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			Name:      plan.TerraformCloudWorkspace.Name.ValueString(),
 			ProjectID: plan.TerraformCloudWorkspace.TerraformProjectID.ValueString(),
 		},
+		VariableOptions: varOpts,
 	}
 
 	params := &waypoint_service.WaypointServiceUpdateAddOnDefinitionParams{

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -10,7 +10,7 @@ import (
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypointModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -155,7 +155,8 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 							Description: "List of options",
 						},
 						"user_editable": &schema.BoolAttribute{
-							Required:    true,
+							Optional:    true,
+							Computed:    true,
 							Description: "Whether the variable is editable by the user creating an add-on",
 						},
 					},
@@ -235,7 +236,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		)
 	}
 
-	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
+	varOpts := []*waypointModels.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags := v.Options.ElementsAs(ctx, &strOpts, false)
@@ -243,7 +244,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypointModels.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -251,18 +252,18 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		})
 	}
 
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceCreateAddOnDefinitionBody{
+	modelBody := &waypointModels.HashicorpCloudWaypointWaypointServiceCreateAddOnDefinitionBody{
 		Name:                   plan.Name.ValueString(),
 		Summary:                plan.Summary.ValueString(),
 		Description:            plan.Description.ValueString(),
 		ReadmeMarkdownTemplate: readmeBytes,
 		Labels:                 stringLabels,
-		TerraformNocodeModule: &waypoint_models.HashicorpCloudWaypointTerraformNocodeModule{
+		TerraformNocodeModule: &waypointModels.HashicorpCloudWaypointTerraformNocodeModule{
 			// verify these exist in the file
 			Source:  plan.TerraformNoCodeModule.Source.ValueString(),
 			Version: plan.TerraformNoCodeModule.Version.ValueString(),
 		},
-		TerraformCloudWorkspaceDetails: &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+		TerraformCloudWorkspaceDetails: &waypointModels.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      plan.TerraformCloudWorkspace.Name.ValueString(),
 			ProjectID: plan.TerraformCloudWorkspace.TerraformProjectID.ValueString(),
 		},
@@ -279,7 +280,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	var addOnDefinition *waypoint_models.HashicorpCloudWaypointAddOnDefinition
+	var addOnDefinition *waypointModels.HashicorpCloudWaypointAddOnDefinition
 	if def.Payload != nil {
 		addOnDefinition = def.Payload.AddOnDefinition
 	}
@@ -476,7 +477,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		}
 	}
 
-	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
+	varOpts := []*waypointModels.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags := v.Options.ElementsAs(ctx, &strOpts, false)
@@ -484,7 +485,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypointModels.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -493,18 +494,18 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// TODO: add support for Tags
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceUpdateAddOnDefinitionBody{
+	modelBody := &waypointModels.HashicorpCloudWaypointWaypointServiceUpdateAddOnDefinitionBody{
 		Name:                   plan.Name.ValueString(),
 		Summary:                plan.Summary.ValueString(),
 		Description:            plan.Description.ValueString(),
 		ReadmeMarkdownTemplate: readmeBytes,
 		Labels:                 stringLabels,
-		TerraformNocodeModule: &waypoint_models.HashicorpCloudWaypointTerraformNocodeModule{
+		TerraformNocodeModule: &waypointModels.HashicorpCloudWaypointTerraformNocodeModule{
 			// verify these exist in the file
 			Source:  plan.TerraformNoCodeModule.Source.ValueString(),
 			Version: plan.TerraformNoCodeModule.Version.ValueString(),
 		},
-		TerraformCloudWorkspaceDetails: &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+		TerraformCloudWorkspaceDetails: &waypointModels.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      plan.TerraformCloudWorkspace.Name.ValueString(),
 			ProjectID: plan.TerraformCloudWorkspace.TerraformProjectID.ValueString(),
 		},
@@ -522,7 +523,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	var addOnDefinition *waypoint_models.HashicorpCloudWaypointAddOnDefinition
+	var addOnDefinition *waypointModels.HashicorpCloudWaypointAddOnDefinition
 	if def.Payload != nil {
 		addOnDefinition = def.Payload.AddOnDefinition
 	}

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -39,6 +39,7 @@ func TestAccWaypoint_Add_On_Definition_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "variable_options.0.variable_type", "string"),
 					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.0", "b"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.user_editable", "false"),
 				),
 			},
 			{
@@ -51,6 +52,7 @@ func TestAccWaypoint_Add_On_Definition_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "variable_options.0.variable_type", "string"),
 					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.0", "b"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.user_editable", "false"),
 				),
 			},
 		},
@@ -155,6 +157,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
       options = [
         "b"
       ]
+      user_editable = false
     }
   ]
 }`, name)

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -35,6 +35,10 @@ func TestAccWaypoint_Add_On_Definition_basic(t *testing.T) {
 					testAccCheckWaypointAddOnDefinitionExists(t, resourceName, &addOnDefinitionModel),
 					testAccCheckWaypointAddOnDefinitionName(t, &addOnDefinitionModel, name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.name", "string_variable"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.variable_type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.0", "b"),
 				),
 			},
 			{
@@ -43,6 +47,10 @@ func TestAccWaypoint_Add_On_Definition_basic(t *testing.T) {
 					testAccCheckWaypointAddOnDefinitionExists(t, resourceName, &addOnDefinitionModel),
 					testAccCheckWaypointAddOnDefinitionName(t, &addOnDefinitionModel, updatedName),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.name", "string_variable"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.variable_type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "variable_options.0.options.0", "b"),
 				),
 			},
 		},
@@ -134,11 +142,20 @@ resource "hcp_waypoint_add_on_definition" "test" {
   description = "some description for fun"
   terraform_no_code_module = {
     source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
+    version = "0.0.3"
   }
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
+  variable_options = [
+	{
+	  name        = "string_variable"
+      variable_type = "string"
+      options = [
+        "b"
+      ]
+    }
+  ]
 }`, name)
 }

--- a/internal/provider/waypoint/resource_waypoint_application_template.go
+++ b/internal/provider/waypoint/resource_waypoint_application_template.go
@@ -175,6 +175,7 @@ func (r *ApplicationTemplateResource) Schema(ctx context.Context, req resource.S
 						},
 						"user_editable": &schema.BoolAttribute{
 							Optional: true,
+							Computed: true,
 							Description: "Whether the variable is editable by the user " +
 								"creating an application",
 						},

--- a/internal/provider/waypoint/resource_waypoint_application_template.go
+++ b/internal/provider/waypoint/resource_waypoint_application_template.go
@@ -176,7 +176,7 @@ func (r *ApplicationTemplateResource) Schema(ctx context.Context, req resource.S
 						"user_editable": &schema.BoolAttribute{
 							Optional: true,
 							Description: "Whether the variable is editable by the user " +
-								"creating an application.",
+								"creating an application",
 						},
 					},
 				},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

This PR updates the hcp_waypoint_add_on_definition resource and data source to set and retrieve input variable options for HCP Waypoint add-ons.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccWaypoint_Add_On_Definition_basic'
=== RUN   TestAccWaypoint_Add_On_Definition_basic
--- PASS: TestAccWaypoint_Add_On_Definition_basic (8.16s)

$ make testacc TESTARGS='-run=TestAccWaypointData_Add_On_Definition_basic'
=== RUN   TestAccWaypointData_Add_On_Definition_basic
--- PASS: TestAccWaypointData_Add_On_Definition_basic (11.91s)
```