### PR TITLE
Convert var opts from list to set for add-on definitions & templates

### DIFF
--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -27,7 +27,7 @@ Waypoint Add-on Definition resource
 - `labels` (List of String) List of labels attached to this Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
 - `readme_markdown_template` (String) The markdown template for the Add-on Definition README.
-- `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
+- `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 

--- a/docs/resources/waypoint_application_template.md
+++ b/docs/resources/waypoint_application_template.md
@@ -27,7 +27,7 @@ Waypoint Application Template resource
 - `labels` (List of String) List of labels attached to this Application Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Application Template is located.
 - `readme_markdown_template` (String) Instructions for using the template (markdown format supported
-- `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
+- `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -136,7 +136,7 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 					},
 				},
 			},
-			"variable_options": schema.ListNestedAttribute{
+			"variable_options": schema.SetNestedAttribute{
 				Optional:    true,
 				Description: "List of variable options for the template",
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/waypoint/resource_waypoint_application_template.go
+++ b/internal/provider/waypoint/resource_waypoint_application_template.go
@@ -155,7 +155,7 @@ func (r *ApplicationTemplateResource) Schema(ctx context.Context, req resource.S
 					},
 				},
 			},
-			"variable_options": schema.ListNestedAttribute{
+			"variable_options": schema.SetNestedAttribute{
 				Optional:    true,
 				Description: "List of variable options for the template",
 				NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
This PR updates the variables with options for Waypoint add-on definitions and templates to be a set and not a list, because ordering isn't a concern.