### PR TITLE
Handle breaking change in boundary client

### DIFF
--- a/.changelog/1110.txt
+++ b/.changelog/1110.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Upgrade the HCP SDK and fix a breaking change in the Boundary API.
+```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.114.0
+	github.com/hashicorp/hcp-sdk-go v0.115.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.114.0 h1:OQno/I9UGEplkDzBBo04C1XUYHkWIU9g/+W2jWqZWGw=
-github.com/hashicorp/hcp-sdk-go v0.114.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.115.0 h1:q6viFNFPd4H4cHm/B9KGYvkpkT5ZSBQASh9KR/zYHEI=
+github.com/hashicorp/hcp-sdk-go v0.115.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/internal/clients/boundary_cluster.go
+++ b/internal/clients/boundary_cluster.go
@@ -75,7 +75,7 @@ func SetBoundaryClusterMaintenanceWindow(
 	loc *sharedmodels.HashicorpCloudLocationLocation,
 	boundaryClusterID string,
 	mwUpdateRequest *boundarymodels.HashicorpCloudBoundary20211221MaintenanceWindowUpdateRequest,
-) (*boundarymodels.HashicorpCloudBoundary20211221MaintenanceWindowUpdateResponse, error) {
+) error {
 
 	params := boundary_service.NewBoundaryServiceMaintenanceWindowUpdateParams()
 	params.Context = ctx
@@ -85,12 +85,12 @@ func SetBoundaryClusterMaintenanceWindow(
 	params.LocationProjectID = loc.ProjectID
 	params.ClusterID = boundaryClusterID
 
-	resp, err := client.Boundary.BoundaryServiceMaintenanceWindowUpdate(params, nil)
+	_, err := client.Boundary.BoundaryServiceMaintenanceWindowUpdate(params, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return resp.Payload, nil
+	return nil
 }
 
 // GetBoundaryClusterMaintenanceWindow gets the maintenance window configuration for a Boundary cluster.

--- a/internal/providersdkv2/resource_boundary_cluster.go
+++ b/internal/providersdkv2/resource_boundary_cluster.go
@@ -264,8 +264,7 @@ func resourceBoundaryClusterCreate(ctx context.Context, d *schema.ResourceData, 
 		mwReq.ClusterID = cluster.ClusterID
 		mwReq.Location = cluster.Location
 
-		_, err := clients.SetBoundaryClusterMaintenanceWindow(ctx, client, loc, clusterID, &mwReq)
-		if err != nil {
+		if err = clients.SetBoundaryClusterMaintenanceWindow(ctx, client, loc, clusterID, &mwReq); err != nil {
 			return diag.Errorf("error setting maintenance window configuration for Boundary cluster (%s): %v", clusterID, err)
 		}
 		currentMaintenanceWindow = maintenanceWindow
@@ -325,8 +324,7 @@ func resourceBoundaryClusterUpdate(ctx context.Context, d *schema.ResourceData, 
 		mwReq.ClusterID = cluster.ClusterID
 		mwReq.Location = cluster.Location
 
-		_, err := clients.SetBoundaryClusterMaintenanceWindow(ctx, client, loc, clusterID, &mwReq)
-		if err != nil {
+		if err = clients.SetBoundaryClusterMaintenanceWindow(ctx, client, loc, clusterID, &mwReq); err != nil {
 			return diag.Errorf("error setting maintenance window configuration for Boundary cluster (%s): %v", clusterID, err)
 		}
 		currentMaintenanceWindow = maintenanceWindow


### PR DESCRIPTION
This commit upgrades the hcp-sdk-go dependency to 0.115.0 and addresses a breaking change within the cloud-boundary APIs. Seems that an empty response body will be generated as an empty interface instead of a struct causing compilation errors when attempting to upgrade.