### PR TITLE
VAULT-32136: Enable updates to Vault Radar integration subscriptions.

### DIFF
--- a/.changelog/1139.txt
+++ b/.changelog/1139.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Enable updates to Vault Radar integration subscriptions.
+```

--- a/internal/clients/vault_radar.go
+++ b/internal/clients/vault_radar.go
@@ -262,3 +262,16 @@ func DeleteIntegrationSubscription(ctx context.Context, client *Client, projectI
 
 	return nil
 }
+
+func UpdateIntegrationSubscription(ctx context.Context, client *Client, projectID string, subscription iss.UpdateIntegrationSubscriptionBody) error {
+	params := iss.NewUpdateIntegrationSubscriptionParams()
+	params.Context = ctx
+	params.LocationProjectID = projectID
+	params.Body = subscription
+
+	if _, err := client.RadarSubscriptionService.UpdateIntegrationSubscription(params, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/provider/vaultradar/integration_subscription.go
+++ b/internal/provider/vaultradar/integration_subscription.go
@@ -190,7 +190,61 @@ func (r *integrationSubscriptionResource) Delete(ctx context.Context, req resour
 }
 
 func (r *integrationSubscriptionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// In-place update is not supported.
-	// Plans to support updating subscription details will be in a future iteration.
-	resp.Diagnostics.AddError("Unexpected provider error", "This is an internal error, please report this issue to the provider developers")
+	plan, planDiags := r.GetSubscriptionFromPlan(ctx, req.Plan)
+	resp.Diagnostics.Append(planDiags...)
+
+	state, stateDiags := r.GetSubscriptionFromState(ctx, req.State)
+	resp.Diagnostics.Append(stateDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	projectID := r.client.Config.ProjectID
+	if !plan.GetProjectID().IsUnknown() {
+		projectID = plan.GetProjectID().ValueString()
+	}
+
+	// Initialize the update body with the subscription ID.
+	update := service.UpdateIntegrationSubscriptionBody{
+		ID: plan.GetID().ValueString(),
+	}
+
+	// Check if the name was updated
+	if !plan.GetName().Equal(state.GetName()) {
+		tflog.Trace(ctx, "Radar integration subscription name changed.")
+		update.Name = plan.GetName().ValueString()
+	}
+
+	// Check if the connection id was updated
+	if !plan.GetConnectionID().Equal(state.GetConnectionID()) {
+		tflog.Trace(ctx, "Radar integration subscription connection id changed.")
+		update.ConnectionID = plan.GetConnectionID().ValueString()
+	}
+
+	planDetails, planDiags := plan.GetDetails()
+	resp.Diagnostics.Append(planDiags...)
+
+	stateDetails, stateDiags := state.GetDetails()
+	resp.Diagnostics.Append(stateDiags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Check if the details were updated
+	if planDetails != stateDetails {
+		tflog.Trace(ctx, "Radar integration subscription details changed.")
+		update.Details = planDetails
+	}
+
+	if err := clients.UpdateIntegrationSubscription(ctx, r.client, projectID, update); err != nil {
+		resp.Diagnostics.AddError("Error Updating Radar subscription", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "Radar integration subscription updated.")
+
+	// Store the updated plan values
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/vaultradar/resource_radar_integration_jira_connection_test.go
+++ b/internal/provider/vaultradar/resource_radar_integration_jira_connection_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"
 )
 
@@ -74,6 +75,11 @@ func TestRadarIntegrationJiraConnection(t *testing.T) {
 						token = %q	
 					}
 				`, projectID, updatedName, baseURL, email, token),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_jira_connection.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_radar_integration_jira_connection.example", "name", updatedName),
 				),
@@ -89,6 +95,11 @@ func TestRadarIntegrationJiraConnection(t *testing.T) {
 						token = %q	
 					}
 				`, projectID, updatedName, updatedBaseURL, email, token),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_jira_connection.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_radar_integration_jira_connection.example", "base_url", updatedBaseURL),
 				),
@@ -104,6 +115,11 @@ func TestRadarIntegrationJiraConnection(t *testing.T) {
 						token = %q	
 					}
 				`, projectID, updatedName, updatedBaseURL, updateEmail, token),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_jira_connection.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_radar_integration_jira_connection.example", "email", updateEmail),
 				),

--- a/internal/provider/vaultradar/resource_radar_integration_jira_subscription.go
+++ b/internal/provider/vaultradar/resource_radar_integration_jira_subscription.go
@@ -41,12 +41,15 @@ var integrationJiraSubscriptionSchema = schema.Schema{
 		"id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The ID of this resource.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"name": schema.StringAttribute{
 			Description: "Name of subscription. Name must be unique.",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -56,14 +59,14 @@ var integrationJiraSubscriptionSchema = schema.Schema{
 			Description: "id of the integration jira connection to use for the subscription.",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"jira_project_key": schema.StringAttribute{
 			Description: "The name of the project under which the jira issue will be created. Example: OPS",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -73,7 +76,7 @@ var integrationJiraSubscriptionSchema = schema.Schema{
 			Description: "The type of issue to be created from the event(s). Example: Task",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -85,7 +88,7 @@ var integrationJiraSubscriptionSchema = schema.Schema{
 			Description: "The identifier of the Jira user who will be assigned the ticket. In case of Jira Cloud, this will be the Atlassian Account ID of the user. Example: 71509:11bb945b-c0de-4bac-9d57-9f09db2f7bc9",
 			Optional:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -95,7 +98,7 @@ var integrationJiraSubscriptionSchema = schema.Schema{
 			Description: "This message will be included in the ticket description.",
 			Optional:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),

--- a/internal/provider/vaultradar/resource_radar_integration_slack_connection_test.go
+++ b/internal/provider/vaultradar/resource_radar_integration_slack_connection_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"
 )
 
@@ -56,6 +57,11 @@ func TestRadarIntegrationSlackConnection(t *testing.T) {
 						token = %q	
 					}
 				`, projectID, updatedName, token),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_connection.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_radar_integration_slack_connection.example", "name", updatedName),
 				),
@@ -69,6 +75,11 @@ func TestRadarIntegrationSlackConnection(t *testing.T) {
 						token = %q	
 					}
 				`, projectID, updatedName, updateToken),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_connection.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("hcp_vault_radar_integration_slack_connection.example", "token", func(value string) error {
 						if value != updateToken {

--- a/internal/provider/vaultradar/resource_radar_integration_slack_subscription.go
+++ b/internal/provider/vaultradar/resource_radar_integration_slack_subscription.go
@@ -41,12 +41,15 @@ var integrationSlackSubscriptionSchema = schema.Schema{
 		"id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The ID of this resource.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"name": schema.StringAttribute{
 			Description: "Name of subscription. Name must be unique.",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),
@@ -56,14 +59,14 @@ var integrationSlackSubscriptionSchema = schema.Schema{
 			Description: "id of the integration slack connection to use for the subscription.",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"channel": schema.StringAttribute{
 			Description: "Name of the Slack channel that messages should be sent to. Note that HashiCorp Vault Radar will send a test message to verify the channel. Example: dev-ops-team",
 			Required:    true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
+				stringplanmodifier.UseStateForUnknown(),
 			},
 			Validators: []validator.String{
 				stringvalidator.LengthAtLeast(1),

--- a/internal/provider/vaultradar/resource_radar_integration_slack_subscription_test.go
+++ b/internal/provider/vaultradar/resource_radar_integration_slack_subscription_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"
 )
 
@@ -24,6 +25,9 @@ func TestRadarIntegrationSlackSubscription(t *testing.T) {
 	if projectID == "" || token == "" || channel == "" {
 		t.Skip("HCP_PROJECT_ID, RADAR_INTEGRATION_SLACK_TOKEN and RADAR_INTEGRATION_SLACK_CHANNEL must be set for acceptance tests")
 	}
+
+	name := "AC Test of Creating Slack Subscription From TF"
+	updatedName := "AC Test of Updating Slack Subscription From TF"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -41,18 +45,82 @@ func TestRadarIntegrationSlackSubscription(t *testing.T) {
 
 					resource "hcp_vault_radar_integration_slack_subscription" "slack_subscription" {
 						project_id = hcp_vault_radar_integration_slack_connection.slack_connection.project_id
-						name = "AC Test of Slack Subscription From TF"
+						name = %q
 						connection_id = hcp_vault_radar_integration_slack_connection.slack_connection.id
 						channel = %q
 					}
 						
-				`, projectID, token, channel),
+				`, projectID, token, name, channel),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("hcp_vault_radar_integration_slack_subscription.slack_subscription", "connection_id"),
+					resource.TestCheckResourceAttr("hcp_vault_radar_integration_slack_subscription.slack_subscription", "name", name),
 					resource.TestCheckResourceAttr("hcp_vault_radar_integration_slack_subscription.slack_subscription", "channel", channel),
 				),
 			},
-			// UPDATE not supported at this time.
+			// UPDATE name.
+			{
+				Config: fmt.Sprintf(`
+					# An integration_slack_subscription is required to create a hcp_vault_radar_integration_slack_subscription.
+					resource "hcp_vault_radar_integration_slack_connection" "slack_connection" {
+						project_id = %q
+						name = "AC Test of Slack Connect from TF"
+						token = %q	
+					}
+
+					resource "hcp_vault_radar_integration_slack_subscription" "slack_subscription" {
+						project_id = hcp_vault_radar_integration_slack_connection.slack_connection.project_id
+						name = %q
+						connection_id = hcp_vault_radar_integration_slack_connection.slack_connection.id
+						channel = %q
+					}
+						
+				`, projectID, token, updatedName, channel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_connection.slack_connection", plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_subscription.slack_subscription", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hcp_vault_radar_integration_slack_subscription.slack_subscription", "name", updatedName),
+				),
+			},
+			// UPDATE Connection ID.
+			{
+				Config: fmt.Sprintf(`
+					# An integration_slack_subscription is required to create a hcp_vault_radar_integration_slack_subscription.
+					resource "hcp_vault_radar_integration_slack_connection" "slack_connection" {
+						project_id = %q
+						name = "AC Test of Slack Connect from TF"
+						token = %q	
+					}
+
+					# Create another integration_slack_subscription to connect to.
+					resource "hcp_vault_radar_integration_slack_connection" "slack_connection_2" {
+						project_id = %q
+						name = "AC Test of Slack Connect from TF 2"
+						token = %q	
+					}
+
+					resource "hcp_vault_radar_integration_slack_subscription" "slack_subscription" {
+						project_id = hcp_vault_radar_integration_slack_connection.slack_connection.project_id
+						name = %q
+						connection_id = hcp_vault_radar_integration_slack_connection.slack_connection_2.id
+						channel = %q
+					}
+						
+				`, projectID, token, projectID, token, updatedName, channel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_connection.slack_connection", plancheck.ResourceActionNoop),
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_connection.slack_connection_2", plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction("hcp_vault_radar_integration_slack_subscription.slack_subscription", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("hcp_vault_radar_integration_slack_subscription.slack_subscription", "connection_id"),
+				),
+			},
 			// DELETE happens automatically.
 		},
 	})

--- a/internal/provider/vaultradar/resource_radar_source_github_cloud_test.go
+++ b/internal/provider/vaultradar/resource_radar_source_github_cloud_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"
 )
 
@@ -55,6 +56,11 @@ func TestRadarSourceGitHubCloud(t *testing.T) {
 						token = %q
 					}				
 				`, projectID, githubOrganization, updateToken),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_source_github_cloud.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("hcp_vault_radar_source_github_cloud.example", "token", func(value string) error {
 						if value != updateToken {

--- a/internal/provider/vaultradar/resource_radar_source_github_enterprise_test.go
+++ b/internal/provider/vaultradar/resource_radar_source_github_enterprise_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"
 )
 
@@ -58,6 +59,11 @@ func TestRadarSourceGitHubEnterprise(t *testing.T) {
 						token = %q
 					}				
 				`, projectID, githubOrganization, domainName, updateToken),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("hcp_vault_radar_source_github_enterprise.example", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrWith("hcp_vault_radar_source_github_enterprise.example", "token", func(value string) error {
 						if value != updateToken {


### PR DESCRIPTION
### :hammer_and_wrench: Description

VAULT-32136: Enable updates to Vault Radar integration subscriptions.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

> [!NOTE] 
> The test were run from my dev env.
> These AC test will be skipped for CICD because of pre-existing conditions that would be require for the test to succeed. 
> - Requires Project to already setup with Radar Provisioned.
> - Requires a Service Account with an Admin role on the Project.
> - Requires access to a Jira and Slack instances
> - Requires the following environment variables to be set:
>    - HCP_PROJECT_ID
>    - RADAR_INTEGRATION_JIRA_BASE_URL
>    - RADAR_INTEGRATION_JIRA_EMAIL
>    - RADAR_INTEGRATION_JIRA_TOKEN
>    - RADAR_INTEGRATION_JIRA_PROJECT_KEY
>    - RADAR_INTEGRATION_JIRA_ISSUE_TYPE
>    - RADAR_INTEGRATION_JIRA_ASSIGNEE
>    - RADAR_INTEGRATION_SLACK_TOKEN
>    - RADAR_INTEGRATION_SLACK_CHANNEL

Jira Subscription
```sh
$ make testacc TESTARGS='-run=TestRadarIntegrationJiraSubscription' 
...
=== RUN   TestRadarIntegrationJiraSubscription
--- PASS: TestRadarIntegrationJiraSubscription (20.60s)
PASS
...
```

Slack Subscription
```sh
$ make testacc TESTARGS='-run=TestRadarIntegrationSlackSubscription'
...
=== RUN   TestRadarIntegrationSlackSubscription
--- PASS: TestRadarIntegrationSlackSubscription (15.45s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultradar        16.089s
...
```
