### PR TITLE
Add Version Attributes To Boundary Cluster Resource & Data Source

### DIFF
--- a/.changelog/1089.txt
+++ b/.changelog/1089.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Added the `version` attribute(s) to `hcp_boundary_cluster` resource and data sources. 
+```

--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -39,6 +39,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `maintenance_window_config` (List of Object) (see [below for nested schema](#nestedatt--maintenance_window_config))
 - `state` (String) The state of the Boundary cluster.
 - `tier` (String) The tier of the Boundary cluster.
+- `version` (String) The version of the Boundary cluster.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -49,6 +49,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `created_at` (String) The time that the Boundary cluster was created.
 - `id` (String) The ID of this resource.
 - `state` (String) The state of the Boundary cluster.
+- `version` (String) The version of the Boundary cluster.
 
 <a id="nestedblock--maintenance_window_config"></a>
 ### Nested Schema for `maintenance_window_config`

--- a/internal/providersdkv2/data_source_boundary_cluster.go
+++ b/internal/providersdkv2/data_source_boundary_cluster.go
@@ -89,6 +89,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 					},
 				},
 			},
+			"version": {
+				Description: "The version of the Boundary cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/internal/providersdkv2/resource_boundary_cluster.go
+++ b/internal/providersdkv2/resource_boundary_cluster.go
@@ -161,6 +161,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 					},
 				},
 			},
+			"version": {
+				Description: "The version of the Boundary cluster.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/internal/providersdkv2/resource_boundary_cluster.go
+++ b/internal/providersdkv2/resource_boundary_cluster.go
@@ -497,6 +497,10 @@ func setBoundaryClusterResourceData(d *schema.ResourceData, cluster *boundarymod
 	if err := d.Set("maintenance_window_config", []interface{}{mwConfig}); err != nil {
 		return err
 	}
+
+	if err := d.Set("version", cluster.BoundaryVersion); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/providersdkv2/resource_boundary_cluster_test.go
+++ b/internal/providersdkv2/resource_boundary_cluster_test.go
@@ -68,6 +68,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
 				),
 			},
 			{
@@ -96,6 +97,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
 				),
 			},
 			{
@@ -108,6 +110,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					testAccCheckFullURL(boundaryClusterDataSourceName, "cluster_url", ""),
 					resource.TestCheckResourceAttrPair(boundaryClusterResourceName, "state", boundaryClusterDataSourceName, "state"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
+					resource.TestCheckResourceAttrPair(boundaryClusterResourceName, "version", boundaryClusterDataSourceName, "version"),
 				),
 			},
 			{
@@ -125,6 +128,7 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.day", "TUESDAY"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.start", "2"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.end", "12"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
- Updated the `hcp_boundary_cluster` resources & data sources for collecting version information for deployed or existing clusters. 
### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

![image](https://github.com/user-attachments/assets/0183ac01-af4b-479f-be5b-06126649dbbb)
