### PR TITLE
HCP Waypoint Readme update to accept unencoded strings

### DIFF
--- a/.changelog/894.txt
+++ b/.changelog/894.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+waypoint: The `readme_markdown_template` attribute for both template and add-on definition resources now accepts unencoded strings as well as base64 encoded strings.
+```

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -20,13 +20,13 @@ Waypoint Add-on Definition resource
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
-- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. Refer to https://developer.hashicorp.com/terraform/language/modules/sources for more details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
 
 ### Optional
 
 - `labels` (List of String) List of labels attached to this Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
-- `readme_markdown_template` (String) The markdown template for the Add-on Definition README.
+- `readme_markdown_template` (String) The markdown template for the Add-on Definition README. Must be base 64 encoded.
 - `variable_options` (Attributes Set) List of variable options for the Add-on Definition. (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
@@ -39,8 +39,8 @@ Waypoint Add-on Definition resource
 
 Required:
 
-- `name` (String) Name of the Terraform Cloud Workspace
-- `terraform_project_id` (String) Tetraform Cloud Project ID
+- `name` (String) Name of the Terraform Cloud Project
+- `terraform_project_id` (String) Terraform Cloud Project ID
 
 
 <a id="nestedatt--terraform_no_code_module"></a>
@@ -63,4 +63,4 @@ Required:
 
 Optional:
 
-- `user_editable` (Boolean) Whether the variable is editable by the user creating an add-on
+- `user_editable` (Boolean) Whether the variable is editable by the user creating an add-on. If options are provided, then the user may only use those options, regardless of this setting.

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -19,20 +19,29 @@ Waypoint Add-on Definition resource
 - `description` (String) A longer description of the Add-on Definition.
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
-- `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
-- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. Refer to https://developer.hashicorp.com/terraform/language/modules/sources for more details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
+- `terraform_no_code_module` (Attributes) Terraform Cloud no-code Module details. (see [below for nested schema](#nestedatt--terraform_no_code_module))
 
 ### Optional
 
 - `labels` (List of String) List of labels attached to this Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
-- `readme_markdown_template` (String) The markdown template for the Add-on Definition README. Must be base 64 encoded.
+- `readme_markdown_template` (String) The markdown template for the Add-on Definition README (markdown format supported).
+- `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details. If not provided, defaults to the HCP Terraform project of the associated application. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `variable_options` (Attributes Set) List of variable options for the Add-on Definition. (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 
 - `id` (String) The ID of the Add-on Definition.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Add-on Definition is located.
+
+<a id="nestedatt--terraform_no_code_module"></a>
+### Nested Schema for `terraform_no_code_module`
+
+Required:
+
+- `source` (String) Terraform Cloud no-code Module Source , expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws"
+- `version` (String) Terraform Cloud no-code Module Version
+
 
 <a id="nestedatt--terraform_cloud_workspace_details"></a>
 ### Nested Schema for `terraform_cloud_workspace_details`
@@ -41,15 +50,6 @@ Required:
 
 - `name` (String) Name of the Terraform Cloud Project
 - `terraform_project_id` (String) Terraform Cloud Project ID
-
-
-<a id="nestedatt--terraform_no_code_module"></a>
-### Nested Schema for `terraform_no_code_module`
-
-Required:
-
-- `source` (String) Terraform Cloud no-code Module Source
-- `version` (String) Terraform Cloud no-code Module Version
 
 
 <a id="nestedatt--variable_options"></a>

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -26,7 +26,7 @@ Waypoint Template resource
 - `description` (String) A description of the template, along with when and why it should be used, up to 500 characters
 - `labels` (List of String) List of labels attached to this Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.
-- `readme_markdown_template` (String) Instructions for using the template (markdown format supported
+- `readme_markdown_template` (String) Instructions for using the template (markdown format supported). Must be base 64 encoded.
 - `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
@@ -39,7 +39,7 @@ Waypoint Template resource
 
 Required:
 
-- `name` (String) Name of the Terraform Cloud Workspace
+- `name` (String) Name of the Terraform Cloud Project
 - `terraform_project_id` (String) Terraform Cloud Project ID
 
 

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -26,7 +26,7 @@ Waypoint Template resource
 - `description` (String) A description of the template, along with when and why it should be used, up to 500 characters
 - `labels` (List of String) List of labels attached to this Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.
-- `readme_markdown_template` (String) Instructions for using the template (markdown format supported). Must be base 64 encoded.
+- `readme_markdown_template` (String) Instructions for using the template (markdown format supported).
 - `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -105,7 +105,7 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 				},
 			},
 			"readme_markdown_template": schema.StringAttribute{
-				Description: "The markdown template for the Add-on Definition README.",
+				Description: "The markdown template for the Add-on Definition README. Must be base 64 encoded.",
 				Optional:    true,
 			},
 			"terraform_cloud_workspace_details": &schema.SingleNestedAttribute{
@@ -114,17 +114,18 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 				Attributes: map[string]schema.Attribute{
 					"name": &schema.StringAttribute{
 						Required:    true,
-						Description: "Name of the Terraform Cloud Workspace",
+						Description: "Name of the Terraform Cloud Project",
 					},
 					"terraform_project_id": &schema.StringAttribute{
 						Required:    true,
-						Description: "Tetraform Cloud Project ID",
+						Description: "Terraform Cloud Project ID",
 					},
 				},
 			},
 			"terraform_no_code_module": &schema.SingleNestedAttribute{
-				Required:    true,
-				Description: "Terraform Cloud no-code Module details.",
+				Required: true,
+				Description: "Terraform Cloud no-code Module details. Refer to " +
+					"https://developer.hashicorp.com/terraform/language/modules/sources for more details.",
 				Attributes: map[string]schema.Attribute{
 					"source": &schema.StringAttribute{
 						Required:    true,
@@ -155,9 +156,11 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 							Description: "List of options",
 						},
 						"user_editable": &schema.BoolAttribute{
-							Optional:    true,
-							Computed:    true,
-							Description: "Whether the variable is editable by the user creating an add-on",
+							Optional: true,
+							Computed: true,
+							Description: "Whether the variable is editable by the user creating an " +
+								"add-on. If options are provided, then the user may only use those " +
+								"options, regardless of this setting.",
 						},
 					},
 				},

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -118,7 +118,7 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"readme_markdown_template": schema.StringAttribute{
 				Optional:    true,
-				Description: "Instructions for using the template (markdown format supported",
+				Description: "Instructions for using the template (markdown format supported). Must be base 64 encoded.",
 			},
 			"labels": schema.ListAttribute{
 				// Computed:    true,
@@ -135,7 +135,7 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				Attributes: map[string]schema.Attribute{
 					"name": &schema.StringAttribute{
 						Required:    true,
-						Description: "Name of the Terraform Cloud Workspace",
+						Description: "Name of the Terraform Cloud Project",
 					},
 					"terraform_project_id": &schema.StringAttribute{
 						Required:    true,

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -58,6 +59,13 @@ type tfcWorkspace struct {
 	Name types.String `tfsdk:"name"`
 	// this refers to the project ID found in Terraform Cloud
 	TerraformProjectID types.String `tfsdk:"terraform_project_id"`
+}
+
+func (t tfcWorkspace) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":                 types.StringType,
+		"terraform_project_id": types.StringType,
+	}
 }
 
 type tfcNoCodeModule struct {
@@ -118,7 +126,7 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"readme_markdown_template": schema.StringAttribute{
 				Optional:    true,
-				Description: "Instructions for using the template (markdown format supported). Must be base 64 encoded.",
+				Description: "Instructions for using the template (markdown format supported).",
 			},
 			"labels": schema.ListAttribute{
 				// Computed:    true,
@@ -248,14 +256,6 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	readmeBytes, err := base64.StdEncoding.DecodeString(plan.ReadmeMarkdownTemplate.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error decoding the base64 file contents",
-			err.Error(),
-		)
-	}
-
 	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
@@ -274,11 +274,10 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 
 	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceCreateApplicationTemplateBody{
 		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointApplicationTemplate{
-			Name:                   plan.Name.ValueString(),
-			Summary:                plan.Summary.ValueString(),
-			Labels:                 strLabels,
-			Description:            plan.Description.ValueString(),
-			ReadmeMarkdownTemplate: readmeBytes,
+			Name:        plan.Name.ValueString(),
+			Summary:     plan.Summary.ValueString(),
+			Labels:      strLabels,
+			Description: plan.Description.ValueString(),
 			TerraformNocodeModule: &waypoint_models.HashicorpCloudWaypointTerraformNocodeModule{
 				Source:  plan.TerraformNoCodeModule.Source.ValueString(),
 				Version: plan.TerraformNoCodeModule.Version.ValueString(),
@@ -289,6 +288,18 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 			},
 			VariableOptions: varOpts,
 		},
+	}
+
+	// Decode the base64 encoded readme markdown template to see if it is encoded
+	readmeBytes, err := base64.StdEncoding.DecodeString(plan.ReadmeMarkdownTemplate.ValueString())
+	// If there is an error, we assume that it is because the string is not encoded. This is ok and
+	// we will just use the string as is in the ReadmeTemplate field of the model.
+	// Eventually the ReadMeMarkdownTemplate field will be deprecated, so the default behavior will be to
+	// expect the readme to not be encoded
+	if err != nil {
+		modelBody.ApplicationTemplate.ReadmeTemplate = plan.ReadmeMarkdownTemplate.ValueString()
+	} else {
+		modelBody.ApplicationTemplate.ReadmeMarkdownTemplate = readmeBytes
 	}
 
 	params := &waypoint_service.WaypointServiceCreateApplicationTemplateParams{
@@ -523,15 +534,6 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	readmeBytes, err := base64.StdEncoding.DecodeString(plan.ReadmeMarkdownTemplate.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error decoding the base64 file contents",
-			err.Error(),
-		)
-		return
-	}
-
 	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
@@ -550,11 +552,10 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 
 	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceUpdateApplicationTemplateBody{
 		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointApplicationTemplate{
-			Name:                   plan.Name.ValueString(),
-			Summary:                plan.Summary.ValueString(),
-			Labels:                 strLabels,
-			Description:            plan.Description.ValueString(),
-			ReadmeMarkdownTemplate: readmeBytes,
+			Name:        plan.Name.ValueString(),
+			Summary:     plan.Summary.ValueString(),
+			Labels:      strLabels,
+			Description: plan.Description.ValueString(),
 			TerraformNocodeModule: &waypoint_models.HashicorpCloudWaypointTerraformNocodeModule{
 				Source:  plan.TerraformNoCodeModule.Source.ValueString(),
 				Version: plan.TerraformNoCodeModule.Version.ValueString(),
@@ -565,6 +566,18 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 			},
 			VariableOptions: varOpts,
 		},
+	}
+
+	// Decode the base64 encoded readme markdown template to see if it is encoded
+	readmeBytes, err := base64.StdEncoding.DecodeString(plan.ReadmeMarkdownTemplate.ValueString())
+	// If there is an error, we assume that it is because the string is not encoded. This is ok and
+	// we will just use the string as is in the ReadmeTemplate field of the model.
+	// Eventually the ReadMeMarkdownTemplate field will be deprecated, so the default behavior will be to
+	// expect the readme to not be encoded
+	if err != nil {
+		modelBody.ApplicationTemplate.ReadmeTemplate = plan.ReadmeMarkdownTemplate.ValueString()
+	} else {
+		modelBody.ApplicationTemplate.ReadmeMarkdownTemplate = readmeBytes
 	}
 
 	params := &waypoint_service.WaypointServiceUpdateApplicationTemplateParams{


### PR DESCRIPTION
This PR fixes a number of Waypoint provider issues identified in internal testing. The main changes are:

- The `readme_markdown_template` attribute is now able to handle both a base64 encoded string and an unencoded string to better match the underlying behavior of the Waypoint API, which accepts both for now. Eventually the ability to provide a base64 encoded version will be deprecated in the API, this change allows users to use both the new and old behavior until then. This change has been made for both the add-on definition and template resources.
- Various smaller documentation improvements to support the above change and to address smaller pieces of feedback recieved.

Output from acceptance testing:

```sh
$  make testacc TESTARGS='-run=TestAccWaypoint'
=== RUN   TestAccWaypoint_Action_DataSource_basic
    data_source_waypoint_action_test.go:20: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_DataSource_basic (0.00s)
=== RUN   TestAccWaypointData_Add_On_Definition_basic
--- PASS: TestAccWaypointData_Add_On_Definition_basic (14.95s)
=== RUN   TestAccWaypointData_Add_On_basic
--- PASS: TestAccWaypointData_Add_On_basic (26.04s)
=== RUN   TestAccWaypoint_AddOn_DataSource_WithInputVars
--- PASS: TestAccWaypoint_AddOn_DataSource_WithInputVars (23.76s)
=== RUN   TestAccWaypoint_Application_DataSource_basic
--- PASS: TestAccWaypoint_Application_DataSource_basic (16.55s)
=== RUN   TestAccWaypoint_Application_DataSource_WithInputVars
--- PASS: TestAccWaypoint_Application_DataSource_WithInputVars (18.11s)
=== RUN   TestAccWaypointData_Template_basic
--- PASS: TestAccWaypointData_Template_basic (11.99s)
=== RUN   TestAccWaypoint_Action_basic
    resource_waypoint_action_test.go:25: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_basic (0.00s)
=== RUN   TestAccWaypoint_Add_On_Definition_basic
--- PASS: TestAccWaypoint_Add_On_Definition_basic (10.11s)
=== RUN   TestAccWaypoint_Add_On_basic
--- PASS: TestAccWaypoint_Add_On_basic (13.37s)
=== RUN   TestAccWaypoint_AddOnInputVariables
--- PASS: TestAccWaypoint_AddOnInputVariables (13.73s)
=== RUN   TestAccWaypoint_AddOnInputVariables_OnDefinition
--- PASS: TestAccWaypoint_AddOnInputVariables_OnDefinition (14.15s)
=== RUN   TestAccWaypoint_Application_basic
--- PASS: TestAccWaypoint_Application_basic (8.91s)
=== RUN   TestAccWaypoint_ApplicationInputVariables
--- PASS: TestAccWaypoint_ApplicationInputVariables (9.82s)
=== RUN   TestAccWaypoint_ApplicationInputVariables_OnTemplate
--- PASS: TestAccWaypoint_ApplicationInputVariables_OnTemplate (10.09s)
=== RUN   TestAccWaypoint_Template_basic
--- PASS: TestAccWaypoint_Template_basic (9.63s)
=== RUN   TestAccWaypoint_template_with_variable_options
--- PASS: TestAccWaypoint_template_with_variable_options (6.67s)
...
```
