### PR TITLE
Fix skip-e2e-tests flag for Prerelease scheduled runs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,16 +14,6 @@ on:
         description: "Skip the E2E test suite for break-glass scenarios"
         type: boolean
         default: false
-  workflow_call:
-    inputs:
-      release-as-patch:
-        description: "Patch Release (default: Minor)"
-        type: boolean
-        default: false
-      skip-tests:
-        description: "Skip the E2E test suite for break-glass scenarios"
-        type: boolean
-        default: false
 permissions: write-all
 
 jobs:
@@ -31,7 +21,7 @@ jobs:
     name: Run Tests
     uses: ./.github/workflows/test.yml
     with:
-      skip-e2e-tests: ${{ inputs.skip-tests }}
+      skip-e2e-tests: ${{ inputs.skip-tests == true }} # inputs are null when run with the schedule cron
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,8 @@ jobs:
     name: Run Tests
     uses: ./.github/workflows/test.yml
     with:
-      skip-e2e-tests: ${{ inputs.skip-tests == true }} # inputs are null when run with the schedule cron
+      # need to use contains because inputs are null for schedule runs
+      skip-e2e-tests: ${{ contains(inputs.skip-tests, 'true') }}
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Fixing the Prerelease Github Action for scheduled runs. 

After this PR: https://github.com/hashicorp/terraform-provider-hcp/pull/796 , we were still seeing the same error message in the runs [Example](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/8904358607):
```
[Prerelease](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/8904358607/workflow)
The template is not valid. .github/workflows/prerelease.yml (Line: 34, Col: 23): Unexpected value ''
```

Apparently scheduled jobs set all inputs as null ([example 1](https://stackoverflow.com/questions/72539900/schedule-trigger-github-action-workflow-with-input-parameters), [example 2](https://github.com/orgs/community/discussions/74698)), so we need to account for that case.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
