### PR TITLE
Waypoint: Remove module version

### DIFF
--- a/.changelog/869.txt
+++ b/.changelog/869.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+waypoint: Remove version number from templates and add-on definition resources and data sources.
+```

--- a/docs/data-sources/waypoint_add_on.md
+++ b/docs/data-sources/waypoint_add_on.md
@@ -34,7 +34,7 @@ The Waypoint Add-on data source retrieves information on a given Add-on.
 - `readme_markdown` (String) Instructions for using the Add-on (markdown format supported).
 - `status` (Number) The status of the Terraform run for the Add-on.
 - `summary` (String) A short summary of the Add-on.
-- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module_source` (String) The Terraform module source for the Add-on.
 
 <a id="nestedatt--input_variables"></a>
 ### Nested Schema for `input_variables`
@@ -55,12 +55,3 @@ Read-Only:
 - `sensitive` (Boolean) Whether the output value is sensitive.
 - `type` (String) The type of the output value.
 - `value` (String) The value of the output value.
-
-
-<a id="nestedatt--terraform_no_code_module"></a>
-### Nested Schema for `terraform_no_code_module`
-
-Read-Only:
-
-- `source` (String) Terraform Cloud no-code Module Source
-- `version` (String) Terraform Cloud no-code Module Version

--- a/docs/data-sources/waypoint_template.md
+++ b/docs/data-sources/waypoint_template.md
@@ -28,7 +28,7 @@ The Waypoint Template data source retrieves information on a given Template.
 - `readme_markdown_template` (String) Instructions for using the template (markdown format supported)
 - `summary` (String) A brief description of the template, up to 110 characters
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
-- `terraform_no_code_module` (Attributes) Terraform Cloud No-Code Module details (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module_source` (Attributes) Terraform No Code Module source (see [below for nested schema](#nestedatt--terraform_no_code_module_source))
 - `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 <a id="nestedatt--terraform_cloud_workspace_details"></a>
@@ -40,13 +40,8 @@ Read-Only:
 - `terraform_project_id` (String) Terraform Cloud Project ID
 
 
-<a id="nestedatt--terraform_no_code_module"></a>
-### Nested Schema for `terraform_no_code_module`
-
-Read-Only:
-
-- `source` (String) No-Code Module Source
-- `version` (String) No-Code Module Version
+<a id="nestedatt--terraform_no_code_module_source"></a>
+### Nested Schema for `terraform_no_code_module_source`
 
 
 <a id="nestedatt--variable_options"></a>

--- a/docs/resources/waypoint_add_on.md
+++ b/docs/resources/waypoint_add_on.md
@@ -38,7 +38,7 @@ Waypoint Add-on resource
 - `readme_markdown` (String) The markdown for the Add-on README.
 - `status` (Number) The status of the Terraform run for the Add-on.
 - `summary` (String) A short summary of the Add-on.
-- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module_source` (String) The Terraform No Code Module source for the Add-on.
 
 <a id="nestedatt--add_on_input_variables"></a>
 ### Nested Schema for `add_on_input_variables`
@@ -72,12 +72,3 @@ Read-Only:
 - `sensitive` (Boolean) Whether the output value is sensitive.
 - `type` (String) The type of the output value.
 - `value` (String) The value of the output value.
-
-
-<a id="nestedatt--terraform_no_code_module"></a>
-### Nested Schema for `terraform_no_code_module`
-
-Read-Only:
-
-- `source` (String) Terraform Cloud no-code Module Source
-- `version` (String) Terraform Cloud no-code Module Version

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -19,7 +19,7 @@ Waypoint Add-on Definition resource
 - `description` (String) A longer description of the Add-on Definition.
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
-- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module_source` (String) Terraform Cloud no-code Module Source, expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws"
 
 ### Optional
 
@@ -33,15 +33,6 @@ Waypoint Add-on Definition resource
 
 - `id` (String) The ID of the Add-on Definition.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Add-on Definition is located.
-
-<a id="nestedatt--terraform_no_code_module"></a>
-### Nested Schema for `terraform_no_code_module`
-
-Required:
-
-- `source` (String) Terraform Cloud no-code Module Source , expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws"
-- `version` (String) Terraform Cloud no-code Module Version
-
 
 <a id="nestedatt--terraform_cloud_workspace_details"></a>
 ### Nested Schema for `terraform_cloud_workspace_details`

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -19,7 +19,7 @@ Waypoint Template resource
 - `name` (String) The name of the Template.
 - `summary` (String) A brief description of the template, up to 110 characters
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
-- `terraform_no_code_module` (Attributes) Terraform Cloud No-Code Module details (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module_source` (String) Terraform Cloud No-Code Module details
 
 ### Optional
 
@@ -41,15 +41,6 @@ Required:
 
 - `name` (String) Name of the Terraform Cloud Project
 - `terraform_project_id` (String) Terraform Cloud Project ID
-
-
-<a id="nestedatt--terraform_no_code_module"></a>
-### Nested Schema for `terraform_no_code_module`
-
-Required:
-
-- `source` (String) No-Code Module Source
-- `version` (String) No-Code Module Version
 
 
 <a id="nestedatt--variable_options"></a>

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -44,9 +44,9 @@ type DataSourceAddOnDefinitionModel struct {
 	Description            types.String `tfsdk:"description"`
 	ReadmeMarkdownTemplate types.String `tfsdk:"readme_markdown_template"`
 
-	TerraformCloudWorkspace  *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
-	TerraformNoCodeModule    *tfcNoCodeModule     `tfsdk:"terraform_no_code_module"`
-	TerraformVariableOptions []*tfcVariableOption `tfsdk:"variable_options"`
+	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
+	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
+	TerraformVariableOptions    []*tfcVariableOption `tfsdk:"variable_options"`
 }
 
 func NewAddOnDefinitionDataSource() datasource.DataSource {
@@ -210,6 +210,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 	state.OrgID = types.StringValue(client.Config.OrganizationID)
 	state.ProjectID = types.StringValue(client.Config.ProjectID)
 	state.Summary = types.StringValue(definition.Summary)
+	state.Description = types.StringValue(definition.Description)
 
 	if definition.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{
@@ -217,14 +218,6 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 			TerraformProjectID: types.StringValue(definition.TerraformCloudWorkspaceDetails.ProjectID),
 		}
 		state.TerraformCloudWorkspace = tfcWorkspace
-	}
-
-	if definition.TerraformNocodeModule != nil {
-		tfcNoCode := &tfcNoCodeModule{
-			Source:  types.StringValue(definition.TerraformNocodeModule.Source),
-			Version: types.StringValue(definition.TerraformNocodeModule.Version),
-		}
-		state.TerraformNoCodeModule = tfcNoCode
 	}
 
 	labels, diags := types.ListValueFrom(ctx, types.StringType, definition.Labels)

--- a/internal/provider/waypoint/data_source_waypoint_template.go
+++ b/internal/provider/waypoint/data_source_waypoint_template.go
@@ -44,9 +44,9 @@ type DataSourceTemplateModel struct {
 	Description            types.String `tfsdk:"description"`
 	ReadmeMarkdownTemplate types.String `tfsdk:"readme_markdown_template"`
 
-	TerraformCloudWorkspace *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
-	TerraformNoCodeModule   *tfcNoCodeModule     `tfsdk:"terraform_no_code_module"`
-	VariableOptions         []*tfcVariableOption `tfsdk:"variable_options"`
+	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
+	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
+	VariableOptions             []*tfcVariableOption `tfsdk:"variable_options"`
 }
 
 func NewTemplateDataSource() datasource.DataSource {
@@ -111,19 +111,9 @@ func (d *DataSourceTemplate) Schema(ctx context.Context, req datasource.SchemaRe
 					},
 				},
 			},
-			"terraform_no_code_module": &schema.SingleNestedAttribute{
+			"terraform_no_code_module_source": &schema.SingleNestedAttribute{
 				Computed:    true,
-				Description: "Terraform Cloud No-Code Module details",
-				Attributes: map[string]schema.Attribute{
-					"source": &schema.StringAttribute{
-						Computed:    true,
-						Description: "No-Code Module Source",
-					},
-					"version": &schema.StringAttribute{
-						Computed:    true,
-						Description: "No-Code Module Version",
-					},
-				},
+				Description: "Terraform No Code Module source",
 			},
 			"variable_options": schema.ListNestedAttribute{
 				Computed:    true,
@@ -210,6 +200,7 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 	data.OrgID = types.StringValue(client.Config.OrganizationID)
 	data.ProjectID = types.StringValue(client.Config.ProjectID)
 	data.Summary = types.StringValue(appTemplate.Summary)
+	data.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
 	if appTemplate.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{
@@ -217,14 +208,6 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 			TerraformProjectID: types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID),
 		}
 		data.TerraformCloudWorkspace = tfcWorkspace
-	}
-
-	if appTemplate.TerraformNocodeModule != nil {
-		tfcNoCode := &tfcNoCodeModule{
-			Source:  types.StringValue(appTemplate.TerraformNocodeModule.Source),
-			Version: types.StringValue(appTemplate.TerraformNocodeModule.Version),
-		}
-		data.TerraformNoCodeModule = tfcNoCode
 	}
 
 	data.VariableOptions, err = readVarOpts(ctx, appTemplate.VariableOptions, &resp.Diagnostics)

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -53,7 +53,7 @@ type AddOnResourceModel struct {
 	DefinitionID   types.String `tfsdk:"definition_id"`
 	OutputValues   types.List   `tfsdk:"output_values"`
 
-	TerraformNoCodeModule types.Object `tfsdk:"terraform_no_code_module"`
+	TerraformNoCodeModuleSource types.String `tfsdk:"terraform_no_code_module_source"`
 
 	InputVars                types.Set `tfsdk:"add_on_input_variables"`
 	AddOnDefinitionInputVars types.Set `tfsdk:"add_on_definition_input_variables"`
@@ -72,13 +72,6 @@ func (o outputValue) attrTypes() map[string]attr.Type {
 		"type":      types.StringType,
 		"value":     types.StringType,
 		"sensitive": types.BoolType,
-	}
-}
-
-func (r tfcNoCodeModule) attrTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"source":  types.StringType,
-		"version": types.StringType,
 	}
 }
 
@@ -148,19 +141,9 @@ func (r *AddOnResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					"Add-on Definition.",
 				Computed: true,
 			},
-			"terraform_no_code_module": &schema.SingleNestedAttribute{
+			"terraform_no_code_module_source": schema.StringAttribute{
+				Description: "The Terraform No Code Module source for the Add-on.",
 				Computed:    true,
-				Description: "Terraform Cloud no-code Module details.",
-				Attributes: map[string]schema.Attribute{
-					"source": &schema.StringAttribute{
-						Computed:    true,
-						Description: "Terraform Cloud no-code Module Source",
-					},
-					"version": &schema.StringAttribute{
-						Computed:    true,
-						Description: "Terraform Cloud no-code Module Version",
-					},
-				},
 			},
 			"definition_id": schema.StringAttribute{
 				Required:    true,
@@ -391,8 +374,9 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.ProjectID = types.StringValue(projectID)
 	plan.OrgID = types.StringValue(orgID)
 	plan.Summary = types.StringValue(addOn.Summary)
-
 	plan.Description = types.StringValue(addOn.Description)
+	plan.TerraformNoCodeModuleSource = types.StringValue(addOn.TerraformNocodeModule.Source)
+
 	// set plan.description if it's not null or addOn.description is not empty
 	if addOn.Description == "" {
 		plan.Description = types.StringNull()
@@ -409,21 +393,6 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 	plan.Labels = labels
-
-	if addOn.TerraformNocodeModule != nil {
-		tfcNoCode := &tfcNoCodeModule{}
-		if addOn.TerraformNocodeModule.Source != "" {
-			tfcNoCode.Source = types.StringValue(addOn.TerraformNocodeModule.Source)
-		}
-		if addOn.TerraformNocodeModule.Version != "" {
-			tfcNoCode.Version = types.StringValue(addOn.TerraformNocodeModule.Version)
-		}
-		plan.TerraformNoCodeModule, diags = types.ObjectValueFrom(ctx, tfcNoCode.attrTypes(), tfcNoCode)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
 
 	// Display the reference to the Definition in the plan
 	if addOn.Definition != nil {
@@ -557,6 +526,7 @@ func (r *AddOnResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.ProjectID = types.StringValue(projectID)
 	state.OrgID = types.StringValue(orgID)
 	state.Summary = types.StringValue(addOn.Summary)
+	state.TerraformNoCodeModuleSource = types.StringValue(addOn.TerraformNocodeModule.Source)
 
 	state.Description = types.StringValue(addOn.Description)
 	// set plan.description if it's not null or addOn.description is not empty
@@ -575,18 +545,6 @@ func (r *AddOnResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 	state.Labels = labels
-
-	if addOn.TerraformNocodeModule != nil {
-		tfcNoCode := &tfcNoCodeModule{
-			Source:  types.StringValue(addOn.TerraformNocodeModule.Source),
-			Version: types.StringValue(addOn.TerraformNocodeModule.Version),
-		}
-		state.TerraformNoCodeModule, diags = types.ObjectValueFrom(ctx, tfcNoCode.attrTypes(), tfcNoCode)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
 
 	state.CreatedBy = types.StringValue(addOn.CreatedBy)
 
@@ -719,6 +677,7 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	plan.ProjectID = types.StringValue(projectID)
 	plan.OrgID = types.StringValue(orgID)
 	plan.Summary = types.StringValue(addOn.Summary)
+	plan.TerraformNoCodeModuleSource = types.StringValue(addOn.TerraformNocodeModule.Source)
 
 	plan.Description = types.StringValue(addOn.Description)
 	// set plan.description if it's not null or addOn.description is not empty
@@ -737,18 +696,6 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 	plan.Labels = labels
-
-	if addOn.TerraformNocodeModule != nil {
-		tfcNoCode := &tfcNoCodeModule{
-			Source:  types.StringValue(addOn.TerraformNocodeModule.Source),
-			Version: types.StringValue(addOn.TerraformNocodeModule.Version),
-		}
-		plan.TerraformNoCodeModule, diags = types.ObjectValueFrom(ctx, tfcNoCode.attrTypes(), tfcNoCode)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
 
 	// Display the reference to the Definition in the plan
 	if addOn.Definition != nil {

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -303,7 +303,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 	plan.Name = types.StringValue(addOnDefinition.Name)
 	plan.OrgID = types.StringValue(orgID)
 	plan.Summary = types.StringValue(addOnDefinition.Summary)
-	plan.TerraformNoCodeModuleSource = types.StringValue(addOnDefinition.TerraformNocodeModule.Source)
+	plan.TerraformNoCodeModuleSource = types.StringValue(addOnDefinition.ModuleSource)
 
 	plan.Description = types.StringValue(addOnDefinition.Description)
 	// set plan.description if it's not null or addOnDefinition.description is not empty
@@ -388,7 +388,7 @@ func (r *AddOnDefinitionResource) Read(ctx context.Context, req resource.ReadReq
 	state.OrgID = types.StringValue(client.Config.OrganizationID)
 	state.ProjectID = types.StringValue(client.Config.ProjectID)
 	state.Summary = types.StringValue(definition.Summary)
-	state.TerraformNoCodeModuleSource = types.StringValue(definition.TerraformNocodeModule.Source)
+	state.TerraformNoCodeModuleSource = types.StringValue(definition.ModuleSource)
 
 	state.Description = types.StringValue(definition.Description)
 	// set plan.description if it's not null or addOnDefinition.description is not empty
@@ -548,7 +548,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 	plan.Name = types.StringValue(addOnDefinition.Name)
 	plan.OrgID = types.StringValue(orgID)
 	plan.Summary = types.StringValue(addOnDefinition.Summary)
-	plan.TerraformNoCodeModuleSource = types.StringValue(addOnDefinition.TerraformNocodeModule.Source)
+	plan.TerraformNoCodeModuleSource = types.StringValue(addOnDefinition.ModuleSource)
 
 	plan.Description = types.StringValue(addOnDefinition.Description)
 	// set plan.description if it's not null or addOnDefinition.description is not empty

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -142,10 +142,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
   name    = %q
   summary = "some summary for fun"
   description = "some description for fun"
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.3"
-  }
+  terraform_no_code_module = "private/waypoint-tfc-testing/waypoint-template-starter/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"

--- a/internal/provider/waypoint/resource_waypoint_add_on_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_test.go
@@ -190,10 +190,7 @@ resource "hcp_waypoint_template" "test" {
   name    = "%s"
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -210,10 +207,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
   name    = "%s"
   summary = "some summary for fun"
   description = "some description for fun"
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -233,10 +227,7 @@ resource "hcp_waypoint_template" "test" {
   name    = "%s"
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -254,10 +245,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   summary = "some summary for fun"
   description = "some description for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-    version = "0.0.1"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -318,10 +306,7 @@ resource "hcp_waypoint_template" "test" {
   name    = "%s"
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -339,10 +324,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   summary     = "some summary for fun"
   description = "some description"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-    version = "0.0.1"
-  }
+  terraform_no_code_module = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"

--- a/internal/provider/waypoint/resource_waypoint_application_test.go
+++ b/internal/provider/waypoint/resource_waypoint_application_test.go
@@ -215,10 +215,7 @@ resource "hcp_waypoint_template" "test_var_opts" {
   name    = "%s"
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-    version = "0.0.1"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -276,10 +273,7 @@ resource "hcp_waypoint_template" "test_var_opts" {
   name    = "%s"
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-    version = "0.0.1"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -311,7 +311,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	plan.Name = types.StringValue(appTemplate.Name)
 	plan.OrgID = types.StringValue(orgID)
 	plan.Summary = types.StringValue(appTemplate.Summary)
-	plan.TerraformNoCodeModuleSource = types.StringValue(appTemplate.TerraformNocodeModule.Source)
+	plan.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
 	if appTemplate.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{
@@ -426,7 +426,7 @@ func (r *TemplateResource) Read(ctx context.Context, req resource.ReadRequest, r
 	data.OrgID = types.StringValue(client.Config.OrganizationID)
 	data.ProjectID = types.StringValue(client.Config.ProjectID)
 	data.Summary = types.StringValue(appTemplate.Summary)
-	data.TerraformNoCodeModuleSource = types.StringValue(appTemplate.TerraformNocodeModule.Source)
+	data.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
 	if appTemplate.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{
@@ -573,7 +573,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	plan.Name = types.StringValue(appTemplate.Name)
 	plan.OrgID = types.StringValue(orgID)
 	plan.Summary = types.StringValue(appTemplate.Summary)
-	plan.TerraformNoCodeModuleSource = types.StringValue(appTemplate.TerraformNocodeModule.Source)
+	plan.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
 	labels, diags := types.ListValueFrom(ctx, types.StringType, appTemplate.Labels)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -157,10 +157,7 @@ resource "hcp_waypoint_template" "test" {
   name                     = "%s"
   summary                  = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -175,10 +172,7 @@ resource "hcp_waypoint_template" "var_opts_test" {
   name                     = "%s"
   summary                  = "A template with a variable with options."
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-    version = "0.0.1"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"


### PR DESCRIPTION
The version of a no-code module is being removed from Waypoint templates and add-ons. The pinned version for a no-code module in HCP TF will be used at provision time.