### PR TITLE
fix vault radar docs.

### DIFF
--- a/.changelog/1129.txt
+++ b/.changelog/1129.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+HCP Vault Radar resource documents did not have the subcategory set correctly.
+```

--- a/docs/resources/vault_radar_integration_jira_connection.md
+++ b/docs/resources/vault_radar_integration_jira_connection.md
@@ -1,13 +1,13 @@
 ---
 page_title: "hcp_vault_radar_integration_jira_connection Resource - terraform-provider-hcp"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
   This terraform resource manages an Integration Jira Connection in Vault Radar.
 ---
 
 # hcp_vault_radar_integration_jira_connection (Resource)
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 This terraform resource manages an Integration Jira Connection in Vault Radar.
 

--- a/docs/resources/vault_radar_integration_jira_subscription.md
+++ b/docs/resources/vault_radar_integration_jira_subscription.md
@@ -1,13 +1,13 @@
 ---
 page_title: "hcp_vault_radar_integration_jira_subscription Resource - terraform-provider-hcp"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
   This terraform resource manages an Integration Jira Subscription in Vault Radar.
 ---
 
 # hcp_vault_radar_integration_jira_subscription (Resource)
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 This terraform resource manages an Integration Jira Subscription in Vault Radar.
 

--- a/docs/resources/vault_radar_integration_slack_connection.md
+++ b/docs/resources/vault_radar_integration_slack_connection.md
@@ -1,13 +1,13 @@
 ---
 page_title: "hcp_vault_radar_integration_slack_connection Resource - terraform-provider-hcp"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
   This terraform resource manages an Integration Slack Connection in Vault Radar.
 ---
 
 # hcp_vault_radar_integration_slack_connection (Resource)
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 This terraform resource manages an Integration Slack Connection in Vault Radar.
 

--- a/docs/resources/vault_radar_integration_slack_subscription.md
+++ b/docs/resources/vault_radar_integration_slack_subscription.md
@@ -1,13 +1,13 @@
 ---
 page_title: "hcp_vault_radar_integration_slack_subscription Resource - terraform-provider-hcp"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
   This terraform resource manages an Integration Slack Subscription in Vault Radar.
 ---
 
 # hcp_vault_radar_integration_slack_subscription (Resource)
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 This terraform resource manages an Integration Slack Subscription in Vault Radar.
 

--- a/docs/resources/vault_radar_source_github_cloud.md
+++ b/docs/resources/vault_radar_source_github_cloud.md
@@ -1,13 +1,13 @@
 ---
 page_title: "hcp_vault_radar_source_github_cloud Resource - terraform-provider-hcp"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
   This terraform resource manages a GitHub Cloud data source lifecycle in Vault Radar.
 ---
 
 # hcp_vault_radar_source_github_cloud (Resource)
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 This terraform resource manages a GitHub Cloud data source lifecycle in Vault Radar.
 

--- a/docs/resources/vault_radar_source_github_enterprise.md
+++ b/docs/resources/vault_radar_source_github_enterprise.md
@@ -1,13 +1,13 @@
 ---
 page_title: "hcp_vault_radar_source_github_enterprise Resource - terraform-provider-hcp"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
   This terraform resource manages a GitHub Enterprise Server data source lifecycle in Vault Radar.
 ---
 
 # hcp_vault_radar_source_github_enterprise (Resource)
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 This terraform resource manages a GitHub Enterprise Server data source lifecycle in Vault Radar.
 

--- a/templates/resources/vault_radar_integration_jira_connection.md.tmpl
+++ b/templates/resources/vault_radar_integration_jira_connection.md.tmpl
@@ -1,13 +1,13 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/vault_radar_integration_jira_subscription.md.tmpl
+++ b/templates/resources/vault_radar_integration_jira_subscription.md.tmpl
@@ -1,13 +1,13 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/vault_radar_integration_slack_connection.md.tmpl
+++ b/templates/resources/vault_radar_integration_slack_connection.md.tmpl
@@ -1,13 +1,13 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/vault_radar_integration_slack_subscription.md.tmpl
+++ b/templates/resources/vault_radar_integration_slack_subscription.md.tmpl
@@ -1,13 +1,13 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/vault_radar_source_github_cloud.md.tmpl
+++ b/templates/resources/vault_radar_source_github_cloud.md.tmpl
@@ -1,13 +1,13 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/vault_radar_source_github_enterprise.md.tmpl
+++ b/templates/resources/vault_radar_source_github_enterprise.md.tmpl
@@ -1,13 +1,13 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: ""
+subcategory: "HCP Vault Radar"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** HCP Vault Radar Terraform resources are in preview.
+-> **Note:** This feature is currently in private beta.
 
 {{ .Description | trimspace }}
 


### PR DESCRIPTION
Fix to the Vault Radar resource documentation templates.

### :hammer_and_wrench: Description
Documents did not have the subcategory set correctly.

