### PR TITLE
use openAppSecrets instead of list+Open secret in DataSourceVaultSecr…

### DIFF
--- a/.changelog/826.txt
+++ b/.changelog/826.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Documentation: call OpenAppSecrets instead of List + Open in hcp_vault_secrets_app data source. This improves an issue with additional unnecessary client API usage.
+```

--- a/internal/clients/response.go
+++ b/internal/clients/response.go
@@ -32,6 +32,8 @@ func IsResponseCodeInternalError(erro error) bool {
 	}
 }
 
+// ErrorWithCode is an interface wrapping the error interface
+// to also return the response status code.
 type ErrorWithCode interface {
 	error
 	Code() int

--- a/internal/clients/response.go
+++ b/internal/clients/response.go
@@ -31,3 +31,8 @@ func IsResponseCodeInternalError(erro error) bool {
 		return strings.Contains(erro.Error(), fmt.Sprintf("[%d]", http.StatusInternalServerError))
 	}
 }
+
+type ErrorWithCode interface {
+	error
+	Code() int
+}

--- a/internal/provider/packer/testutils/testclient/errors.go
+++ b/internal/provider/packer/testutils/testclient/errors.go
@@ -7,14 +7,11 @@ import (
 	"net/http"
 
 	"google.golang.org/grpc/codes"
+
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 
-type ErrorWithCode interface {
-	error
-	Code() int
-}
-
-func isAlreadyExistsError(e ErrorWithCode) bool {
+func isAlreadyExistsError(e clients.ErrorWithCode) bool {
 	switch e.Code() {
 	case int(codes.AlreadyExists), http.StatusConflict:
 		return true

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_app.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_app.go
@@ -98,7 +98,7 @@ func (d *DataSourceVaultSecretsApp) Read(ctx context.Context, req datasource.Rea
 		ProjectID:      client.Config.ProjectID,
 	}
 
-	appSecrets, err := clients.ListVaultSecretsAppSecrets(ctx, client, loc, data.AppName.ValueString())
+	appSecrets, err := clients.OpenVaultSecretsAppSecrets(ctx, client, loc, data.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(err.Error(), "")
 		return
@@ -107,13 +107,7 @@ func (d *DataSourceVaultSecretsApp) Read(ctx context.Context, req datasource.Rea
 	openAppSecrets := map[string]string{}
 	for _, appSecret := range appSecrets {
 		secretName := appSecret.Name
-
-		openSecret, err := clients.OpenVaultSecretsAppSecret(ctx, client, loc, data.AppName.ValueString(), secretName)
-		if err != nil {
-			resp.Diagnostics.AddError(err.Error(), "Unable to open secret")
-			return
-		}
-		openAppSecrets[secretName] = openSecret.Version.Value
+		openAppSecrets[secretName] = appSecret.Version.Value
 	}
 
 	data.ID = data.AppName


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
Addresses: https://hashicorp.atlassian.net/browse/VAULT-26495
We currently call ListAppSecrets, iterate over each secret and individually invoke OpenAppSecret [here](https://github.com/hashicorp/terraform-provider-hcp/blob/07e943eda98e351035443487165847c84757de5f/internal/provider/vaultsecrets/data_source_vault_secrets_app.go#L101-L117). This is both inefficient for us and causes additional API usage for the clients.

I think switching to OpenAppSecrets for this data source would be best.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAcc_dataSourceVaultSecretsApp'

...

=== RUN   TestAcc_dataSourceVaultSecretsAppMigration
--- PASS: TestAcc_dataSourceVaultSecretsAppMigration (12.94s)
=== RUN   TestAcc_dataSourceVaultSecretsApp
    data_source_vault_secrets_app_test.go:97: secrets:  secret_one  =  hey, this is version 1!
    data_source_vault_secrets_app_test.go:97: secrets:  secret_two  =  hey, this is version 2!
--- PASS: TestAcc_dataSourceVaultSecretsApp (6.39s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets      20.318s
testing: warning: no tests to run
PASS
```
To test this, I also created the following helper function:
```

func openTestAppSecret(t *testing.T, appName string) {
	t.Helper()

	client := acctest.HCPClients(t)

	loc := &sharedmodels.HashicorpCloudLocationLocation{
		OrganizationID: client.Config.OrganizationID,
		ProjectID:      client.Config.ProjectID,
	}

	secrets, err := clients.OpenVaultSecretsAppSecrets(context.Background(), client, loc, appName)
	if err != nil {
		t.Fatal(err)
	}
	if len(secrets) != 2 {
		t.Fatal("failed to read the secrets")
	}
	for _, s := range secrets {
		t.Log("secrets: ", s.Name, " = ", s.Version.Value)
	}

}
```
Added the above function to `TestAcc_dataSourceVaultSecretsApp` test on line 97 (which is after the test creates two secrets). The test passes and generates the following DD log:

<img width="801" alt="image" src="https://github.com/hashicorp/terraform-provider-hcp/assets/83242695/c40bec57-3591-45e6-ab46-8a9e55e0453a">
