### PR TITLE
Allow empty description for hcp_group updates

### DIFF
--- a/.changelog/846.txt
+++ b/.changelog/846.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+Cloud Platform: fix issue where hcp_group description cannot be set to an empty string after it has been set to a non-empty string

--- a/internal/provider/iam/resource_group_test.go
+++ b/internal/provider/iam/resource_group_test.go
@@ -51,6 +51,16 @@ func TestAccGroupResource(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccGroupConfigResourceWithoutDescription(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hcp_group.example", "display_name", groupName),
+					resource.TestCheckResourceAttr("hcp_group.example", "description", ""),
+					resource.TestCheckResourceAttrSet("hcp_group.example", "resource_name"),
+					resource.TestCheckResourceAttrSet("hcp_group.example", "resource_id"),
+					testAccGroupExists(t, "hcp_group.example", &group),
+				),
+			},
+			{
 				ResourceName:                         "hcp_group.example",
 				ImportState:                          true,
 				ImportStateVerifyIdentifierAttribute: "resource_name",


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Allow empty description for hcp_group updates

Why:

* There may be a case where you want to set an empty description for a group where it had a description before.

This change addresses the need by:

* Adding a default value set to an empty string for the description field in the resource schema.
* Use the update mask to explicitly set the fields that are being updated. This is due to the an empty string not being output in the json payload as the model is set to omitempty.

Side effects:

* The Groups PATCH API will now have a case where update mask is used.

Fixes #843

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality? **No**
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccGroupResource'; echo $?
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccGroupResource -timeout 360m -parallel=10
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy  [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer    [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils  [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder    [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck        [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils      [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location     [no test files]
=== RUN   TestAccGroupResource
--- PASS: TestAccGroupResource (30.29s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       30.882s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/artifact   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/version    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2      (cached) [no tests to run]
0
```
