### PR TITLE
Waypoint: Require TF Project ID to be set, instead of a `terraform_cloud_workspace_details` resource

### DIFF
--- a/.changelog/1052.txt
+++ b/.changelog/1052.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+Waypoint resources for templates and add-on definitions no longer require setting
+a `terraform_cloud_workspace_details` resource, and instead can be set by the
+`terraform_project_id` param.
+```

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -20,6 +20,7 @@ Waypoint Add-on Definition resource
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
 - `terraform_no_code_module_source` (String) Terraform Cloud no-code Module Source, expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws"
+- `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in
 
 ### Optional
 

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -20,7 +20,7 @@ Waypoint Add-on Definition resource
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
 - `terraform_no_code_module_source` (String) Terraform Cloud no-code Module Source, expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws"
-- `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in
+- `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.
 
 ### Optional
 

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -27,7 +27,7 @@ Waypoint Add-on Definition resource
 - `labels` (List of String) List of labels attached to this Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
 - `readme_markdown_template` (String) The markdown template for the Add-on Definition README (markdown format supported).
-- `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details. If not provided, defaults to the HCP Terraform project of the associated application. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
+- `terraform_cloud_workspace_details` (Attributes, Deprecated) Terraform Cloud Workspace details. If not provided, defaults to the HCP Terraform project of the associated application. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `variable_options` (Attributes Set) List of variable options for the Add-on Definition. (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -27,7 +27,7 @@ Waypoint Template resource
 - `labels` (List of String) List of labels attached to this Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.
 - `readme_markdown_template` (String) Instructions for using the template (markdown format supported).
-- `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
+- `terraform_cloud_workspace_details` (Attributes, Deprecated) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -18,8 +18,8 @@ Waypoint Template resource
 
 - `name` (String) The name of the Template.
 - `summary` (String) A brief description of the template, up to 110 characters
-- `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `terraform_no_code_module_source` (String) Terraform Cloud No-Code Module details
+- `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in
 
 ### Optional
 
@@ -27,6 +27,7 @@ Waypoint Template resource
 - `labels` (List of String) List of labels attached to this Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.
 - `readme_markdown_template` (String) Instructions for using the template (markdown format supported).
+- `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -19,7 +19,7 @@ Waypoint Template resource
 - `name` (String) The name of the Template.
 - `summary` (String) A brief description of the template, up to 110 characters
 - `terraform_no_code_module_source` (String) Terraform Cloud No-Code Module details
-- `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in
+- `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.
 
 ### Optional
 

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -111,7 +111,7 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"terraform_project_id": schema.StringAttribute{
 				Required:    true,
-				Description: "The ID of the Terraform Cloud Project to create workspaces in",
+				Description: "The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -117,8 +117,9 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 				},
 			},
 			"terraform_cloud_workspace_details": &schema.SingleNestedAttribute{
-				Optional: true,
-				Computed: true,
+				DeprecationMessage: "terraform_cloud_workspace_details is deprecated, use terraform_project_id instead",
+				Optional:           true,
+				Computed:           true,
 				Description: "Terraform Cloud Workspace details. If not provided, defaults to " +
 					"the HCP Terraform project of the associated application.",
 				Attributes: map[string]schema.Attribute{

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -11,7 +11,6 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	waypointModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -47,7 +46,7 @@ type AddOnDefinitionResourceModel struct {
 	Description            types.String `tfsdk:"description"`
 	ReadmeMarkdownTemplate types.String `tfsdk:"readme_markdown_template"`
 
-	TerraformProjectId          types.String         `tfsdk:"terraform_project_id"`
+	TerraformProjectID          types.String         `tfsdk:"terraform_project_id"`
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
 	TerraformVariableOptions    []*tfcVariableOption `tfsdk:"variable_options"`
@@ -250,16 +249,16 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		})
 	}
 
-	tfProjId := plan.TerraformProjectId.ValueString()
+	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.TerraformCloudWorkspace.Name.ValueString()
 	if tfWsName == "" {
 		// NOTE: this field is optional anyways, so if its unset, lets just use
 		// the template name for it.
 		tfWsName = plan.Name.ValueString()
 	}
-	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+	tfWsDetails := &waypointModels.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
-		ProjectID: tfProjId,
+		ProjectID: tfProjID,
 	}
 
 	modelBody := &waypointModels.HashicorpCloudWaypointWaypointServiceCreateAddOnDefinitionBody{
@@ -485,16 +484,16 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		})
 	}
 
-	tfProjId := plan.TerraformProjectId.ValueString()
+	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.TerraformCloudWorkspace.Name.ValueString()
 	if tfWsName == "" {
 		// NOTE: this field is optional anyways, so if its unset, lets just use
 		// the template name for it.
 		tfWsName = plan.Name.ValueString()
 	}
-	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+	tfWsDetails := &waypointModels.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
-		ProjectID: tfProjId,
+		ProjectID: tfProjID,
 	}
 
 	// TODO: add support for Tags

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -112,6 +112,9 @@ func (r *AddOnDefinitionResource) Schema(ctx context.Context, req resource.Schem
 			"terraform_project_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The ID of the Terraform Cloud Project to create workspaces in",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"terraform_cloud_workspace_details": &schema.SingleNestedAttribute{
 				Optional: true,

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -142,14 +142,15 @@ resource "hcp_waypoint_add_on_definition" "test" {
   name    = %q
   summary = "some summary for fun"
   description = "some description for fun"
-  terraform_no_code_module = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
   variable_options = [
-	{
-	  name        = "string_variable"
+  {
+    name        = "string_variable"
       variable_type = "string"
       options = [
         "b"

--- a/internal/provider/waypoint/resource_waypoint_add_on_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_test.go
@@ -329,7 +329,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   summary     = "some summary for fun"
   description = "some description"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"

--- a/internal/provider/waypoint/resource_waypoint_add_on_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_test.go
@@ -256,11 +256,11 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   }
   labels = ["fallout", "vault-tec"]
   variable_options = [
-	{
-	  name          = "vault_dweller_name"
+  {
+      name          = "vault_dweller_name"
       variable_type = "string"
       user_editable = true
-      options 		= [
+      options       = [
         "lucy",
         "courier",
         "lone-wanderer",
@@ -268,10 +268,10 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
       ]
     },
     {
-	  name          = "faction"
+      name          = "faction"
       variable_type = "string"
       user_editable = true
-      options 		= [
+      options       = [
         "ncr",
         "brotherhood-of-steel",
         "caesars-legion",
@@ -288,16 +288,16 @@ resource "hcp_waypoint_add_on" "test_var_opts" {
   application_id = hcp_waypoint_application.test.id
 
   add_on_input_variables = [
-	{
-      name  		= "faction"
+  {
+      name          = "faction"
       variable_type = "string"
-      value 		= "brotherhood-of-steel"
+      value         = "brotherhood-of-steel"
     },
     {
-      name  		= "vault_dweller_name"
+      name          = "vault_dweller_name"
       variable_type = "string"
-	  value 		= "courier"
-    }	
+      value         = "courier"
+    }
   ]
 }
 
@@ -330,26 +330,26 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   description = "some description"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
   labels = ["fallout", "vault-tec"]
   variable_options = [
-	{
-	  name          = "vault_dweller_name"
+  {
+      name          = "vault_dweller_name"
       variable_type = "string"
       user_editable = false
-      options 		= [
+      options       = [
         "lone-wanderer",
       ]
     },
     {
-	  name          = "faction"
+      name          = "faction"
       variable_type = "string"
       user_editable = false
-      options 		= [
+      options       = [
         "brotherhood-of-steel",
       ]
     },
@@ -357,7 +357,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
 }
 
 resource "hcp_waypoint_add_on" "test_var_opts" {
-  name    		 = "%s"
+  name           = "%s"
   definition_id  = hcp_waypoint_add_on_definition.test_var_opts.id
   application_id = hcp_waypoint_application.test.id
 }`, tempName, appName, defName, addOnName)

--- a/internal/provider/waypoint/resource_waypoint_add_on_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_test.go
@@ -191,7 +191,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -209,7 +209,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
   summary = "some summary for fun"
   description = "some description for fun"
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -230,7 +230,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -249,7 +249,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   description = "some description for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -311,7 +311,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"

--- a/internal/provider/waypoint/resource_waypoint_add_on_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_test.go
@@ -191,6 +191,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -208,6 +209,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
   summary = "some summary for fun"
   description = "some description for fun"
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -228,6 +230,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -246,6 +249,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   description = "some description for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -307,6 +311,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -325,6 +330,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   description = "some description"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+	terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"

--- a/internal/provider/waypoint/resource_waypoint_application_test.go
+++ b/internal/provider/waypoint/resource_waypoint_application_test.go
@@ -192,10 +192,8 @@ resource "hcp_waypoint_template" "test" {
   name    = "%s"
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
-  terraform_no_code_module = {
-    source  = "private/waypoint-tfc-testing/waypoint-template-starter/null"
-    version = "0.0.2"
-  }
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -216,6 +214,7 @@ resource "hcp_waypoint_template" "test_var_opts" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -274,25 +273,26 @@ resource "hcp_waypoint_template" "test_var_opts" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
   labels = ["fallout", "vault-tec"]
   variable_options = [
-	{
-	  name          = "vault_dweller_name"
+  {
+      name          = "vault_dweller_name"
       variable_type = "string"
       user_editable = false
-      options 		= [
+      options       = [
         "lone-wanderer",
       ]
     },
     {
-	  name          = "faction"
+      name          = "faction"
       variable_type = "string"
       user_editable = false
-      options 		= [
+      options       = [
         "brotherhood-of-steel",
       ]
     },

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -50,7 +50,7 @@ type TemplateResourceModel struct {
 	Description            types.String `tfsdk:"description"`
 	ReadmeMarkdownTemplate types.String `tfsdk:"readme_markdown_template"`
 
-	TerraformProjectId          types.String         `tfsdk:"terraform_project_id"`
+	TerraformProjectID          types.String         `tfsdk:"terraform_project_id"`
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
 	TerraformVariableOptions    []*tfcVariableOption `tfsdk:"variable_options"`
@@ -265,7 +265,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		})
 	}
 
-	tfProjId := plan.TerraformProjectId.ValueString()
+	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.TerraformCloudWorkspace.Name.ValueString()
 	if tfWsName == "" {
 		// NOTE: this field is optional anyways, so if its unset, lets just use
@@ -274,7 +274,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	}
 	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
-		ProjectID: tfProjId,
+		ProjectID: tfProjID,
 	}
 
 	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceCreateApplicationTemplateBody{
@@ -535,7 +535,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		})
 	}
 
-	tfProjId := plan.TerraformProjectId.ValueString()
+	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.TerraformCloudWorkspace.Name.ValueString()
 	if tfWsName == "" {
 		// NOTE: this field is optional anyways, so if its unset, lets just use
@@ -544,7 +544,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
-		ProjectID: tfProjId,
+		ProjectID: tfProjID,
 	}
 
 	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceUpdateApplicationTemplateBody{

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -53,6 +54,13 @@ type TemplateResourceModel struct {
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
 	TerraformVariableOptions    []*tfcVariableOption `tfsdk:"variable_options"`
+}
+
+func (t tfcWorkspace) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":                 types.StringType,
+		"terraform_project_id": types.StringType,
+	}
 }
 
 type tfcWorkspace struct {

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -133,8 +133,9 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				},
 			},
 			"terraform_cloud_workspace_details": &schema.SingleNestedAttribute{
-				Optional:    true,
-				Description: "Terraform Cloud Workspace details",
+				DeprecationMessage: "terraform_cloud_workspace_details is deprecated, use terraform_project_id instead",
+				Optional:           true,
+				Description:        "Terraform Cloud Workspace details",
 				Attributes: map[string]schema.Attribute{
 					"name": &schema.StringAttribute{
 						Required:    true,

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -127,7 +127,7 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"terraform_project_id": schema.StringAttribute{
 				Required:    true,
-				Description: "The ID of the Terraform Cloud Project to create workspaces in",
+				Description: "The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -128,6 +128,9 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 			"terraform_project_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The ID of the Terraform Cloud Project to create workspaces in",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"terraform_cloud_workspace_details": &schema.SingleNestedAttribute{
 				Optional:    true,

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
 	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -60,13 +59,6 @@ type tfcWorkspace struct {
 	Name types.String `tfsdk:"name"`
 	// this refers to the project ID found in Terraform Cloud
 	TerraformProjectID types.String `tfsdk:"terraform_project_id"`
-}
-
-func (t tfcWorkspace) attrTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"name":                 types.StringType,
-		"terraform_project_id": types.StringType,
-	}
 }
 
 type tfcVariableOption struct {

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -158,6 +158,7 @@ resource "hcp_waypoint_template" "test" {
   summary                  = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
@@ -173,6 +174,7 @@ resource "hcp_waypoint_template" "var_opts_test" {
   summary                  = "A template with a variable with options."
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Prior to this commit, the template and add-on definition resource required a user to set a full resource for specifying `terraform_cloud_workspace_details`. However, this resource required users to set a `name` which is a value that Waypoint does nothing with. Rather than requiring users to set this field that isn't used in the first place, this pull request instead introduces a `terraform_project_id` field that is required, and will use the add-on or template name for the erroneous field.

Fixes WAYP-2768 WAYP-2769

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
