### PR TITLE
Add HCP Boundary to statuspage component IDs

### DIFF
--- a/.changelog/835.txt
+++ b/.changelog/835.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added HCP Boundary to statuspage components used to warn about potential issues with HCP.
+```

--- a/internal/provider/statuspage.go
+++ b/internal/provider/statuspage.go
@@ -21,6 +21,7 @@ var hcpComponentIds = map[string]string{
 	"0mbkqnrzg33w": "HCP Packer",
 	"mgv1p2j9x444": "HCP Portal",
 	"mb7xrbx9gjnq": "HCP Vault",
+	"9gzfhnxdsf93": "HCP Boundary",
 }
 
 type statuspage struct {

--- a/internal/providersdkv2/statuspage.go
+++ b/internal/providersdkv2/statuspage.go
@@ -21,6 +21,7 @@ var hcpComponentIds = map[string]string{
 	"0mbkqnrzg33w": "HCP Packer",
 	"mgv1p2j9x444": "HCP Portal",
 	"mb7xrbx9gjnq": "HCP Vault",
+	"9gzfhnxdsf93": "HCP Boundary",
 }
 
 type statuspage struct {


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

The provider uses these component IDs to show a warning in Terraform plan output if there is a known outage listed on any of the components on the statuspage. This commit adds HCP Boundary to be included when determining if there's an issue with HCP.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?