### PR TITLE
[Waypoint] Stop using the deprecated terraform cloud workspace name field

### DIFF
--- a/.changelog/1093.txt
+++ b/.changelog/1093.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Waypoint: fix where using the deprecated terraform_cloud_workspace_details.name field could cause an error.
+```

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -270,12 +270,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	tfProjID := plan.TerraformProjectID.ValueString()
-	tfWsName := plan.TerraformCloudWorkspace.Name.ValueString()
-	if tfWsName == "" {
-		// NOTE: this field is optional anyways, so if its unset, lets just use
-		// the template name for it.
-		tfWsName = plan.Name.ValueString()
-	}
+	tfWsName := plan.Name.ValueString()
 	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
 		ProjectID: tfProjID,
@@ -332,11 +327,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	plan.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
 	if appTemplate.TerraformCloudWorkspaceDetails != nil {
-		tfcWorkspace := &tfcWorkspace{
-			Name:               types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.Name),
-			TerraformProjectID: types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID),
-		}
-		plan.TerraformCloudWorkspace = tfcWorkspace
+		plan.TerraformProjectID = types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID)
 	}
 
 	labels, diags := types.ListValueFrom(ctx, types.StringType, appTemplate.Labels)
@@ -447,11 +438,7 @@ func (r *TemplateResource) Read(ctx context.Context, req resource.ReadRequest, r
 	data.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
 	if appTemplate.TerraformCloudWorkspaceDetails != nil {
-		tfcWorkspace := &tfcWorkspace{
-			Name:               types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.Name),
-			TerraformProjectID: types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID),
-		}
-		data.TerraformCloudWorkspace = tfcWorkspace
+		data.TerraformProjectID = types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID)
 	}
 
 	data.TerraformVariableOptions, err = readVarOpts(ctx, appTemplate.VariableOptions, &resp.Diagnostics)
@@ -540,12 +527,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	tfProjID := plan.TerraformProjectID.ValueString()
-	tfWsName := plan.TerraformCloudWorkspace.Name.ValueString()
-	if tfWsName == "" {
-		// NOTE: this field is optional anyways, so if its unset, lets just use
-		// the template name for it.
-		tfWsName = plan.Name.ValueString()
-	}
+	tfWsName := plan.Name.ValueString()
 	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
 		ProjectID: tfProjID,
@@ -602,20 +584,16 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	plan.Summary = types.StringValue(appTemplate.Summary)
 	plan.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
 
+	if appTemplate.TerraformCloudWorkspaceDetails != nil {
+		plan.TerraformProjectID = types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID)
+	}
+
 	labels, diags := types.ListValueFrom(ctx, types.StringType, appTemplate.Labels)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	plan.Labels = labels
-
-	if appTemplate.TerraformCloudWorkspaceDetails != nil {
-		tfcWorkspace := &tfcWorkspace{
-			Name:               types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.Name),
-			TerraformProjectID: types.StringValue(appTemplate.TerraformCloudWorkspaceDetails.ProjectID),
-		}
-		plan.TerraformCloudWorkspace = tfcWorkspace
-	}
 
 	plan.Description = types.StringValue(appTemplate.Description)
 	if appTemplate.Description == "" {


### PR DESCRIPTION
Previously we had deprecated the `terraform_cloud_workspace_details` resource field for the `hcp_waypoint_template` resource. However the field was still being used by our create and update functions, causing an ugly error whenever users attempted to not use the deprecated field. This fixes that by no longer using the deprecated field at all. This closes Waypoint ticket WAYP-2988.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccWaypoint_Template'
=== RUN   TestAccWaypoint_Template_basic
--- PASS: TestAccWaypoint_Template_basic (10.31s)
=== RUN   TestAccWaypoint_template_with_variable_options
--- PASS: TestAccWaypoint_template_with_variable_options (6.36s)
```
