### PR TITLE
update github.com/hashicorp/hcp-sdk-go

### DIFF
--- a/.changelog/855.txt
+++ b/.changelog/855.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update `hcp-sdk-go` to v0.98.0
+```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcp-sdk-go v0.97.0
+	github.com/hashicorp/hcp-sdk-go v0.98.0
 	github.com/hashicorp/terraform-plugin-docs v0.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,6 @@ github.com/hashicorp/hc-install v0.6.2 h1:V1k+Vraqz4olgZ9UzKiAcbman9i9scg9GgSt/U
 github.com/hashicorp/hc-install v0.6.2/go.mod h1:2JBpd+NCFKiHiu/yYCGaPyPHhZLxXTpz8oreHa/a3Ps=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.97.0 h1:+nYq13t2Wn6c0M4FpqJXmzMyFvBRqW32iAz2xlZnscE=
-github.com/hashicorp/hcp-sdk-go v0.97.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/hcp-sdk-go v0.98.0 h1:DKLbGJcP9tCR4EBme6npvcigcRuvma6WCyH1ApZuNaU=
 github.com/hashicorp/hcp-sdk-go v0.98.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5R
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/hcp-sdk-go v0.97.0 h1:+nYq13t2Wn6c0M4FpqJXmzMyFvBRqW32iAz2xlZnscE=
 github.com/hashicorp/hcp-sdk-go v0.97.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.98.0 h1:DKLbGJcP9tCR4EBme6npvcigcRuvma6WCyH1ApZuNaU=
+github.com/hashicorp/hcp-sdk-go v0.98.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.20.0 h1:DIZnPsqzPGuUnq6cH8jWcPunBfY+C+M8JyYF3vpnuEo=


### PR DESCRIPTION
updates github.com/hashicorp/hcp-sdk-go

particularly adds additional api endpoints for the vault secrets sdk