### PR TITLE
Added deprecation message in hcp consul resources and data sources

### DIFF
--- a/internal/providersdkv2/data_source_consul_agent_helm_config.go
+++ b/internal/providersdkv2/data_source_consul_agent_helm_config.go
@@ -67,7 +67,8 @@ connectInject:
 
 func dataSourceConsulAgentHelmConfig() *schema.Resource {
 	return &schema.Resource{
-		Description: "The Consul agent Helm config data source provides Helm values for a Consul agent running in Kubernetes.",
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
+		Description:        "The Consul agent Helm config data source provides Helm values for a Consul agent running in Kubernetes.",
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultConsulAgentHelmConfigTimeoutDuration,
 		},

--- a/internal/providersdkv2/data_source_consul_agent_kubernetes_secret.go
+++ b/internal/providersdkv2/data_source_consul_agent_kubernetes_secret.go
@@ -34,8 +34,9 @@ data:
 
 func dataSourceConsulAgentKubernetesSecret() *schema.Resource {
 	return &schema.Resource{
-		Description: "The agent config Kubernetes secret data source provides Consul agents running in Kubernetes the configuration needed to connect to the Consul cluster.",
-		ReadContext: dataSourceConsulAgentKubernetesSecretRead,
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
+		Description:        "The agent config Kubernetes secret data source provides Consul agents running in Kubernetes the configuration needed to connect to the Consul cluster.",
+		ReadContext:        dataSourceConsulAgentKubernetesSecretRead,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultAgentConfigKubernetesSecretTimeoutDuration,
 		},

--- a/internal/providersdkv2/data_source_consul_cluster.go
+++ b/internal/providersdkv2/data_source_consul_cluster.go
@@ -18,8 +18,9 @@ import (
 
 func dataSourceConsulCluster() *schema.Resource {
 	return &schema.Resource{
-		Description: "The cluster data source provides information about an existing HCP Consul cluster.",
-		ReadContext: dataSourceConsulClusterRead,
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
+		Description:        "The cluster data source provides information about an existing HCP Consul cluster.",
+		ReadContext:        dataSourceConsulClusterRead,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultConsulClusterTimeout,
 		},

--- a/internal/providersdkv2/data_source_consul_versions.go
+++ b/internal/providersdkv2/data_source_consul_versions.go
@@ -23,7 +23,8 @@ var defaultConsulVersionsTimeoutDuration = time.Minute * 5
 // dataSourceConsulVersions is the data source for the Consul versions supported by HCP.
 func dataSourceConsulVersions() *schema.Resource {
 	return &schema.Resource{
-		Description: "The Consul versions data source provides the Consul versions supported by HCP.",
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
+		Description:        "The Consul versions data source provides the Consul versions supported by HCP.",
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultConsulVersionsTimeoutDuration,
 		},

--- a/internal/providersdkv2/resource_consul_cluster.go
+++ b/internal/providersdkv2/resource_consul_cluster.go
@@ -36,11 +36,12 @@ var deleteConsulClusterTimeout = time.Minute * 35
 // resourceConsulCluster represents an HCP Consul cluster.
 func resourceConsulCluster() *schema.Resource {
 	return &schema.Resource{
-		Description:   "The Consul cluster resource allows you to manage an HCP Consul cluster.",
-		CreateContext: resourceConsulClusterCreate,
-		ReadContext:   resourceConsulClusterRead,
-		UpdateContext: resourceConsulClusterUpdate,
-		DeleteContext: resourceConsulClusterDelete,
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
+		Description:        "The Consul cluster resource allows you to manage an HCP Consul cluster.",
+		CreateContext:      resourceConsulClusterCreate,
+		ReadContext:        resourceConsulClusterRead,
+		UpdateContext:      resourceConsulClusterUpdate,
+		DeleteContext:      resourceConsulClusterDelete,
 		Timeouts: &schema.ResourceTimeout{
 			Default: &defaultConsulClusterTimeout,
 			Create:  &createUpdateConsulClusterTimeout,

--- a/internal/providersdkv2/resource_consul_cluster_root_token.go
+++ b/internal/providersdkv2/resource_consul_cluster_root_token.go
@@ -36,6 +36,7 @@ data:
 // resourceConsulClusterRootToken represents an HCP Consul cluster.
 func resourceConsulClusterRootToken() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
 		Description: "The cluster root token resource is the token used to bootstrap the cluster's ACL system. " +
 			"You can also generate this root token from the HCP Consul UI.",
 		CreateContext: resourceConsulClusterRootTokenCreate,

--- a/internal/providersdkv2/resource_consul_snapshot.go
+++ b/internal/providersdkv2/resource_consul_snapshot.go
@@ -32,6 +32,7 @@ var snapshotCreateUpdateDeleteTimeoutDuration = time.Minute * 15
 
 func resourceConsulSnapshot() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly",
 		Description: "The Consul snapshot resource allows users to manage Consul snapshots of an HCP Consul cluster. " +
 			"Snapshots currently have a retention policy of 30 days.",
 		CreateContext: resourceConsulSnapshotCreate,


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Added deprecation message for the following resources and data sources for consul:

"HashiCorp plans to sunset HashiCorp Consul Dedicated (HCD) in November 2025, more information about the EOL will be provided to existing customers directly"

**Resources:** 
- hcp_consul_cluster
- hcp_consul_cluster_root_token
- hcp_consul_snapshot

**Data Sources:** 
- hcp_consul_agent_helm_config
- hcp_consul_agent_kubernetes_secret
- hcp_consul_cluster
- hcp_consul_versions

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
