### PR TITLE
Make execution mode configurable for Waypoint templates & add-ons

### DIFF
--- a/.changelog/1098.txt
+++ b/.changelog/1098.txt
@@ -1,0 +1,5 @@
+```release-note:feature
+waypoint: Add execution mode and agent pool ID configurations to the
+`hcp_waypoint_template` and `hcp_waypoint_add_on_definition` resources, and
+the `hcp_waypoint_template` and `hcp_waypoint_add_on_definition` data sources.
+```

--- a/docs/data-sources/waypoint_add_on_definition.md
+++ b/docs/data-sources/waypoint_add_on_definition.md
@@ -27,7 +27,9 @@ The Waypoint Add-on Definition data source retrieves information on a given Add-
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Add-on Definition is located.
 - `readme_markdown_template` (String) Instructions for using the Add-on Definition (markdown format supported).
 - `summary` (String) A short summary of the Add-on Definition.
+- `terraform_agent_pool_id` (String) The ID of the Terraform agent pool.
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
+- `terraform_execution_mode` (String) The execution mode for the Terraform Cloud workspace.
 - `terraform_no_code_module_source` (String) Terraform No Code Module source
 - `variable_options` (Attributes List) List of variable options for the Add-on Definition. (see [below for nested schema](#nestedatt--variable_options))
 

--- a/docs/data-sources/waypoint_template.md
+++ b/docs/data-sources/waypoint_template.md
@@ -27,7 +27,9 @@ The Waypoint Template data source retrieves information on a given Template.
 - `organization_id` (String) The ID of the HCP organization where the Waypoint Template is located.
 - `readme_markdown_template` (String) Instructions for using the template (markdown format supported)
 - `summary` (String) A brief description of the template, up to 110 characters
+- `terraform_agent_pool_id` (String) Terraform agent pool ID
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
+- `terraform_execution_mode` (String) Terraform execution mode
 - `terraform_no_code_module_source` (String) Terraform No Code Module source
 - `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -19,7 +19,7 @@ Waypoint Add-on Definition resource
 - `description` (String) A longer description of the Add-on Definition.
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
-- `terraform_no_code_module_source` (String) Terraform Cloud no-code Module Source, expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws"
+- `terraform_no_code_module_source` (String) Terraform Cloud no-code Module Source, expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws".
 - `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.
 
 ### Optional
@@ -27,7 +27,9 @@ Waypoint Add-on Definition resource
 - `labels` (List of String) List of labels attached to this Add-on Definition.
 - `project_id` (String) The ID of the HCP project where the Waypoint Add-on Definition is located.
 - `readme_markdown_template` (String) The markdown template for the Add-on Definition README (markdown format supported).
+- `terraform_agent_pool_id` (String) The ID of the Terraform agent pool to use for running Terraform operations. This is only applicable when the execution mode is set to 'agent'.
 - `terraform_cloud_workspace_details` (Attributes, Deprecated) Terraform Cloud Workspace details. If not provided, defaults to the HCP Terraform project of the associated application. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
+- `terraform_execution_mode` (String) The execution mode of the HCP Terraform workspaces for add-ons using this add-on definition.
 - `variable_options` (Attributes Set) List of variable options for the Add-on Definition. (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -17,7 +17,7 @@ Waypoint Template resource
 ### Required
 
 - `name` (String) The name of the Template.
-- `summary` (String) A brief description of the template, up to 110 characters
+- `summary` (String) A brief description of the template, up to 110 characters.
 - `terraform_no_code_module_source` (String) Terraform Cloud No-Code Module details
 - `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.
 
@@ -27,8 +27,10 @@ Waypoint Template resource
 - `labels` (List of String) List of labels attached to this Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.
 - `readme_markdown_template` (String) Instructions for using the template (markdown format supported).
+- `terraform_agent_pool_id` (String) The ID of the agent pool to use for Terraform operations, for workspaces created for applications using this template. Required if terraform_execution_mode is set to 'agent'.
 - `terraform_cloud_workspace_details` (Attributes, Deprecated) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
-- `variable_options` (Attributes Set) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
+- `terraform_execution_mode` (String) The execution mode of the HCP Terraform workspaces created for applications using this template.
+- `variable_options` (Attributes Set) List of variable options for the template. (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.113.1-0.20240919224752-f386223f1918
+	github.com/hashicorp/hcp-sdk-go v0.114.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.113.0
+	github.com/hashicorp/hcp-sdk-go v0.113.1-0.20240919224752-f386223f1918
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.113.0 h1:JuA6mZosEezE550lNMEq43VLUCzVc+/jPmPC1Nd39Gk=
-github.com/hashicorp/hcp-sdk-go v0.113.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.113.1-0.20240919224752-f386223f1918 h1:uP1E5fx2WZpries7D7ui+lCs23WWXxL9sKdw8sMgiyw=
+github.com/hashicorp/hcp-sdk-go v0.113.1-0.20240919224752-f386223f1918/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.113.1-0.20240919224752-f386223f1918 h1:uP1E5fx2WZpries7D7ui+lCs23WWXxL9sKdw8sMgiyw=
-github.com/hashicorp/hcp-sdk-go v0.113.1-0.20240919224752-f386223f1918/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.114.0 h1:OQno/I9UGEplkDzBBo04C1XUYHkWIU9g/+W2jWqZWGw=
+github.com/hashicorp/hcp-sdk-go v0.114.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -47,6 +47,8 @@ type DataSourceAddOnDefinitionModel struct {
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
 	TerraformVariableOptions    []*tfcVariableOption `tfsdk:"variable_options"`
+	TerraformExecutionMode      types.String         `tfsdk:"terraform_execution_mode"`
+	TerraformAgentPoolID        types.String         `tfsdk:"terraform_agent_pool_id"`
 }
 
 func NewAddOnDefinitionDataSource() datasource.DataSource {
@@ -139,6 +141,14 @@ func (d *DataSourceAddOnDefinition) Schema(ctx context.Context, req datasource.S
 						},
 					},
 				},
+			},
+			"terraform_execution_mode": schema.StringAttribute{
+				Computed:    true,
+				Description: "The execution mode for the Terraform Cloud workspace.",
+			},
+			"terraform_agent_pool_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the Terraform agent pool.",
 			},
 		},
 	}

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
@@ -40,6 +40,7 @@ func TestAccWaypointData_Add_On_Definition_basic(t *testing.T) {
 				Config: testDataAddOnDefinitionConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "terraform_execution_mode", "remote"),
 				),
 			},
 			{

--- a/internal/provider/waypoint/data_source_waypoint_template.go
+++ b/internal/provider/waypoint/data_source_waypoint_template.go
@@ -47,6 +47,8 @@ type DataSourceTemplateModel struct {
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
 	VariableOptions             []*tfcVariableOption `tfsdk:"variable_options"`
+	TerraformExecutionMode      types.String         `tfsdk:"terraform_execution_mode"`
+	TerraformAgentPoolID        types.String         `tfsdk:"terraform_agent_pool_id"`
 }
 
 func NewTemplateDataSource() datasource.DataSource {
@@ -139,6 +141,14 @@ func (d *DataSourceTemplate) Schema(ctx context.Context, req datasource.SchemaRe
 						},
 					},
 				},
+			},
+			"terraform_execution_mode": schema.StringAttribute{
+				Computed:    true,
+				Description: "Terraform execution mode",
+			},
+			"terraform_agent_pool_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Terraform agent pool ID",
 			},
 		},
 	}
@@ -237,6 +247,15 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 	data.ReadmeMarkdownTemplate = types.StringValue(appTemplate.ReadmeMarkdownTemplate.String())
 	if appTemplate.ReadmeMarkdownTemplate.String() == "" {
 		data.ReadmeMarkdownTemplate = types.StringNull()
+	}
+
+	data.TerraformExecutionMode = types.StringValue(appTemplate.TfExecutionMode)
+	if appTemplate.TfExecutionMode == "" {
+		data.TerraformExecutionMode = types.StringNull()
+	}
+	data.TerraformAgentPoolID = types.StringValue(appTemplate.TfAgentPoolID)
+	if appTemplate.TfAgentPoolID == "" {
+		data.TerraformAgentPoolID = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/waypoint/data_source_waypoint_template_test.go
+++ b/internal/provider/waypoint/data_source_waypoint_template_test.go
@@ -40,6 +40,7 @@ func TestAccWaypointData_Template_basic(t *testing.T) {
 				Config: testDataAppTemplateConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "terraform_execution_mode", "remote"),
 				),
 			},
 			{

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -35,6 +35,7 @@ func TestAccWaypoint_Add_On_Definition_basic(t *testing.T) {
 					testAccCheckWaypointAddOnDefinitionExists(t, resourceName, &addOnDefinitionModel),
 					testAccCheckWaypointAddOnDefinitionName(t, &addOnDefinitionModel, name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "terraform_execution_mode", "remote"),
 				),
 			},
 			{
@@ -138,5 +139,6 @@ resource "hcp_waypoint_add_on_definition" "test" {
     name                 = "Default Project"
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
+  terraform_execution_mode = "remote"
 }`, name)
 }

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -37,6 +37,7 @@ func TestAccWaypoint_Template_basic(t *testing.T) {
 					testAccCheckWaypointTemplateExists(t, resourceName, &appTemplateModel),
 					testAccCheckWaypointTemplateName(t, &appTemplateModel, name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "terraform_execution_mode", "remote"),
 				),
 			},
 			{
@@ -164,6 +165,7 @@ resource "hcp_waypoint_template" "test" {
     terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   }
   labels = ["one", "two"]
+  terraform_execution_mode = "remote"
 }`, name)
 }
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

The execution mode and agent pool ID for workspaces created for Waypoint applications and add-ons, based on their respective templates and add-on definitions, is now configurable in HCP Waypoint. This update to the Terraform provider makes it possible to make those configurations via Terraform.

### :building_construction: Acceptance tests

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS="-run=TestAccWaypoint"
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccWaypoint -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/customdiags	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	0.412s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming	0.523s [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/datasources/artifact	0.450s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/datasources/version	0.584s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/resources/bucket	0.474s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	0.449s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	0.477s [no tests to run]
=== RUN   TestAccWaypoint_Action_DataSource_basic
    data_source_waypoint_action_test.go:20: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_DataSource_basic (0.00s)
=== RUN   TestAccWaypointData_Add_On_Definition_basic
    data_source_waypoint_add_on_definition_test.go:24: Step 2/3 error: Check failed: Check 2/2 error: data.hcp_waypoint_add_on_definition.test: Attribute 'terraform_execution_mode' not found
--- FAIL: TestAccWaypointData_Add_On_Definition_basic (4.31s)
=== RUN   TestAccWaypointData_Add_On_basic
--- PASS: TestAccWaypointData_Add_On_basic (19.02s)
=== RUN   TestAccWaypoint_AddOn_DataSource_WithInputVars
--- PASS: TestAccWaypoint_AddOn_DataSource_WithInputVars (18.99s)
=== RUN   TestAccWaypoint_Application_DataSource_basic
--- PASS: TestAccWaypoint_Application_DataSource_basic (11.17s)
=== RUN   TestAccWaypoint_Application_DataSource_WithInputVars
--- PASS: TestAccWaypoint_Application_DataSource_WithInputVars (11.99s)
=== RUN   TestAccWaypointData_Template_basic
--- PASS: TestAccWaypointData_Template_basic (8.78s)
=== RUN   TestAccWaypointData_template_with_variable_options
--- PASS: TestAccWaypointData_template_with_variable_options (6.03s)
=== RUN   TestAccWaypoint_Action_basic
    resource_waypoint_action_test.go:25: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_basic (0.00s)
=== RUN   TestAccWaypoint_Add_On_Definition_basic
--- PASS: TestAccWaypoint_Add_On_Definition_basic (5.95s)
=== RUN   TestAccWaypoint_Add_On_basic
--- PASS: TestAccWaypoint_Add_On_basic (10.67s)
=== RUN   TestAccWaypoint_AddOnInputVariables
--- PASS: TestAccWaypoint_AddOnInputVariables (9.58s)
=== RUN   TestAccWaypoint_AddOnInputVariables_OnDefinition
--- PASS: TestAccWaypoint_AddOnInputVariables_OnDefinition (10.20s)
=== RUN   TestAccWaypoint_Application_basic
--- PASS: TestAccWaypoint_Application_basic (6.01s)
=== RUN   TestAccWaypoint_ApplicationInputVariables
--- PASS: TestAccWaypoint_ApplicationInputVariables (6.11s)
=== RUN   TestAccWaypoint_ApplicationInputVariables_OnTemplate
--- PASS: TestAccWaypoint_ApplicationInputVariables_OnTemplate (5.65s)
=== RUN   TestAccWaypoint_Template_basic
--- PASS: TestAccWaypoint_Template_basic (5.37s)
=== RUN   TestAccWaypoint_template_with_variable_options
--- PASS: TestAccWaypoint_template_with_variable_options (3.01s)
=== RUN   TestAccWaypointTfcConfig_basic
    resource_waypoint_tfc_config_test.go:25: Skipping nonfunctional TFC Config test
--- SKIP: TestAccWaypointTfcConfig_basic (0.00s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint	143.476s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook	0.669s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	0.738s [no tests to run]
FAIL
make: *** [testacc] Error 1

```
