### PR TITLE
Upgrade hcp_log_streaming_destination resource to public beta

### DIFF
--- a/.changelog/830.txt
+++ b/.changelog/830.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+resource/hcp_log_streaming_destination: Label resource as public beta
+```

--- a/docs/resources/log_streaming_destination.md
+++ b/docs/resources/log_streaming_destination.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_log_streaming_destination (Resource)
 
--> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+-> **Note:** This resource is currently in public beta.
 
 The Streaming Destination resource allows users to configure an external log system to stream HCP logs to.
 

--- a/templates/resources/log_streaming_destination.md.tmpl
+++ b/templates/resources/log_streaming_destination.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** This feature is currently in private beta. If you would like early access, please [contact our sales team](https://www.hashicorp.com/contact-sales).
+-> **Note:** This resource is currently in public beta.
 
 {{ .Description | trimspace }}
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Upgrading the `hcp_log_streaming_destination` resource from private beta to public beta

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
