### PR TITLE
Add 404 handling from ResourceServiceGetIamPolicy

### DIFF
--- a/.changelog/838.txt
+++ b/.changelog/838.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+Fix first apply scenario for hcp_vault_secrets_app_iam_binding and hcp_vault_secrets_app_iam_policy, update docs
+
+```

--- a/docs/resources/vault_secrets_app_iam_binding.md
+++ b/docs/resources/vault_secrets_app_iam_binding.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Resource hcp_vault_secrets_app_iam_binding - terraform-provider-hcp"
-subcategory: "Cloud Platform"
+subcategory: "HCP Vault Secrets"
 description: |-
   Updates the Vault Secrets App IAM policy to bind a role to a new member. Existing bindings are preserved.
 ---

--- a/docs/resources/vault_secrets_app_iam_policy.md
+++ b/docs/resources/vault_secrets_app_iam_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Resource hcp_vault_secrets_app_iam_policy - terraform-provider-hcp"
-subcategory: "Cloud Platform"
+subcategory: "HCP Vault Secrets"
 description: |-
   Sets the Vault Secrets App IAM policy and replaces any existing policy.
 ---
@@ -25,7 +25,7 @@ Sets the Vault Secrets App IAM policy and replaces any existing policy.
 data "hcp_iam_policy" "example" {
   bindings = [
     {
-      role = "roles/contributor"
+      role = "roles/secrets.app-secret-reader"
       principals = [
         "example-user-id-1",
         "example-group-id-1",
@@ -35,13 +35,15 @@ data "hcp_iam_policy" "example" {
   ]
 }
 
-resource "hcp_project" "my_project" {
-  name = "example"
+
+resource "hcp_vault_secrets_app" "example" {
+  app_name    = "example-app-name"
+  description = "My new app!"
 }
 
-resource "hcp_project_iam_policy" "project_policy" {
-  project_id  = hcp_project.my_project.resource_id
-  policy_data = data.hcp_iam_policy.example.policy_data
+resource "hcp_vault_secrets_app_iam_policy" "example" {
+  resource_name = hcp_vault_secrets_app.example.resource_name
+  policy_data   = data.hcp_iam_policy.example.policy_data
 }
 ```
 

--- a/internal/provider/vaultsecrets/resource_vault_secrets_app_iam_policy.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_app_iam_policy.go
@@ -5,6 +5,7 @@ package vaultsecrets
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
@@ -83,6 +84,14 @@ func (u *vaultSecretsAppResourceIAMPolicyUpdater) GetResourceIamPolicy(ctx conte
 
 	res, err := u.client.ResourceService.ResourceServiceGetIamPolicy(params, nil)
 	if err != nil {
+		serviceErr, ok := err.(*resource_service.ResourceServiceGetIamPolicyDefault)
+		if !ok {
+			diags.AddError("failed to cast resource IAM policy error", err.Error())
+			return nil, diags
+		}
+		if serviceErr.Code() == http.StatusNotFound {
+			return &models.HashicorpCloudResourcemanagerPolicy{}, diags
+		}
 		diags.AddError("failed to retrieve resource IAM policy", err.Error())
 		return nil, diags
 	}

--- a/templates/resources/vault_secrets_app_iam_binding.md.tmpl
+++ b/templates/resources/vault_secrets_app_iam_binding.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: "Cloud Platform"
+subcategory: "HCP Vault Secrets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/vault_secrets_app_iam_policy.md.tmpl
+++ b/templates/resources/vault_secrets_app_iam_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Type}} {{.Name}} - {{.ProviderName}}"
-subcategory: "Cloud Platform"
+subcategory: "HCP Vault Secrets"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
@@ -21,7 +21,7 @@ import the policy before applying the change.
 
 ## Example Usage
 
-{{ tffile "examples/resources/hcp_project_iam_policy/resource.tf" }}
+{{ tffile "examples/resources/hcp_vault_secrets_app_iam_policy/resource.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Add 404 handling from ResourceServiceGetIamPolicy

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

- Currently, when we try to create a binding or policy on an HVS App that doesn't have any policy associated with it, the ResourceServiceGetIamPolicy done to fetch the existing call errors out, which bubbles up as an error in the terraform apply. 
- This PR adds handling for the 404 error in this case, to ignore it and allow the subsequent PUT call to proceed
- Also updates the docs to be under HCP Vault Secrets and fixes an example in one of them
### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
