### PR TITLE
fix state import for Waypoint resources

### DIFF
--- a/.changelog/839.txt
+++ b/.changelog/839.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ Waypoint: fix issue with importing existing Waypoint resources
+ ```

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -184,7 +184,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 	}
 
 	projectID := client.Config.ProjectID
-	if !state.ProjectID.IsNull() {
+	if !state.ProjectID.IsUnknown() && !state.ProjectID.IsNull() {
 		projectID = state.ProjectID.ValueString()
 	}
 

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -393,6 +393,9 @@ func (r *AddOnResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	projectID := r.client.Config.ProjectID
+	if !state.ProjectID.IsUnknown() && !state.ProjectID.IsNull() {
+		projectID = state.ProjectID.ValueString()
+	}
 
 	orgID := r.client.Config.OrganizationID
 	loc := &sharedmodels.HashicorpCloudLocationLocation{

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -354,7 +354,7 @@ func (r *AddOnDefinitionResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	projectID := r.client.Config.ProjectID
-	if !state.ProjectID.IsUnknown() {
+	if !state.ProjectID.IsUnknown() && !state.ProjectID.IsNull() {
 		projectID = state.ProjectID.ValueString()
 	}
 

--- a/internal/provider/waypoint/resource_waypoint_application.go
+++ b/internal/provider/waypoint/resource_waypoint_application.go
@@ -236,7 +236,7 @@ func (r *ApplicationResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	projectID := r.client.Config.ProjectID
-	if !data.ProjectID.IsUnknown() {
+	if !data.ProjectID.IsUnknown() && !data.ProjectID.IsNull() {
 		projectID = data.ProjectID.ValueString()
 	}
 

--- a/internal/provider/waypoint/resource_waypoint_application_template.go
+++ b/internal/provider/waypoint/resource_waypoint_application_template.go
@@ -403,7 +403,7 @@ func (r *ApplicationTemplateResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	projectID := r.client.Config.ProjectID
-	if !data.ProjectID.IsUnknown() {
+	if !data.ProjectID.IsUnknown() && !data.ProjectID.IsNull() {
 		projectID = data.ProjectID.ValueString()
 	}
 
@@ -418,11 +418,11 @@ func (r *ApplicationTemplateResource) Read(ctx context.Context, req resource.Rea
 	appTemplate, err := clients.GetApplicationTemplateByID(ctx, client, loc, data.ID.ValueString())
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
-			tflog.Info(ctx, "TFC Config not found for organization, removing from state.")
+			tflog.Info(ctx, "Template not found for organization, removing from state.")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Error reading TFC Config", err.Error())
+		resp.Diagnostics.AddError("Error reading Template", err.Error())
 		return
 	}
 

--- a/internal/provider/waypoint/resource_waypoint_tfc_config.go
+++ b/internal/provider/waypoint/resource_waypoint_tfc_config.go
@@ -187,7 +187,7 @@ func (r *TfcConfigResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	projectID := r.client.Config.ProjectID
-	if !data.ProjectID.IsUnknown() {
+	if !data.ProjectID.IsUnknown() && !data.ProjectID.IsNull() {
 		projectID = data.ProjectID.ValueString()
 	}
 


### PR DESCRIPTION
Fix an issue with importing existing Waypoint resources. Prior to this commit any `terraform import` for a waypoint resource could fail because the `projectID` value used to look up the resource by ID would be an empty string, causing a failure to look up the existing resource. 