### PR TITLE
Include rotated secrets for cloud vault secrets VAULT-22307

### DIFF
--- a/.changelog/850.txt
+++ b/.changelog/850.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Allows users to fetch rotating secrets using the hcp_vault_secrets_app and hcp_vault_secrets_secret data sources
+```

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -46,6 +46,8 @@ import (
 	cloud_vault "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client/vault_service"
 
+	cloud_vault_secrets_preview "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client"
+	secret_service_preview "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
 	cloud_vault_secrets "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
 
@@ -66,24 +68,25 @@ import (
 type Client struct {
 	Config ClientConfig
 
-	Billing           billing_account_service.ClientService
-	Boundary          boundary_service.ClientService
-	Consul            consul_service.ClientService
-	IAM               iam_service.ClientService
-	Network           network_service.ClientService
-	Operation         operation_service.ClientService
-	Organization      organization_service.ClientService
-	Packer            packer_service.ClientService
-	PackerV2          packer_service_v2.ClientService
-	Project           project_service.ClientService
-	ServicePrincipals service_principals_service.ClientService
-	Groups            groups_service.ClientService
-	Vault             vault_service.ClientService
-	VaultSecrets      secret_service.ClientService
-	Waypoint          waypoint_service.ClientService
-	Webhook           webhook_service.ClientService
-	LogService        log_service.ClientService
-	ResourceService   resource_service.ClientService
+	Billing             billing_account_service.ClientService
+	Boundary            boundary_service.ClientService
+	Consul              consul_service.ClientService
+	IAM                 iam_service.ClientService
+	Network             network_service.ClientService
+	Operation           operation_service.ClientService
+	Organization        organization_service.ClientService
+	Packer              packer_service.ClientService
+	PackerV2            packer_service_v2.ClientService
+	Project             project_service.ClientService
+	ServicePrincipals   service_principals_service.ClientService
+	Groups              groups_service.ClientService
+	Vault               vault_service.ClientService
+	VaultSecrets        secret_service.ClientService
+	VaultSecretsPreview secret_service_preview.ClientService
+	Waypoint            waypoint_service.ClientService
+	Webhook             webhook_service.ClientService
+	LogService          log_service.ClientService
+	ResourceService     resource_service.ClientService
 }
 
 // ClientConfig specifies configuration for the client that interacts with HCP
@@ -158,25 +161,26 @@ func NewClient(config ClientConfig) (*Client, error) {
 	}
 
 	client := &Client{
-		Config:            config,
-		Billing:           cloud_billing.New(httpClient, nil).BillingAccountService,
-		Boundary:          cloud_boundary.New(httpClient, nil).BoundaryService,
-		Consul:            cloud_consul.New(httpClient, nil).ConsulService,
-		IAM:               cloud_iam.New(httpClient, nil).IamService,
-		Network:           cloud_network.New(httpClient, nil).NetworkService,
-		Operation:         cloud_operation.New(httpClient, nil).OperationService,
-		Organization:      cloud_resource_manager.New(httpClient, nil).OrganizationService,
-		Packer:            cloud_packer.New(httpClient, nil).PackerService,
-		PackerV2:          cloud_packer_v2.New(httpClient, nil).PackerService,
-		Project:           cloud_resource_manager.New(httpClient, nil).ProjectService,
-		ServicePrincipals: cloud_iam.New(httpClient, nil).ServicePrincipalsService,
-		Groups:            cloud_iam.New(httpClient, nil).GroupsService,
-		Vault:             cloud_vault.New(httpClient, nil).VaultService,
-		VaultSecrets:      cloud_vault_secrets.New(httpClient, nil).SecretService,
-		Waypoint:          cloud_waypoint.New(httpClient, nil).WaypointService,
-		LogService:        cloud_log_service.New(httpClient, nil).LogService,
-		Webhook:           cloud_webhook.New(httpClient, nil).WebhookService,
-		ResourceService:   cloud_resource_manager.New(httpClient, nil).ResourceService,
+		Config:              config,
+		Billing:             cloud_billing.New(httpClient, nil).BillingAccountService,
+		Boundary:            cloud_boundary.New(httpClient, nil).BoundaryService,
+		Consul:              cloud_consul.New(httpClient, nil).ConsulService,
+		IAM:                 cloud_iam.New(httpClient, nil).IamService,
+		Network:             cloud_network.New(httpClient, nil).NetworkService,
+		Operation:           cloud_operation.New(httpClient, nil).OperationService,
+		Organization:        cloud_resource_manager.New(httpClient, nil).OrganizationService,
+		Packer:              cloud_packer.New(httpClient, nil).PackerService,
+		PackerV2:            cloud_packer_v2.New(httpClient, nil).PackerService,
+		Project:             cloud_resource_manager.New(httpClient, nil).ProjectService,
+		ServicePrincipals:   cloud_iam.New(httpClient, nil).ServicePrincipalsService,
+		Groups:              cloud_iam.New(httpClient, nil).GroupsService,
+		Vault:               cloud_vault.New(httpClient, nil).VaultService,
+		VaultSecrets:        cloud_vault_secrets.New(httpClient, nil).SecretService,
+		VaultSecretsPreview: cloud_vault_secrets_preview.New(httpClient, nil).SecretService,
+		Waypoint:            cloud_waypoint.New(httpClient, nil).WaypointService,
+		LogService:          cloud_log_service.New(httpClient, nil).LogService,
+		Webhook:             cloud_webhook.New(httpClient, nil).WebhookService,
+		ResourceService:     cloud_resource_manager.New(httpClient, nil).ResourceService,
 	}
 
 	return client, nil

--- a/internal/clients/vault_secrets.go
+++ b/internal/clients/vault_secrets.go
@@ -69,23 +69,6 @@ func UpdateVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodel
 	return updateResp.Payload.App, nil
 }
 
-// ListVaultSecretsAppSecrets will retrieve all app secrets metadata for a Vault Secrets application.
-func ListVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) ([]*secretmodels.Secrets20230613Secret, error) {
-
-	listParams := secret_service.NewListAppSecretsParams()
-	listParams.Context = ctx
-	listParams.AppName = appName
-	listParams.LocationOrganizationID = loc.OrganizationID
-	listParams.LocationProjectID = loc.ProjectID
-
-	listResp, err := client.VaultSecrets.ListAppSecrets(listParams, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return listResp.Payload.Secrets, nil
-}
-
 // DeleteVaultSecretsApp will delete a Vault Secrets application.
 func DeleteVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) error {
 
@@ -120,35 +103,6 @@ func CreateVaultSecretsAppSecret(ctx context.Context, client *Client, loc *share
 	}
 
 	return createResp.Payload.Secret, nil
-}
-
-// OpenVaultSecretsAppSecret will retrieve the latest secret for a Vault Secrets app, including it's value.
-func OpenVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName, secretName string) (*secretmodels.Secrets20230613OpenSecret, error) {
-	getParams := secret_service.NewOpenAppSecretParams()
-	getParams.Context = ctx
-	getParams.AppName = appName
-	getParams.SecretName = secretName
-	getParams.LocationOrganizationID = loc.OrganizationID
-	getParams.LocationProjectID = loc.ProjectID
-
-	var getResp *secret_service.OpenAppSecretOK
-	var err error
-	for attempt := 0; attempt < retryCount; attempt++ {
-		getResp, err = client.VaultSecrets.OpenAppSecret(getParams, nil)
-		if err != nil {
-			serviceErr, ok := err.(*secret_service.OpenAppSecretDefault)
-			if !ok {
-				return nil, err
-			}
-
-			if shouldRetryWithSleep(ctx, serviceErr, attempt, []int{http.StatusTooManyRequests}) {
-				continue
-			}
-			return nil, err
-		}
-		break
-	}
-	return getResp.Payload.Secret, nil
 }
 
 func OpenVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) ([]*secretmodels.Secrets20230613OpenSecret, error) {

--- a/internal/clients/vault_secrets.go
+++ b/internal/clients/vault_secrets.go
@@ -105,33 +105,6 @@ func CreateVaultSecretsAppSecret(ctx context.Context, client *Client, loc *share
 	return createResp.Payload.Secret, nil
 }
 
-func OpenVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) ([]*secretmodels.Secrets20230613OpenSecret, error) {
-	params := secret_service.NewOpenAppSecretsParams()
-	params.Context = ctx
-	params.AppName = appName
-	params.LocationOrganizationID = loc.OrganizationID
-	params.LocationProjectID = loc.ProjectID
-
-	var secrets *secret_service.OpenAppSecretsOK
-	var err error
-	for attempt := 0; attempt < retryCount; attempt++ {
-		secrets, err = client.VaultSecrets.OpenAppSecrets(params, nil)
-		if err != nil {
-			serviceErr, ok := err.(*secret_service.OpenAppSecretsDefault)
-			if !ok {
-				return nil, err
-			}
-			if shouldRetryWithSleep(ctx, serviceErr, attempt, []int{http.StatusTooManyRequests}) {
-				continue
-			}
-			return nil, err
-		}
-		break
-	}
-
-	return secrets.Payload.Secrets, nil
-}
-
 // DeleteVaultSecretsAppSecret will delete a Vault Secrets application secret.
 func DeleteVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName, secretName string) error {
 

--- a/internal/clients/vault_secrets_preview.go
+++ b/internal/clients/vault_secrets_preview.go
@@ -18,11 +18,10 @@ import (
 
 // ListVaultSecretsAppSecrets will retrieve all app secrets metadata for a Vault Secrets application.
 func ListVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) ([]*secretmodels.Secrets20231128Secret, error) {
-	listParams := secret_service.NewListAppSecretsParams()
-	listParams.Context = ctx
-	listParams.AppName = appName
-	listParams.OrganizationID = loc.OrganizationID
-	listParams.ProjectID = loc.ProjectID
+	listParams := secret_service.NewListAppSecretsParamsWithContext(ctx).
+		WithAppName(appName).
+		WithOrganizationID(loc.OrganizationID).
+		WithProjectID(loc.ProjectID)
 
 	listResp, err := client.VaultSecretsPreview.ListAppSecrets(listParams, nil)
 	if err != nil {
@@ -33,12 +32,11 @@ func ListVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *shared
 
 // OpenVaultSecretsAppSecret will retrieve the latest secret for a Vault Secrets app, including it's value.
 func OpenVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName, secretName string) (*secretmodels.Secrets20231128OpenSecret, error) {
-	getParams := secret_service.NewOpenAppSecretParams()
-	getParams.Context = ctx
-	getParams.AppName = appName
-	getParams.SecretName = secretName
-	getParams.OrganizationID = loc.OrganizationID
-	getParams.ProjectID = loc.ProjectID
+	getParams := secret_service.NewOpenAppSecretParamsWithContext(ctx).
+		WithAppName(appName).
+		WithSecretName(secretName).
+		WithOrganizationID(loc.OrganizationID).
+		WithProjectID(loc.ProjectID)
 
 	var getResp *secret_service.OpenAppSecretOK
 	var err error

--- a/internal/clients/vault_secrets_preview.go
+++ b/internal/clients/vault_secrets_preview.go
@@ -1,0 +1,70 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// ListVaultSecretsAppSecrets will retrieve all app secrets metadata for a Vault Secrets application.
+func ListVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) ([]*secretmodels.Secrets20231128Secret, error) {
+	listParams := secret_service.NewListAppSecretsParams()
+	listParams.Context = ctx
+	listParams.AppName = appName
+	listParams.OrganizationID = loc.OrganizationID
+	listParams.ProjectID = loc.ProjectID
+
+	listResp, err := client.VaultSecretsPreview.ListAppSecrets(listParams, nil)
+	if err != nil {
+		return nil, err
+	}
+	return listResp.GetPayload().Secrets, nil
+}
+
+// OpenVaultSecretsAppSecret will retrieve the latest secret for a Vault Secrets app, including it's value.
+func OpenVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName, secretName string) (*secretmodels.Secrets20231128OpenSecret, error) {
+	getParams := secret_service.NewOpenAppSecretParams()
+	getParams.Context = ctx
+	getParams.AppName = appName
+	getParams.SecretName = secretName
+	getParams.OrganizationID = loc.OrganizationID
+	getParams.ProjectID = loc.ProjectID
+
+	var getResp *secret_service.OpenAppSecretOK
+	var err error
+	for attempt := 0; attempt < retryCount; attempt++ {
+		getResp, err = client.VaultSecretsPreview.OpenAppSecret(getParams, nil)
+		if err != nil {
+			var serviceErr *secret_service.OpenAppSecretDefault
+			ok := errors.As(err, &serviceErr)
+			if !ok {
+				return nil, err
+			}
+
+			if shouldRetryErrorCode(serviceErr.Code(), []int{http.StatusTooManyRequests}) {
+				backOffDuration := getAPIBackoffDuration(serviceErr.Error())
+				tflog.Debug(ctx, fmt.Sprintf("The api rate limit has been exceeded, retrying in %d seconds, attempt: %d", int64(backOffDuration.Seconds()), (attempt+1)))
+				time.Sleep(backOffDuration)
+				continue
+			}
+			return nil, err
+		}
+		break
+	}
+
+	if getResp == nil {
+		return nil, errors.New("unable to get secret")
+	}
+
+	return getResp.GetPayload().Secret, nil
+}

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_app.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_app.go
@@ -106,8 +106,20 @@ func (d *DataSourceVaultSecretsApp) Read(ctx context.Context, req datasource.Rea
 
 	openAppSecrets := map[string]string{}
 	for _, appSecret := range appSecrets {
-		secretName := appSecret.Name
-		openAppSecrets[secretName] = appSecret.Version.Value
+		switch {
+		case appSecret.StaticVersion != nil:
+			openAppSecrets[appSecret.Name] = appSecret.StaticVersion.Value
+		case appSecret.RotatingVersion != nil:
+			for name, value := range appSecret.RotatingVersion.Values {
+				openAppSecrets[appSecret.Name+"_"+name] = value
+			}
+		default:
+			resp.Diagnostics.AddError(
+				"Unsupported HCP Secret type",
+				fmt.Sprintf("HCP Secrets secret type %q is not currently supported by terraform-provider-hcp", appSecret.Type),
+			)
+			return
+		}
 	}
 
 	data.ID = data.AppName

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_secret.go
@@ -109,8 +109,8 @@ func (d *DataSourceVaultSecretsSecret) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	// NOTE: for backwards compatibility purposes, if the secret is not a static secret (aka a string)
-	// encode the complex secret as a json string
+	// NOTE: for backwards compatibility purposes, if the secret is not a static secret (a string)
+	// encode the complex secret as a JSON string
 	var secretValue string
 	switch {
 	case openSecret.StaticVersion != nil:

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_secret.go
@@ -121,6 +121,10 @@ func (d *DataSourceVaultSecretsSecret) Read(ctx context.Context, req datasource.
 			resp.Diagnostics.AddError(err.Error(), "could not encode rotating secret as json")
 			return
 		}
+		resp.Diagnostics.AddWarning(
+			"HCP Vault Secrets mismatched type",
+			"Attempted to get a rotating secret in a KV secret data source, encoding the secret values as JSON",
+		)
 		secretValue = string(secretData)
 	default:
 		resp.Diagnostics.AddError(

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_secret.go
@@ -5,6 +5,7 @@ package vaultsecrets
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
@@ -31,11 +32,11 @@ func NewVaultSecretsSecretDataSource() datasource.DataSource {
 	return &DataSourceVaultSecretsSecret{}
 }
 
-func (d *DataSourceVaultSecretsSecret) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *DataSourceVaultSecretsSecret) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_vault_secrets_secret"
 }
 
-func (d *DataSourceVaultSecretsSecret) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataSourceVaultSecretsSecret) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "The Vault Secrets secret data source retrieves a singular secret and its latest version.",
 		Attributes: map[string]schema.Attribute{
@@ -107,7 +108,27 @@ func (d *DataSourceVaultSecretsSecret) Read(ctx context.Context, req datasource.
 		resp.Diagnostics.AddError(err.Error(), "Unable to open secret")
 		return
 	}
-	secretValue := openSecret.Version.Value
+
+	// NOTE: for backwards compatibility purposes, if the secret is not a static secret (aka a string)
+	// encode the complex secret as a json string
+	var secretValue string
+	switch {
+	case openSecret.StaticVersion != nil:
+		secretValue = openSecret.StaticVersion.Value
+	case openSecret.RotatingVersion != nil:
+		secretData, err := json.Marshal(openSecret.RotatingVersion.Values)
+		if err != nil {
+			resp.Diagnostics.AddError(err.Error(), "could not encode rotating secret as json")
+			return
+		}
+		secretValue = string(secretData)
+	default:
+		resp.Diagnostics.AddError(
+			"Unsupported HCP Secret type",
+			fmt.Sprintf("HCP Secrets secret type %q is not currently supported by terraform-provider-hcp", openSecret.Type),
+		)
+		return
+	}
 
 	data.ID = data.AppName
 	data.SecretValue = types.StringValue(secretValue)

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
@@ -175,7 +175,9 @@ func (r *resourceVaultsecretsSecret) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	state.SecretValue = types.StringValue(res.Version.Value)
+	// TODO: so the resource can only create a static secret,
+	// what happens when a user tries to import a rotating/other type of secret?
+	state.SecretValue = types.StringValue(res.StaticVersion.Value)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
Allows users to fetch rotating secrets using the `hcp_vault_secrets_app` and `hcp_vault_secrets_secret` data sources

#### hcp_vault_secrets_app
`hcp_vault_secrets_app`: keys from complex (rotating) secrets are concatenated in the same pattern we've been using
 
Given these secrets 
![image](https://github.com/hashicorp/terraform-provider-hcp/assets/5751944/006559c9-cda9-4ac2-8aa9-2f6c908edb56)
with
```hcl
data "hcp_vault_secrets_app" "example" {
  app_name = "sample-app"
}

output "all-secrets" {
  value = data.hcp_vault_secrets_app.example.secrets
  sensitive = true
}
```
gives (secret values print out to stdout successfully, am not including here)
```
❯ terraform output all-secrets
tomap({
  "READ_ME" = ***
  "Step1" = ***
  "Step2" = ***
  "Step3" = ***
  "mongodb_atlas_password" = ***
  "mongodb_atlas_username" = ***
})
```

#### hcp_vault_secrets_secret
For backwards compatibility in the `hcp_vault_secrets_secret`, any rotating secret will be JSON encoded
using the same secrets setup above in the portal
```hcl
data "hcp_vault_secrets_secret" "rotating" {
  app_name    = "sample-app"
  secret_name = "mongodb_atlas"
}

output "rotating-secret" {
  value = data.hcp_vault_secrets_secret.rotating.secret_value
  sensitive = true
}
``` 
gives
```
❯ terraform output rotating-secret
"{\"password\":\"***\",\"username\":\"***\"}"
```
Because the user may not expect a json payload we emit a warning
<img width="790" alt="image" src="https://github.com/hashicorp/terraform-provider-hcp/assets/5751944/91207106-1b03-4a9c-bf9d-3610aa188fcd">


 

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
