### PR TITLE
Add-on resources and data sources now retrieve output values. 

### DIFF
--- a/.changelog/822.txt
+++ b/.changelog/822.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Support retrieving output values in `hcp_waypoint_add_on`
+```

--- a/docs/data-sources/waypoint_add_on.md
+++ b/docs/data-sources/waypoint_add_on.md
@@ -28,11 +28,23 @@ The Waypoint Add-on data source retrieves information on a given Add-on.
 - `install_count` (Number) The number of installed Add-ons for the same Application that share the same Add-on Definition.
 - `labels` (List of String) List of labels attached to this Add-on.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint AddOn is located.
+- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `project_id` (String) The ID of the HCP project where the Waypoint AddOn is located.
 - `readme_markdown` (String) Instructions for using the Add-on (markdown format supported).
 - `status` (Number) The status of the Terraform run for the Add-on.
 - `summary` (String) A short summary of the Add-on.
 - `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+
+<a id="nestedatt--output_values"></a>
+### Nested Schema for `output_values`
+
+Read-Only:
+
+- `name` (String) The name of the output value.
+- `sensitive` (Boolean) Whether the output value is sensitive.
+- `type` (String) The type of the output value.
+- `value` (String) The value of the output value.
+
 
 <a id="nestedatt--terraform_no_code_module"></a>
 ### Nested Schema for `terraform_no_code_module`

--- a/docs/resources/waypoint_add_on.md
+++ b/docs/resources/waypoint_add_on.md
@@ -32,10 +32,22 @@ Waypoint Add-on resource
 - `install_count` (Number) The number of installed Add-ons for the same Application that share the same Add-on Definition.
 - `labels` (List of String) List of labels attached to this Add-on.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint AddOn is located.
+- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `readme_markdown` (String) The markdown for the Add-on README.
 - `status` (Number) The status of the Terraform run for the Add-on.
 - `summary` (String) A short summary of the Add-on.
 - `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+
+<a id="nestedatt--output_values"></a>
+### Nested Schema for `output_values`
+
+Read-Only:
+
+- `name` (String) The name of the output value.
+- `sensitive` (Boolean) Whether the output value is sensitive.
+- `type` (String) The type of the output value.
+- `value` (String) The value of the output value.
+
 
 <a id="nestedatt--terraform_no_code_module"></a>
 ### Nested Schema for `terraform_no_code_module`

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcp-sdk-go v0.93.0
+	github.com/hashicorp/hcp-sdk-go v0.96.0
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,6 @@ github.com/hashicorp/hc-install v0.6.2 h1:V1k+Vraqz4olgZ9UzKiAcbman9i9scg9GgSt/U
 github.com/hashicorp/hc-install v0.6.2/go.mod h1:2JBpd+NCFKiHiu/yYCGaPyPHhZLxXTpz8oreHa/a3Ps=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.93.0 h1:Ddo261pU9mnHIK5+ncRqSfRqMkkCJsmGyoMHoatAdFg=
-github.com/hashicorp/hcp-sdk-go v0.93.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/hcp-sdk-go v0.96.0 h1:7oI993ZN7HG7TiFg00r2Po1N5mZZryOtSX0Ec/8cCQ4=
 github.com/hashicorp/hcp-sdk-go v0.96.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5R
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/hcp-sdk-go v0.93.0 h1:Ddo261pU9mnHIK5+ncRqSfRqMkkCJsmGyoMHoatAdFg=
 github.com/hashicorp/hcp-sdk-go v0.93.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.96.0 h1:7oI993ZN7HG7TiFg00r2Po1N5mZZryOtSX0Ec/8cCQ4=
+github.com/hashicorp/hcp-sdk-go v0.96.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.20.0 h1:DIZnPsqzPGuUnq6cH8jWcPunBfY+C+M8JyYF3vpnuEo=

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -269,28 +269,10 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 		}
 	}
 
-	if addOn.OutputValues != nil {
-		outputList := make([]*outputValue, len(addOn.OutputValues))
-		for i, outputVal := range addOn.OutputValues {
-			output := &outputValue{
-				Name:      types.StringValue(outputVal.Name),
-				Type:      types.StringValue(outputVal.Type),
-				Value:     types.StringValue(outputVal.Value),
-				Sensitive: types.BoolValue(outputVal.Sensitive),
-			}
-			outputList[i] = output
-		}
-		if len(outputList) > 0 || len(outputList) != len(state.OutputValues.Elements()) {
-			state.OutputValues, diags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: outputValue{}.attrTypes()}, outputList)
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-		} else {
-			state.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
-		}
-	} else {
-		state.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
+	diags = ReadOutputs(ctx, addOn, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -119,7 +119,7 @@ func (d *DataSourceAddOn) Schema(ctx context.Context, req datasource.SchemaReque
 				Computed:    true,
 				Description: "The status of the Terraform run for the Add-on.",
 			},
-			/*"output_values": schema.ListNestedAttribute{
+			"output_values": schema.ListNestedAttribute{
 				Computed: true,
 				Description: "The output values of the Terraform run for the Add-on, sensitive values have type " +
 					"and value omitted.",
@@ -143,7 +143,7 @@ func (d *DataSourceAddOn) Schema(ctx context.Context, req datasource.SchemaReque
 						},
 					},
 				},
-			},*/
+			},
 		},
 	}
 }
@@ -239,8 +239,6 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	state.CreatedBy = types.StringValue(addOn.CreatedBy)
 
-	// TODO: Add support for outputValues
-
 	// If we can process status as an int64, add it to the plan
 	statusNum, err := strconv.ParseInt(addOn.Count, 10, 64)
 	if err != nil {
@@ -269,6 +267,30 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 		if addOn.Application.ID != "" {
 			state.ApplicationID = types.StringValue(addOn.Application.ID)
 		}
+	}
+
+	if addOn.OutputValues != nil {
+		outputList := make([]*outputValue, len(addOn.OutputValues))
+		for i, outputVal := range addOn.OutputValues {
+			output := &outputValue{
+				Name:      types.StringValue(outputVal.Name),
+				Type:      types.StringValue(outputVal.Type),
+				Value:     types.StringValue(outputVal.Value),
+				Sensitive: types.BoolValue(outputVal.Sensitive),
+			}
+			outputList[i] = output
+		}
+		if len(outputList) > 0 || len(outputList) != len(state.OutputValues.Elements()) {
+			state.OutputValues, diags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: outputValue{}.attrTypes()}, outputList)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+		} else {
+			state.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
+		}
+	} else {
+		state.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -269,7 +269,7 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 		}
 	}
 
-	diags = ReadOutputs(ctx, addOn, &state)
+	diags = readOutputs(ctx, addOn, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -388,7 +388,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 		plan.Count = types.Int64Value(installedCount)
 	}
 
-	diags = ReadOutputs(ctx, addOn, plan)
+	diags = readOutputs(ctx, addOn, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -505,7 +505,7 @@ func (r *AddOnResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		}
 	}
 
-	diags = ReadOutputs(ctx, addOn, state)
+	diags = readOutputs(ctx, addOn, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -634,7 +634,7 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		plan.Count = types.Int64Value(installedCount)
 	}
 
-	diags = ReadOutputs(ctx, addOn, plan)
+	diags = readOutputs(ctx, addOn, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -699,7 +699,7 @@ func (r *AddOnResource) ImportState(ctx context.Context, req resource.ImportStat
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func ReadOutputs(ctx context.Context, addOn *waypointmodels.HashicorpCloudWaypointAddOn, plan *AddOnResourceModel) diag.Diagnostics {
+func readOutputs(ctx context.Context, addOn *waypointmodels.HashicorpCloudWaypointAddOn, plan *AddOnResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if addOn.OutputValues != nil {
 		outputList := make([]*outputValue, len(addOn.OutputValues))
@@ -712,11 +712,8 @@ func ReadOutputs(ctx context.Context, addOn *waypointmodels.HashicorpCloudWaypoi
 			}
 			outputList[i] = output
 		}
-		if len(outputList) > 0 || len(outputList) != len(plan.OutputValues.Elements()) {
+		if len(outputList) > 0 {
 			plan.OutputValues, diags = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: outputValue{}.attrTypes()}, outputList)
-			if diags.HasError() {
-				return diags
-			}
 		} else {
 			plan.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
 		}


### PR DESCRIPTION
### :hammer_and_wrench: Description

This updates the `hcp_waypoint_add_on` resource and data source to read Terraform output values, when present.

In addition, it bumps hcp-sdk-go to v0.96.0

To test:

```sh
$ make testacc TESTARGS='-run=TestAccWaypoint_Add_On_basic'
$ make testacc TESTARGS='-run=TestAccWaypointData_Add_On_basic'
```
