### PR TITLE
[Waypoint] Added useModuleReadme attrubute to Template resource

### DIFF
--- a/.changelog/1099.txt
+++ b/.changelog/1099.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Waypoint: New template resource attribute `use_module_readme` allows users to use the associated Terraform module readme in place of providing a seperate readme for the template.
+```

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -30,6 +30,7 @@ Waypoint Template resource
 - `terraform_agent_pool_id` (String) The ID of the agent pool to use for Terraform operations, for workspaces created for applications using this template. Required if terraform_execution_mode is set to 'agent'.
 - `terraform_cloud_workspace_details` (Attributes, Deprecated) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `terraform_execution_mode` (String) The execution mode of the HCP Terraform workspaces created for applications using this template.
+- `use_module_readme` (Boolean) If true, will auto-import the readme form the Terraform odule used. If this is set to true, users should not also set `readme_markdown_template`.
 - `variable_options` (Attributes Set) List of variable options for the template. (see [below for nested schema](#nestedatt--variable_options))
 
 ### Read-Only

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -49,6 +49,7 @@ type TemplateResourceModel struct {
 	Labels                 types.List   `tfsdk:"labels"`
 	Description            types.String `tfsdk:"description"`
 	ReadmeMarkdownTemplate types.String `tfsdk:"readme_markdown_template"`
+	UseModuleReadme        types.Bool   `tfsdk:"use_module_readme"`
 
 	TerraformProjectID          types.String         `tfsdk:"terraform_project_id"`
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
@@ -124,7 +125,12 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"readme_markdown_template": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Instructions for using the template (markdown format supported).",
+			},
+			"use_module_readme": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If true, will auto-import the readme form the Terraform odule used. If this is set to true, users should not also set `readme_markdown_template`.",
 			},
 			"labels": schema.ListAttribute{
 				// Computed:    true,
@@ -302,6 +308,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 			TfExecutionMode:                plan.TerraformExecutionMode.ValueString(),
 			TfAgentPoolID:                  plan.TerraformAgentPoolID.ValueString(),
 		},
+		UseModuleReadme: plan.UseModuleReadme.ValueBool(),
 	}
 
 	// Decode the base64 encoded readme markdown template to see if it is encoded
@@ -333,6 +340,11 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	if appTemplate == nil {
 		resp.Diagnostics.AddError("unknown error creating template", "empty template returned")
 		return
+	}
+
+	// If plan.UseModuleReadme is not set, set it to false
+	if plan.UseModuleReadme.IsUnknown() {
+		plan.UseModuleReadme = types.BoolValue(false)
 	}
 
 	plan.ID = types.StringValue(appTemplate.ID)
@@ -578,6 +590,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 			TfExecutionMode:                plan.TerraformExecutionMode.ValueString(),
 			TfAgentPoolID:                  plan.TerraformAgentPoolID.ValueString(),
 		},
+		UseModuleReadme: plan.UseModuleReadme.ValueBool(),
 	}
 
 	// Decode the base64 encoded readme markdown template to see if it is encoded
@@ -610,6 +623,11 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	if appTemplate == nil {
 		resp.Diagnostics.AddError("unknown error updating template", "empty template returned")
 		return
+	}
+
+	// If plan.UseModuleReadme is not set, set it to false
+	if plan.UseModuleReadme.IsUnknown() {
+		plan.UseModuleReadme = types.BoolValue(false)
 	}
 
 	plan.ID = types.StringValue(appTemplate.ID)


### PR DESCRIPTION
The `use_module_readme` attribute allows users to elect to use the readme of their Waypoint template's associated Terraform module in place of providing a readme for that template themselves.

This also updates [hcp-sdk-go](https://github.com/hashicorp/hcp-sdk-go) to release 114.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccWaypoint_Template'
=== RUN   TestAccWaypoint_Template_basic
--- PASS: TestAccWaypoint_Template_basic (11.73s)
```
