### PR TITLE
HCP Waypoint Application resource and data source reads output values

### DIFF
--- a/.changelog/871.txt
+++ b/.changelog/871.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+HCP Waypoint Application resource and data source can now read any output values associated with that application
+```

--- a/docs/data-sources/waypoint_add_on.md
+++ b/docs/data-sources/waypoint_add_on.md
@@ -29,7 +29,7 @@ The Waypoint Add-on data source retrieves information on a given Add-on.
 - `install_count` (Number) The number of installed Add-ons for the same Application that share the same Add-on Definition.
 - `labels` (List of String) List of labels attached to this Add-on.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint AddOn is located.
-- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
+- `output_values` (Attributes List) The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `project_id` (String) The ID of the HCP project where the Waypoint AddOn is located.
 - `readme_markdown` (String) Instructions for using the Add-on (markdown format supported).
 - `status` (Number) The status of the Terraform run for the Add-on.

--- a/docs/data-sources/waypoint_application.md
+++ b/docs/data-sources/waypoint_application.md
@@ -25,6 +25,7 @@ The Waypoint Application data source retrieves information on a given Applicatio
 
 - `namespace_id` (String) Internal Namespace ID.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Application is located.
+- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `readme_markdown` (String) Instructions for using the Application (markdown format supported).
 - `template_id` (String) ID of the Template this Application is based on.
 - `template_name` (String) Name of the Template this Application is based on.
@@ -37,3 +38,14 @@ Read-Only:
 - `name` (String) Variable name
 - `value` (String) Variable value
 - `variable_type` (String) Variable type
+
+
+<a id="nestedatt--output_values"></a>
+### Nested Schema for `output_values`
+
+Read-Only:
+
+- `name` (String) The name of the output value.
+- `sensitive` (Boolean) Whether the output value is sensitive.
+- `type` (String) The type of the output value.
+- `value` (String) The value of the output value.

--- a/docs/data-sources/waypoint_application.md
+++ b/docs/data-sources/waypoint_application.md
@@ -25,7 +25,7 @@ The Waypoint Application data source retrieves information on a given Applicatio
 
 - `namespace_id` (String) Internal Namespace ID.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Application is located.
-- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, Sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
+- `output_values` (Attributes List) The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, Sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `readme_markdown` (String) Instructions for using the Application (markdown format supported).
 - `template_id` (String) ID of the Template this Application is based on.
 - `template_name` (String) Name of the Template this Application is based on.

--- a/docs/data-sources/waypoint_application.md
+++ b/docs/data-sources/waypoint_application.md
@@ -25,7 +25,7 @@ The Waypoint Application data source retrieves information on a given Applicatio
 
 - `namespace_id` (String) Internal Namespace ID.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Application is located.
-- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
+- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, Sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `readme_markdown` (String) Instructions for using the Application (markdown format supported).
 - `template_id` (String) ID of the Template this Application is based on.
 - `template_name` (String) Name of the Template this Application is based on.
@@ -46,6 +46,6 @@ Read-Only:
 Read-Only:
 
 - `name` (String) The name of the output value.
-- `sensitive` (Boolean) Whether the output value is sensitive.
+- `sensitive` (Boolean) Whether the output value is Sensitive.
 - `type` (String) The type of the output value.
 - `value` (String) The value of the output value.

--- a/docs/resources/waypoint_add_on.md
+++ b/docs/resources/waypoint_add_on.md
@@ -34,7 +34,7 @@ Waypoint Add-on resource
 - `install_count` (Number) The number of installed Add-ons for the same Application that share the same Add-on Definition.
 - `labels` (List of String) List of labels attached to this Add-on.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint AddOn is located.
-- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
+- `output_values` (Attributes List) The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `readme_markdown` (String) The markdown for the Add-on README.
 - `status` (Number) The status of the Terraform run for the Add-on.
 - `summary` (String) A short summary of the Add-on.

--- a/docs/resources/waypoint_application.md
+++ b/docs/resources/waypoint_application.md
@@ -30,7 +30,7 @@ The Waypoint Application resource managed the lifecycle of an Application that's
 - `id` (String) The ID of the Application.
 - `namespace_id` (String) Internal Namespace ID.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Application is located.
-- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
+- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, Sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `template_input_variables` (Attributes Set) Input variables set for the application. (see [below for nested schema](#nestedatt--template_input_variables))
 - `template_name` (String) Name of the Template this Application is based on.
 
@@ -50,7 +50,7 @@ Required:
 Read-Only:
 
 - `name` (String) The name of the output value.
-- `sensitive` (Boolean) Whether the output value is sensitive.
+- `sensitive` (Boolean) Whether the output value is Sensitive.
 - `type` (String) The type of the output value.
 - `value` (String) The value of the output value.
 

--- a/docs/resources/waypoint_application.md
+++ b/docs/resources/waypoint_application.md
@@ -30,6 +30,7 @@ The Waypoint Application resource managed the lifecycle of an Application that's
 - `id` (String) The ID of the Application.
 - `namespace_id` (String) Internal Namespace ID.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Application is located.
+- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `template_input_variables` (Attributes Set) Input variables set for the application. (see [below for nested schema](#nestedatt--template_input_variables))
 - `template_name` (String) Name of the Template this Application is based on.
 
@@ -41,6 +42,17 @@ Required:
 - `name` (String) Variable name
 - `value` (String) Variable value
 - `variable_type` (String) Variable type
+
+
+<a id="nestedatt--output_values"></a>
+### Nested Schema for `output_values`
+
+Read-Only:
+
+- `name` (String) The name of the output value.
+- `sensitive` (Boolean) Whether the output value is sensitive.
+- `type` (String) The type of the output value.
+- `value` (String) The value of the output value.
 
 
 <a id="nestedatt--template_input_variables"></a>

--- a/docs/resources/waypoint_application.md
+++ b/docs/resources/waypoint_application.md
@@ -30,7 +30,7 @@ The Waypoint Application resource managed the lifecycle of an Application that's
 - `id` (String) The ID of the Application.
 - `namespace_id` (String) Internal Namespace ID.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Application is located.
-- `output_values` (Attributes List) The output values of the Terraform run for the Add-on, Sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
+- `output_values` (Attributes List) The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, Sensitive values have type and value omitted. (see [below for nested schema](#nestedatt--output_values))
 - `template_input_variables` (Attributes Set) Input variables set for the application. (see [below for nested schema](#nestedatt--template_input_variables))
 - `template_name` (String) Name of the Template this Application is based on.
 

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -315,6 +315,7 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 	} else {
 		state.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
 	}
+
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -141,7 +141,7 @@ func (d *DataSourceAddOn) Schema(ctx context.Context, req datasource.SchemaReque
 			},
 			"output_values": schema.ListNestedAttribute{
 				Computed: true,
-				Description: "The output values of the Terraform run for the Add-on, sensitive values have type " +
+				Description: "The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, sensitive values have type " +
 					"and value omitted.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/waypoint/data_source_waypoint_application.go
+++ b/internal/provider/waypoint/data_source_waypoint_application.go
@@ -103,7 +103,7 @@ func (d *DataSourceApplication) Schema(ctx context.Context, req datasource.Schem
 			},
 			"output_values": schema.ListNestedAttribute{
 				Computed: true,
-				Description: "The output values of the Terraform run for the Add-on, Sensitive values have type " +
+				Description: "The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, Sensitive values have type " +
 					"and value omitted.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/waypoint/data_source_waypoint_application.go
+++ b/internal/provider/waypoint/data_source_waypoint_application.go
@@ -103,7 +103,7 @@ func (d *DataSourceApplication) Schema(ctx context.Context, req datasource.Schem
 			},
 			"output_values": schema.ListNestedAttribute{
 				Computed: true,
-				Description: "The output values of the Terraform run for the Add-on, sensitive values have type " +
+				Description: "The output values of the Terraform run for the Add-on, Sensitive values have type " +
 					"and value omitted.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -121,7 +121,7 @@ func (d *DataSourceApplication) Schema(ctx context.Context, req datasource.Schem
 						},
 						"sensitive": schema.BoolAttribute{
 							Computed:    true,
-							Description: "Whether the output value is sensitive.",
+							Description: "Whether the output value is Sensitive.",
 						},
 					},
 				},

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -463,6 +463,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 	} else {
 		plan.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
 	}
+
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -625,6 +626,7 @@ func (r *AddOnResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	} else {
 		state.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
 	}
+
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -786,6 +788,7 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	} else {
 		plan.OutputValues = types.ListNull(types.ObjectType{AttrTypes: outputValue{}.attrTypes()})
 	}
+
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -176,7 +176,7 @@ func (r *AddOnResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"output_values": schema.ListNestedAttribute{
 				Computed: true,
-				Description: "The output values of the Terraform run for the Add-on, sensitive values have type " +
+				Description: "The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, sensitive values have type " +
 					"and value omitted.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -853,6 +853,8 @@ func (r *AddOnResource) ImportState(ctx context.Context, req resource.ImportStat
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+// readOutputs accepts a list of output values in the type returned by the Waypoint API and returns a list of output
+// values in the custom outputValue type used in this provider
 func readOutputs(ovs []*waypoint_models.HashicorpCloudWaypointTFOutputValue) []*outputValue {
 	ol := make([]*outputValue, len(ovs))
 	for i, ov := range ovs {

--- a/internal/provider/waypoint/resource_waypoint_application.go
+++ b/internal/provider/waypoint/resource_waypoint_application.go
@@ -192,7 +192,7 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"output_values": schema.ListNestedAttribute{
 				Computed: true,
-				Description: "The output values of the Terraform run for the Add-on, sensitive values have type " +
+				Description: "The output values of the Terraform run for the Add-on, Sensitive values have type " +
 					"and value omitted.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -210,7 +210,7 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 						},
 						"sensitive": schema.BoolAttribute{
 							Computed:    true,
-							Description: "Whether the output value is sensitive.",
+							Description: "Whether the output value is Sensitive.",
 						},
 					},
 				},

--- a/internal/provider/waypoint/resource_waypoint_application.go
+++ b/internal/provider/waypoint/resource_waypoint_application.go
@@ -192,7 +192,7 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"output_values": schema.ListNestedAttribute{
 				Computed: true,
-				Description: "The output values of the Terraform run for the Add-on, Sensitive values have type " +
+				Description: "The output values, stored by HCP Waypoint, of the Terraform run for the Add-on, Sensitive values have type " +
 					"and value omitted.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
This is a small addition to the existing HCP Waypoint Application resource and data source to allow both to read any output values that may be returned when getting an Application.

Output from acceptance testing:

```sh
$ make testacc TESTARGS='-run=TestAccWaypoint_Application'
=== RUN   TestAccWaypoint_Application_basic
--- PASS: TestAccWaypoint_Application_basic (9.31s)
=== RUN   TestAccWaypoint_Application_DataSource_basic
--- PASS: TestAccWaypoint_Application_DataSource_basic (16.14s)
=== RUN   TestAccWaypoint_Application_DataSource_WithInputVars
--- PASS: TestAccWaypoint_Application_DataSource_WithInputVars (17.89s)
...
```
