### PR TITLE
Compute unconfigured workload identity description

### DIFF
--- a/.changelog/849.txt
+++ b/.changelog/849.txt
@@ -1,0 +1,2 @@
+```release-note:bug
+Cloud Platform: fix issue where hcp_iam_workload_identity_provider without a description would cause a state error

--- a/internal/provider/iam/resource_workload_identity_provider.go
+++ b/internal/provider/iam/resource_workload_identity_provider.go
@@ -72,8 +72,9 @@ func (r *resourceWorkloadIdentityProvider) Schema(_ context.Context, _ resource.
 				},
 			},
 			"description": schema.StringAttribute{
-				Optional:    true,
 				Description: "A description for the workload identity provider.",
+				Computed:    true,
+				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(0, 255),
 				},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Compute hcp_iam_workload_identity_provider identity description

Why:

* When an hcp_iam_workload_identity_provider description is not configured in a Terraform file, then Terraform returns an error about the state's value of null not matching the provider's return value of "".

This change addresses the need by:

* Add failing test for hcp_iam_workload_identity_provider description not being configured.
* Fix test by configuring the hcp_iam_workload_identity_provider description attribute to be computed.

Fixes #848

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality? **No**
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccWorkloadIdentityProviderResource'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccWorkloadIdentityProviderResource -timeout 360m -parallel=10
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy  [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/clients    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/consul     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/input      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest   [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer    [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils  [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder    [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient       [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck        [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils      [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base [no test files]
?       github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location     [no test files]
=== RUN   TestAccWorkloadIdentityProviderResource
--- PASS: TestAccWorkloadIdentityProviderResource (21.17s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/iam       21.761s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/artifact   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/sources/version    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook   (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2      (cached) [no tests to run]
```
