### PR TITLE
HCPIE-1846: Handle DEADLINE_EXCEEDED Retries for IAM Groups and Group Members

### DIFF
--- a/.changelog/1140.txt
+++ b/.changelog/1140.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update hcp_group API calls to retry when encountering a 502, 503, or 504 error.
+```

--- a/.github/workflows/test-identity.yml
+++ b/.github/workflows/test-identity.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'internal/provider/iam/**'
+      - 'internal/clients/group.go'
+      - 'internal/clients/iam.go'
 
 jobs:
   identity_tests:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.0.11

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=

--- a/internal/clients/group.go
+++ b/internal/clients/group.go
@@ -4,28 +4,77 @@
 package clients
 
 import (
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/groups_service"
 )
+
+var groupErrorCodesToRetry = [...]int{502, 503, 504}
 
 // Groups
 
 // CreateGroupRetry wraps the groups client with an exponential backoff retry mechanism.
 func CreateGroupRetry(client *Client, params *groups_service.GroupsServiceCreateGroupParams) (*groups_service.GroupsServiceCreateGroupOK, error) {
-	res, err := client.Groups.GroupsServiceCreateGroup(params, nil)
+	var res *groups_service.GroupsServiceCreateGroupOK
+	op := func() error {
+		var err error
+		res, err = client.Groups.GroupsServiceCreateGroup(params, nil)
+		return err
+	}
+
+	getCode := func(err error) (int, error) {
+		serviceErr, ok := err.(*groups_service.GroupsServiceCreateGroupDefault)
+		if !ok {
+			return 0, err
+		}
+		return serviceErr.Code(), nil
+	}
+
+	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
 
 	return res, err
 }
 
 // UpdateGroupRetry wraps the groups client with an exponential backoff retry mechanism.
 func UpdateGroupRetry(client *Client, params *groups_service.GroupsServiceUpdateGroup2Params) (*groups_service.GroupsServiceUpdateGroup2OK, error) {
-	res, err := client.Groups.GroupsServiceUpdateGroup2(params, nil)
+	var res *groups_service.GroupsServiceUpdateGroup2OK
+	op := func() error {
+		var err error
+		res, err = client.Groups.GroupsServiceUpdateGroup2(params, nil)
+		return err
+	}
+
+	getCode := func(err error) (int, error) {
+		serviceErr, ok := err.(*groups_service.GroupsServiceUpdateGroup2Default)
+		if !ok {
+			return 0, err
+		}
+		return serviceErr.Code(), nil
+	}
+
+	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
 
 	return res, err
 }
 
 // DeleteGroupRetry wraps the groups client with an exponential backoff retry mechanism.
 func DeleteGroupRetry(client *Client, params *groups_service.GroupsServiceDeleteGroupParams) (*groups_service.GroupsServiceDeleteGroupOK, error) {
-	res, err := client.Groups.GroupsServiceDeleteGroup(params, nil)
+	var res *groups_service.GroupsServiceDeleteGroupOK
+	op := func() error {
+		var err error
+		res, err = client.Groups.GroupsServiceDeleteGroup(params, nil)
+		return err
+	}
+
+	getCode := func(err error) (int, error) {
+		serviceErr, ok := err.(*groups_service.GroupsServiceDeleteGroupDefault)
+		if !ok {
+			return 0, err
+		}
+		return serviceErr.Code(), nil
+	}
+
+	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
 
 	return res, err
 }
@@ -34,7 +83,55 @@ func DeleteGroupRetry(client *Client, params *groups_service.GroupsServiceDelete
 
 // UpdateGroupMembersRetry wraps the groups client with an exponential backoff retry mechanism.
 func UpdateGroupMembersRetry(client *Client, params *groups_service.GroupsServiceUpdateGroupMembersParams) (*groups_service.GroupsServiceUpdateGroupMembersOK, error) {
-	res, err := client.Groups.GroupsServiceUpdateGroupMembers(params, nil)
+	var res *groups_service.GroupsServiceUpdateGroupMembersOK
+	op := func() error {
+		var err error
+		res, err = client.Groups.GroupsServiceUpdateGroupMembers(params, nil)
+		return err
+	}
+
+	getCode := func(err error) (int, error) {
+		serviceErr, ok := err.(*groups_service.GroupsServiceUpdateGroupMembersDefault)
+		if !ok {
+			return 0, err
+		}
+		return serviceErr.Code(), nil
+	}
+
+	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
 
 	return res, err
+}
+
+// newBackoff creates a new exponential backoff with default values.
+func newBackoff() backoff.BackOff {
+	// Create a new exponential backoff with explicit default values.
+	return backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(backoff.DefaultInitialInterval),
+		backoff.WithRandomizationFactor(backoff.DefaultRandomizationFactor),
+		backoff.WithMultiplier(backoff.DefaultMultiplier),
+		backoff.WithMaxInterval(backoff.DefaultMaxInterval),
+		backoff.WithMaxElapsedTime(backoff.DefaultMaxElapsedTime),
+	)
+}
+
+func newBackoffOp(op func() error, getCode func(error) (int, error)) func() error {
+	return func() error {
+		err := op()
+
+		if err == nil {
+			return nil
+		}
+
+		code, err := getCode(err)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+
+		if !shouldRetryErrorCode(code, groupErrorCodesToRetry[:]) {
+			return backoff.Permanent(err)
+		}
+
+		return err
+	}
 }

--- a/internal/clients/group.go
+++ b/internal/clients/group.go
@@ -123,9 +123,9 @@ func newBackoffOp(op func() error, getCode func(error) (int, error)) func() erro
 			return nil
 		}
 
-		code, err := getCode(err)
-		if err != nil {
-			return backoff.Permanent(err)
+		code, codeErr := getCode(err)
+		if codeErr != nil {
+			return backoff.Permanent(codeErr)
 		}
 
 		if !shouldRetryErrorCode(code, groupErrorCodesToRetry[:]) {

--- a/internal/clients/group.go
+++ b/internal/clients/group.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package clients
+
+import (
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-iam/stable/2019-12-10/client/groups_service"
+)
+
+// Groups
+
+// CreateGroupRetry wraps the groups client with an exponential backoff retry mechanism.
+func CreateGroupRetry(client *Client, params *groups_service.GroupsServiceCreateGroupParams) (*groups_service.GroupsServiceCreateGroupOK, error) {
+	res, err := client.Groups.GroupsServiceCreateGroup(params, nil)
+
+	return res, err
+}
+
+// UpdateGroupRetry wraps the groups client with an exponential backoff retry mechanism.
+func UpdateGroupRetry(client *Client, params *groups_service.GroupsServiceUpdateGroup2Params) (*groups_service.GroupsServiceUpdateGroup2OK, error) {
+	res, err := client.Groups.GroupsServiceUpdateGroup2(params, nil)
+
+	return res, err
+}
+
+// DeleteGroupRetry wraps the groups client with an exponential backoff retry mechanism.
+func DeleteGroupRetry(client *Client, params *groups_service.GroupsServiceDeleteGroupParams) (*groups_service.GroupsServiceDeleteGroupOK, error) {
+	res, err := client.Groups.GroupsServiceDeleteGroup(params, nil)
+
+	return res, err
+}
+
+// Group Members
+
+// UpdateGroupMembersRetry wraps the groups client with an exponential backoff retry mechanism.
+func UpdateGroupMembersRetry(client *Client, params *groups_service.GroupsServiceUpdateGroupMembersParams) (*groups_service.GroupsServiceUpdateGroupMembersOK, error) {
+	res, err := client.Groups.GroupsServiceUpdateGroupMembers(params, nil)
+
+	return res, err
+}

--- a/internal/provider/iam/resource_group.go
+++ b/internal/provider/iam/resource_group.go
@@ -117,7 +117,7 @@ func (r *resourceGroup) Create(ctx context.Context, req resource.CreateRequest, 
 		Description: plan.Description.ValueString(),
 	}
 
-	res, err := r.client.Groups.GroupsServiceCreateGroup(createParams, nil)
+	res, err := clients.CreateGroupRetry(r.client, createParams)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating group", err.Error())
@@ -198,7 +198,7 @@ func (r *resourceGroup) Update(ctx context.Context, req resource.UpdateRequest, 
 	updateMaskStr := strings.Join(updateMask, ",")
 	updateParams.SetUpdateMask(&updateMaskStr)
 
-	_, err := r.client.Groups.GroupsServiceUpdateGroup2(updateParams, nil)
+	_, err := clients.UpdateGroupRetry(r.client, updateParams)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating group", err.Error())
 		return
@@ -217,7 +217,8 @@ func (r *resourceGroup) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	deleteParams := groups_service.NewGroupsServiceDeleteGroupParams().WithContext(ctx)
 	deleteParams.ResourceName = state.ResourceName.ValueString()
-	_, err := r.client.Groups.GroupsServiceDeleteGroup(deleteParams, nil)
+
+	_, err := clients.DeleteGroupRetry(r.client, deleteParams)
 
 	if err != nil {
 		var getErr *groups_service.GroupsServiceDeleteGroupDefault

--- a/internal/provider/iam/resource_group_members.go
+++ b/internal/provider/iam/resource_group_members.go
@@ -105,7 +105,7 @@ func (r *resourceGroupMembers) Create(ctx context.Context, req resource.CreateRe
 		MemberPrincipalIdsToAdd: members,
 	})
 
-	_, err = r.client.Groups.GroupsServiceUpdateGroupMembers(updateParams, nil)
+	_, err = clients.UpdateGroupMembersRetry(r.client, updateParams)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update group members", err.Error())
 		return
@@ -187,7 +187,7 @@ func (r *resourceGroupMembers) Update(ctx context.Context, req resource.UpdateRe
 			MemberPrincipalIdsToRemove: membersToRemove,
 		})
 
-		_, err := r.client.Groups.GroupsServiceUpdateGroupMembers(updateParams, nil)
+		_, err := clients.UpdateGroupMembersRetry(r.client, updateParams)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to update group members", err.Error())
 			return
@@ -216,7 +216,7 @@ func (r *resourceGroupMembers) Delete(ctx context.Context, req resource.DeleteRe
 		MemberPrincipalIdsToRemove: members,
 	})
 
-	_, err := r.client.Groups.GroupsServiceUpdateGroupMembers(updateParams, nil)
+	_, err := clients.UpdateGroupMembersRetry(r.client, updateParams)
 	if err != nil {
 		var errResp *groups_service.GroupsServiceUpdateGroupMembersDefault
 		if errors.As(err, &errResp) && !errResp.IsCode(http.StatusNotFound) {


### PR DESCRIPTION
### :hammer_and_wrench: Description

Adds a retry wrapper around the Groups and Group Member clients. This wrapper uses exponential backoff to handle the retry.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality? **No**
- [ ] Have you added an acceptance test for the functionality being added? **Existing acceptance tests cover the code changes**
- [ ] Have you run the acceptance tests on this branch? **Identity acceptance tests run as a part of CI when there are changes in the Identity directories. Output is shown below.**

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test -short -coverprofile=coverage-e2e.out ./internal/provider/iam -v  -timeout 360m -parallel=10
=== RUN   TestAccGroupDataSource
--- PASS: TestAccGroupDataSource (5.34s)
=== RUN   TestAccServicePrincipalDataSource
--- PASS: TestAccServicePrincipalDataSource (2.67s)
=== RUN   TestAccUserPrincipalDataSource
--- PASS: TestAccUserPrincipalDataSource (3.60s)
=== RUN   TestAccGroupIamPolicyResource
--- PASS: TestAccGroupIamPolicyResource (5.77s)
=== RUN   TestAccGroupIamBindingResource
--- PASS: TestAccGroupIamBindingResource (9.79s)
=== RUN   TestAccGroupMembersResource
--- PASS: TestAccGroupMembersResource (9.63s)
=== RUN   TestAccGroupResource
--- PASS: TestAccGroupResource (9.54s)
=== RUN   TestAccServicePrincipalKeyResource
--- PASS: TestAccServicePrincipalKeyResource (14.22s)
=== RUN   TestAccServicePrincipalResource_Project
--- PASS: TestAccServicePrincipalResource_Project (5.20s)
=== RUN   TestAccServicePrincipalResource_ExplicitProject
--- PASS: TestAccServicePrincipalResource_ExplicitProject (2.89s)
=== RUN   TestAccServicePrincipalResource_Organization
--- PASS: TestAccServicePrincipalResource_Organization (3.47s)
=== RUN   TestAccWorkloadIdentityProviderResource
--- PASS: TestAccWorkloadIdentityProviderResource (6.65s)
PASS
coverage: 69.7% of statements
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	78.779s	coverage: 69.7% of statements
```
