### PR TITLE
VAULT-32140: Enable updates to Vault Radar source tokens.

### DIFF
--- a/.changelog/1134.txt
+++ b/.changelog/1134.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Enable updates to Vault Radar source token.
+```

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.117.0
+	github.com/hashicorp/hcp-sdk-go v0.122.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.117.0 h1:7lJpkinpWdsXtejC+X7MdaE/3zhFMweB9Ym3uJ7qFJw=
-github.com/hashicorp/hcp-sdk-go v0.117.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.122.0 h1:eH9NFyscG10/LQjglWgN4HFHDZ6/8uEGDDPQ+6CXAHY=
+github.com/hashicorp/hcp-sdk-go v0.122.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/internal/clients/vault_radar.go
+++ b/internal/clients/vault_radar.go
@@ -123,6 +123,19 @@ func waitFor(ctx context.Context, retry, timeout time.Duration, maxConsecutiveEr
 	}
 }
 
+func UpdateRadarDataSourceToken(ctx context.Context, client *Client, projectID string, tokenBody dsrs.UpdateDataSourceTokenBody) error {
+	params := dsrs.NewUpdateDataSourceTokenParams()
+	params.Context = ctx
+	params.LocationProjectID = projectID
+	params.Body = tokenBody
+
+	if _, err := client.RadarSourceRegistrationService.UpdateDataSourceToken(params, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func CreateIntegrationConnection(ctx context.Context, client *Client, projectID string, connection ics.CreateIntegrationConnectionBody) (*ics.CreateIntegrationConnectionOK, error) {
 	params := ics.NewCreateIntegrationConnectionParams()
 	params.Context = ctx

--- a/internal/provider/vaultradar/resource_radar_source_github_cloud.go
+++ b/internal/provider/vaultradar/resource_radar_source_github_cloud.go
@@ -42,12 +42,16 @@ var githubCloudSourceSchema = schema.Schema{
 		"id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The ID of this resource.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"github_organization": schema.StringAttribute{
 			Description: `GitHub organization Vault Radar will monitor. Example: type "octocat" for the org https://github.com/octocat`,
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9-_.]+$`),
@@ -59,9 +63,6 @@ var githubCloudSourceSchema = schema.Schema{
 			Description: "GitHub personal access token.",
 			Required:    true,
 			Sensitive:   true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
-			},
 		},
 
 		// Optional inputs

--- a/internal/provider/vaultradar/resource_radar_source_github_cloud_test.go
+++ b/internal/provider/vaultradar/resource_radar_source_github_cloud_test.go
@@ -20,9 +20,11 @@ func TestRadarSourceGitHubCloud(t *testing.T) {
 	projectID := os.Getenv("HCP_PROJECT_ID")
 	githubOrganization := os.Getenv("RADAR_GITHUB_CLOUD_ORGANIZATION")
 	token := os.Getenv("RADAR_GITHUB_CLOUD_TOKEN")
+	updateToken := os.Getenv("RADAR_GITHUB_CLOUD_TOKEN_2")
 
-	if projectID == "" || githubOrganization == "" || token == "" {
-		t.Skip("HCP_PROJECT_ID, RADAR_GITHUB_CLOUD_ORGANIZATION, and RADAR_GITHUB_CLOUD_TOKEN must be set for acceptance tests")
+	if projectID == "" || githubOrganization == "" || token == "" || updateToken == "" {
+		t.Skip("HCP_PROJECT_ID, RADAR_GITHUB_CLOUD_ORGANIZATION, RADAR_GITHUB_CLOUD_TOKEN and " +
+			"RADAR_GITHUB_CLOUD_TOKEN_2 must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -41,9 +43,28 @@ func TestRadarSourceGitHubCloud(t *testing.T) {
 					resource.TestCheckResourceAttr("hcp_vault_radar_source_github_cloud.example", "project_id", projectID),
 					resource.TestCheckResourceAttr("hcp_vault_radar_source_github_cloud.example", "github_organization", githubOrganization),
 					resource.TestCheckResourceAttrSet("hcp_vault_radar_source_github_cloud.example", "id"),
+					resource.TestCheckResourceAttrSet("hcp_vault_radar_source_github_cloud.example", "token"),
 				),
 			},
-			// UPDATE not supported at this time.
+			// UPDATE token
+			{
+				Config: fmt.Sprintf(`
+					resource "hcp_vault_radar_source_github_cloud" "example" {
+						project_id = %q
+						github_organization = %q
+						token = %q
+					}				
+				`, projectID, githubOrganization, updateToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("hcp_vault_radar_source_github_cloud.example", "token", func(value string) error {
+						if value != updateToken {
+							// Avoid outputting the token in the error message.
+							return fmt.Errorf("expected token to be updated")
+						}
+						return nil
+					}),
+				),
+			},
 			// DELETE happens automatically.
 		},
 	})

--- a/internal/provider/vaultradar/resource_radar_source_github_enterprise.go
+++ b/internal/provider/vaultradar/resource_radar_source_github_enterprise.go
@@ -42,12 +42,16 @@ var githubEnterpriseSourceSchema = schema.Schema{
 		"id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The ID of this resource.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"domain_name": schema.StringAttribute{
 			Description: "Fully qualified domain name of the server. (Example: myserver.acme.com)",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.RegexMatches(regexp.MustCompile(`^(?:[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,}$`),
@@ -60,6 +64,7 @@ var githubEnterpriseSourceSchema = schema.Schema{
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9-_.]+$`),
@@ -71,9 +76,6 @@ var githubEnterpriseSourceSchema = schema.Schema{
 			Description: "GitHub personal access token.",
 			Required:    true,
 			Sensitive:   true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
-			},
 		},
 		// Optional inputs
 		"project_id": schema.StringAttribute{

--- a/internal/provider/vaultradar/resource_radar_source_github_enterprise_test.go
+++ b/internal/provider/vaultradar/resource_radar_source_github_enterprise_test.go
@@ -21,9 +21,11 @@ func TestRadarSourceGitHubEnterprise(t *testing.T) {
 	githubOrganization := os.Getenv("RADAR_GITHUB_ENTERPRISE_ORGANIZATION")
 	domainName := os.Getenv("RADAR_GITHUB_ENTERPRISE_DOMAIN")
 	token := os.Getenv("RADAR_GITHUB_ENTERPRISE_TOKEN")
+	updateToken := os.Getenv("RADAR_GITHUB_ENTERPRISE_TOKEN_2")
 
-	if projectID == "" || githubOrganization == "" || domainName == "" || token == "" {
-		t.Skip("HCP_PROJECT_ID, RADAR_GITHUB_ENTERPRISE_ORGANIZATION, RADAR_GITHUB_ENTERPRISE_DOMAIN, and RADAR_GITHUB_ENTERPRISE_TOKEN must be set for acceptance tests")
+	if projectID == "" || githubOrganization == "" || domainName == "" || token == "" || updateToken == "" {
+		t.Skip("HCP_PROJECT_ID, RADAR_GITHUB_ENTERPRISE_ORGANIZATION, RADAR_GITHUB_ENTERPRISE_DOMAIN, " +
+			"RADAR_GITHUB_ENTERPRISE_TOKEN and RADAR_GITHUB_ENTERPRISE_TOKEN_2 must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -46,7 +48,26 @@ func TestRadarSourceGitHubEnterprise(t *testing.T) {
 					resource.TestCheckResourceAttrSet("hcp_vault_radar_source_github_enterprise.example", "id"),
 				),
 			},
-			// UPDATE not supported at this time.
+			// Update Token
+			{
+				Config: fmt.Sprintf(`
+					resource "hcp_vault_radar_source_github_enterprise" "example" {
+						project_id = %q
+						github_organization = %q
+						domain_name = %q
+						token = %q
+					}				
+				`, projectID, githubOrganization, domainName, updateToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith("hcp_vault_radar_source_github_enterprise.example", "token", func(value string) error {
+						if value != updateToken {
+							// Avoid outputting the token in the error message.
+							return fmt.Errorf("expected token to be updated")
+						}
+						return nil
+					}),
+				),
+			},
 			// DELETE happens automatically.
 		},
 	})


### PR DESCRIPTION
### :hammer_and_wrench: Description

VAULT-32140: Enable updates to Vault Radar source tokens.
### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

> [!NOTE] 
> The test were run from my dev env.
> These AC test will be skipped for CICD because of pre-existing conditions that would be require for the test to succeed. 
> - Requires Project to already setup with Radar Provisioned.
> - Requires a Service Account with an Admin role on the Project.
> - Requires access to a GitHub Enterprise Server Org and a GitHub Cloud Org
> - Requires the following environment variables to be set:
>    - HCP_PROJECT_ID
>    - RADAR_GITHUB_ENTERPRISE_ORGANIZATION
>    - RADAR_GITHUB_ENTERPRISE_DOMAIN
>    - RADAR_GITHUB_ENTERPRISE_TOKEN
>    - RADAR_GITHUB_ENTERPRISE_TOKEN_2
>    - RADAR_GITHUB_CLOUD_ORGANIZATION
>    - RADAR_GITHUB_CLOUD_TOKEN
>    - RADAR_GITHUB_CLOUD_TOKEN_2

GitHub Enterprise
```sh
$ make testacc TESTARGS='-run=TestRadarSourceGitHubEnterprise' 
...
=== RUN   TestRadarSourceGitHubEnterprise
--- PASS: TestRadarSourceGitHubEnterprise (19.70s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultradar        20.606s
...
```

GitHub Cloud
```sh
$ make testacc TESTARGS='-run=TestRadarSourceGitHubCloud'
...
=== RUN   TestRadarSourceGitHubCloud
--- PASS: TestRadarSourceGitHubCloud (20.40s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultradar        21.044s
...
```
