### PR TITLE
HVS use stable/2023-11-28 api

### DIFF
--- a/.changelog/1142.txt
+++ b/.changelog/1142.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Upgrade the HCP SDK and update Vault Secrets to use API V2 (stable/2023-11-28)
+```

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.122.0
+	github.com/hashicorp/hcp-sdk-go v0.123.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.122.0 h1:eH9NFyscG10/LQjglWgN4HFHDZ6/8uEGDDPQ+6CXAHY=
-github.com/hashicorp/hcp-sdk-go v0.122.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.123.0 h1:kUf/kSCVkQ4XXyny8GUyUWjvIIIanGRRkhRmgj2lC+4=
+github.com/hashicorp/hcp-sdk-go v0.123.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -47,10 +47,8 @@ import (
 	cloud_vault "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-service/stable/2020-11-25/client/vault_service"
 
-	cloud_vault_secrets_preview "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client"
-	secret_service_preview "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	cloud_vault_secrets "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
+	cloud_vault_secrets "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 
 	cloud_waypoint "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
@@ -88,7 +86,6 @@ type Client struct {
 	Groups                         groups_service.ClientService
 	Vault                          vault_service.ClientService
 	VaultSecrets                   secret_service.ClientService
-	VaultSecretsPreview            secret_service_preview.ClientService
 	Waypoint                       waypoint_service.ClientService
 	Webhook                        webhook_service.ClientService
 	LogService                     log_service.ClientService
@@ -180,7 +177,6 @@ func NewClient(config ClientConfig) (*Client, error) {
 		Groups:                         cloud_iam.New(httpClient, nil).GroupsService,
 		Vault:                          cloud_vault.New(httpClient, nil).VaultService,
 		VaultSecrets:                   cloud_vault_secrets.New(httpClient, nil).SecretService,
-		VaultSecretsPreview:            cloud_vault_secrets_preview.New(httpClient, nil).SecretService,
 		Waypoint:                       cloud_waypoint.New(httpClient, nil).WaypointService,
 		LogService:                     cloud_log_service.New(httpClient, nil).LogService,
 		Webhook:                        cloud_webhook.New(httpClient, nil).WebhookService,

--- a/internal/clients/vault_secrets.go
+++ b/internal/clients/vault_secrets.go
@@ -14,19 +14,19 @@ import (
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-06-13/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 )
 
 // CreateVaultSecretsApp will create a Vault Secrets application.
-func CreateVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string, description string) (*secretmodels.Secrets20230613App, error) {
+func CreateVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string, description string) (*secretmodels.Secrets20231128App, error) {
 
 	createParams := secret_service.NewCreateAppParams()
 	createParams.Context = ctx
 	createParams.Body.Name = appName
 	createParams.Body.Description = description
-	createParams.LocationOrganizationID = loc.OrganizationID
-	createParams.LocationProjectID = loc.ProjectID
+	createParams.OrganizationID = loc.OrganizationID
+	createParams.ProjectID = loc.ProjectID
 
 	createResp, err := client.VaultSecrets.CreateApp(createParams, nil)
 	if err != nil {
@@ -37,12 +37,12 @@ func CreateVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodel
 }
 
 // GetVaultSecretsApp will read a Vault Secrets application
-func GetVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*secretmodels.Secrets20230613App, error) {
+func GetVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*secretmodels.Secrets20231128App, error) {
 	getParams := secret_service.NewGetAppParams()
 	getParams.Context = ctx
 	getParams.Name = appName
-	getParams.LocationOrganizationID = loc.OrganizationID
-	getParams.LocationProjectID = loc.ProjectID
+	getParams.OrganizationID = loc.OrganizationID
+	getParams.ProjectID = loc.ProjectID
 
 	getResp, err := client.VaultSecrets.GetApp(getParams, nil)
 	if err != nil {
@@ -53,13 +53,13 @@ func GetVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.H
 }
 
 // UpdateVaultSecretsApp will update an app's description
-func UpdateVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string, description string) (*secretmodels.Secrets20230613App, error) {
+func UpdateVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string, description string) (*secretmodels.Secrets20231128App, error) {
 	updateParams := secret_service.NewUpdateAppParams()
 	updateParams.Context = ctx
 	updateParams.Name = appName
 	updateParams.Body.Description = description
-	updateParams.LocationOrganizationID = loc.OrganizationID
-	updateParams.LocationProjectID = loc.ProjectID
+	updateParams.OrganizationID = loc.OrganizationID
+	updateParams.ProjectID = loc.ProjectID
 
 	updateResp, err := client.VaultSecrets.UpdateApp(updateParams, nil)
 	if err != nil {
@@ -75,8 +75,8 @@ func DeleteVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodel
 	deleteParams := secret_service.NewDeleteAppParams()
 	deleteParams.Context = ctx
 	deleteParams.Name = appName
-	deleteParams.LocationOrganizationID = loc.OrganizationID
-	deleteParams.LocationProjectID = loc.ProjectID
+	deleteParams.OrganizationID = loc.OrganizationID
+	deleteParams.ProjectID = loc.ProjectID
 
 	_, err := client.VaultSecrets.DeleteApp(deleteParams, nil)
 	if err != nil {
@@ -87,15 +87,15 @@ func DeleteVaultSecretsApp(ctx context.Context, client *Client, loc *sharedmodel
 }
 
 // CreateVaultSecretsAppSecret will create a Vault Secrets application secret.
-func CreateVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName, secretName, secretValue string) (*secretmodels.Secrets20230613Secret, error) {
+func CreateVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName, secretName, secretValue string) (*secretmodels.Secrets20231128Secret, error) {
 
 	createParams := secret_service.NewCreateAppKVSecretParams()
 	createParams.Context = ctx
 	createParams.AppName = appName
 	createParams.Body.Name = secretName
 	createParams.Body.Value = secretValue
-	createParams.LocationOrganizationID = loc.OrganizationID
-	createParams.LocationProjectID = loc.ProjectID
+	createParams.OrganizationID = loc.OrganizationID
+	createParams.ProjectID = loc.ProjectID
 
 	createResp, err := client.VaultSecrets.CreateAppKVSecret(createParams, nil)
 	if err != nil {
@@ -112,8 +112,8 @@ func DeleteVaultSecretsAppSecret(ctx context.Context, client *Client, loc *share
 	deleteParams.Context = ctx
 	deleteParams.AppName = appName
 	deleteParams.SecretName = secretName
-	deleteParams.LocationOrganizationID = loc.OrganizationID
-	deleteParams.LocationProjectID = loc.ProjectID
+	deleteParams.OrganizationID = loc.OrganizationID
+	deleteParams.ProjectID = loc.ProjectID
 
 	_, err := client.VaultSecrets.DeleteAppSecret(deleteParams, nil)
 	if err != nil {

--- a/internal/clients/vault_secrets_preview.go
+++ b/internal/clients/vault_secrets_preview.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -27,7 +27,7 @@ func OpenVaultSecretsAppSecret(ctx context.Context, client *Client, loc *sharedm
 	var getResp *secret_service.OpenAppSecretOK
 	var err error
 	for attempt := 0; attempt < retryCount; attempt++ {
-		getResp, err = client.VaultSecretsPreview.OpenAppSecret(getParams, nil)
+		getResp, err = client.VaultSecrets.OpenAppSecret(getParams, nil)
 		if err != nil {
 			var serviceErr *secret_service.OpenAppSecretDefault
 			ok := errors.As(err, &serviceErr)
@@ -65,7 +65,7 @@ func OpenVaultSecretsAppSecrets(ctx context.Context, client *Client, loc *shared
 
 	for {
 		for attempt := 0; attempt < retryCount; attempt++ {
-			secrets, err = client.VaultSecretsPreview.OpenAppSecrets(params, nil)
+			secrets, err = client.VaultSecrets.OpenAppSecrets(params, nil)
 			if err != nil {
 				var serviceErr *secret_service.OpenAppSecretDefault
 				ok := errors.As(err, &serviceErr)
@@ -98,7 +98,7 @@ func GetRotatingSecretState(ctx context.Context, client *Client, loc *sharedmode
 		WithAppName(appName).
 		WithName(secretName)
 
-	resp, err := client.VaultSecretsPreview.GetRotatingSecretState(params, nil)
+	resp, err := client.VaultSecrets.GetRotatingSecretState(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func CreateMongoDBAtlasRotationIntegration(ctx context.Context, client *Client, 
 		WithProjectID(loc.ProjectID).
 		WithBody(&body)
 
-	resp, err := client.VaultSecretsPreview.CreateMongoDBAtlasIntegration(params, nil)
+	resp, err := client.VaultSecrets.CreateMongoDBAtlasIntegration(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func DeleteMongoDBAtlasRotationIntegration(ctx context.Context, client *Client, 
 		WithProjectID(loc.ProjectID).
 		WithName(integrationName)
 
-	_, err := client.VaultSecretsPreview.DeleteMongoDBAtlasIntegration(params, nil)
+	_, err := client.VaultSecrets.DeleteMongoDBAtlasIntegration(params, nil)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func CreateMongoDBAtlasRotatingSecret(
 		WithAppName(appName).
 		WithBody(requestBody)
 
-	resp, err := client.VaultSecretsPreview.CreateMongoDBAtlasRotatingSecret(params, nil)
+	resp, err := client.VaultSecrets.CreateMongoDBAtlasRotatingSecret(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func CreateAwsIntegration(ctx context.Context, client *Client, loc *sharedmodels
 		WithProjectID(loc.ProjectID).
 		WithBody(&body)
 
-	resp, err := client.VaultSecretsPreview.CreateAwsIntegration(params, nil)
+	resp, err := client.VaultSecrets.CreateAwsIntegration(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func DeleteAwsIntegration(ctx context.Context, client *Client, loc *sharedmodels
 		WithProjectID(loc.ProjectID).
 		WithName(name)
 
-	_, err := client.VaultSecretsPreview.DeleteAwsIntegration(params, nil)
+	_, err := client.VaultSecrets.DeleteAwsIntegration(params, nil)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func CreateAwsDynamicSecret(ctx context.Context, client *Client, loc *sharedmode
 		WithAppName(appName).
 		WithBody(&body)
 
-	resp, err := client.VaultSecretsPreview.CreateAwsDynamicSecret(params, nil)
+	resp, err := client.VaultSecrets.CreateAwsDynamicSecret(params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func DeleteAwsDynamicSecret(ctx context.Context, client *Client, loc *sharedmode
 		WithAppName(appName).
 		WithName(name)
 
-	_, err := client.VaultSecretsPreview.DeleteAwsDynamicSecret(params, nil)
+	_, err := client.VaultSecrets.DeleteAwsDynamicSecret(params, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_dynamic_secret_test.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_dynamic_secret_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"

--- a/internal/provider/vaultsecrets/data_source_vault_secrets_rotating_secret_test.go
+++ b/internal/provider/vaultsecrets/data_source_vault_secrets_rotating_secret_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 

--- a/internal/provider/vaultsecrets/dynamic_secret_aws.go
+++ b/internal/provider/vaultsecrets/dynamic_secret_aws.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/provider/vaultsecrets/dynamic_secret_gcp.go
+++ b/internal/provider/vaultsecrets/dynamic_secret_gcp.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/provider/vaultsecrets/resource_vault_secrets_app.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_app.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -120,7 +120,7 @@ func (r *resourceVaultSecretsApp) Create(ctx context.Context, req resource.Creat
 			return nil, fmt.Errorf("invalid resource type, expected *App, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.CreateApp(&secret_service.CreateAppParams{
+		response, err := r.client.VaultSecrets.CreateApp(&secret_service.CreateAppParams{
 			Body: &secretmodels.SecretServiceCreateAppBody{
 				Name:        app.AppName.ValueString(),
 				Description: app.Description.ValueString(),
@@ -145,7 +145,7 @@ func (r *resourceVaultSecretsApp) Read(ctx context.Context, req resource.ReadReq
 			return nil, fmt.Errorf("invalid integration type, expected *App, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.GetApp(
+		response, err := r.client.VaultSecrets.GetApp(
 			secret_service.NewGetAppParamsWithContext(ctx).
 				WithOrganizationID(app.OrganizationID.ValueString()).
 				WithProjectID(app.ProjectID.ValueString()).
@@ -167,7 +167,7 @@ func (r *resourceVaultSecretsApp) Update(ctx context.Context, req resource.Updat
 			return nil, fmt.Errorf("invalid integration type, expected *App, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.UpdateApp(&secret_service.UpdateAppParams{
+		response, err := r.client.VaultSecrets.UpdateApp(&secret_service.UpdateAppParams{
 			Body: &secretmodels.SecretServiceUpdateAppBody{
 				Description: app.Description.ValueString(),
 			},
@@ -192,7 +192,7 @@ func (r *resourceVaultSecretsApp) Delete(ctx context.Context, req resource.Delet
 			return nil, fmt.Errorf("invalid integration type, expected *App, got: %T, this is a bug on the provider", i)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteApp(
+		_, err := r.client.VaultSecrets.DeleteApp(
 			secret_service.NewDeleteAppParamsWithContext(ctx).
 				WithOrganizationID(app.OrganizationID.ValueString()).
 				WithProjectID(app.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_app_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -52,7 +52,7 @@ func TestAccVaultSecretsResourceApp(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteApp(&secret_service.DeleteAppParams{
+					_, err := client.VaultSecrets.DeleteApp(&secret_service.DeleteAppParams{
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
 						Name:           appName2,
@@ -73,7 +73,7 @@ func TestAccVaultSecretsResourceApp(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.CreateApp(&secret_service.CreateAppParams{
+					_, err := client.VaultSecrets.CreateApp(&secret_service.CreateAppParams{
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
 						Body: &models.SecretServiceCreateAppBody{
@@ -130,7 +130,7 @@ func appExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetApp(
+	response, err := client.VaultSecrets.GetApp(
 		secret_service.NewGetAppParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_dynamic_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_dynamic_secret.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -161,7 +161,7 @@ func (r *resourceVaultSecretsDynamicSecret) Read(ctx context.Context, req resour
 		if !ok {
 			return nil, fmt.Errorf(unsupportedProviderErrorFmt, maps.Keys(dynamicSecretsImpl), secret.SecretProvider.ValueString())
 		}
-		return dynamicSecretImpl.read(ctx, r.client.VaultSecretsPreview, secret)
+		return dynamicSecretImpl.read(ctx, r.client.VaultSecrets, secret)
 	})...)
 }
 
@@ -176,7 +176,7 @@ func (r *resourceVaultSecretsDynamicSecret) Create(ctx context.Context, req reso
 		if !ok {
 			return nil, fmt.Errorf(unsupportedProviderErrorFmt, maps.Keys(dynamicSecretsImpl), secret.SecretProvider.ValueString())
 		}
-		return dynamicSecretImpl.create(ctx, r.client.VaultSecretsPreview, secret)
+		return dynamicSecretImpl.create(ctx, r.client.VaultSecrets, secret)
 	})...)
 }
 
@@ -191,7 +191,7 @@ func (r *resourceVaultSecretsDynamicSecret) Update(ctx context.Context, req reso
 		if !ok {
 			return nil, fmt.Errorf(unsupportedProviderErrorFmt, maps.Keys(dynamicSecretsImpl), secret.SecretProvider.ValueString())
 		}
-		return dynamicSecretImpl.update(ctx, r.client.VaultSecretsPreview, secret)
+		return dynamicSecretImpl.update(ctx, r.client.VaultSecrets, secret)
 	})...)
 }
 
@@ -202,7 +202,7 @@ func (r *resourceVaultSecretsDynamicSecret) Delete(ctx context.Context, req reso
 			return nil, fmt.Errorf(invalidSecretTypeErrorFmt, s)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteAppSecret(
+		_, err := r.client.VaultSecrets.DeleteAppSecret(
 			secret_service.NewDeleteAppSecretParamsWithContext(ctx).
 				WithOrganizationID(secret.OrganizationID.ValueString()).
 				WithProjectID(secret.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_dynamic_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_dynamic_secret_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -64,7 +64,7 @@ func testAccVaultSecretsResourceDynamicSecretAWS(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteAppSecret(&secret_service.DeleteAppSecretParams{
+					_, err := client.VaultSecrets.DeleteAppSecret(&secret_service.DeleteAppSecretParams{
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
 						AppName:        appName,
@@ -126,7 +126,7 @@ func awsDynamicSecretExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetAwsDynamicSecret(
+	response, err := client.VaultSecrets.GetAwsDynamicSecret(
 		secret_service.NewGetAwsDynamicSecretParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).
@@ -177,7 +177,7 @@ func testAccVaultSecretsResourceDynamicSecretGCP(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteAppSecret(&secret_service.DeleteAppSecretParams{
+					_, err := client.VaultSecrets.DeleteAppSecret(&secret_service.DeleteAppSecretParams{
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
 						AppName:        appName,
@@ -239,7 +239,7 @@ func gcpDynamicSecretExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetGcpDynamicSecret(
+	response, err := client.VaultSecrets.GetGcpDynamicSecret(
 		secret_service.NewGetGcpDynamicSecretParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_aws.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_aws.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -148,7 +148,7 @@ func (r *resourceVaultSecretsIntegrationAWS) Read(ctx context.Context, req resou
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationAWS, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.GetAwsIntegration(
+		response, err := r.client.VaultSecrets.GetAwsIntegration(
 			secret_service.NewGetAwsIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).
@@ -170,7 +170,7 @@ func (r *resourceVaultSecretsIntegrationAWS) Create(ctx context.Context, req res
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationAWS, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.CreateAwsIntegration(&secret_service.CreateAwsIntegrationParams{
+		response, err := r.client.VaultSecrets.CreateAwsIntegration(&secret_service.CreateAwsIntegrationParams{
 			Body: &secretmodels.SecretServiceCreateAwsIntegrationBody{
 				AccessKeys:                integration.accessKeys,
 				Capabilities:              integration.capabilities,
@@ -197,7 +197,7 @@ func (r *resourceVaultSecretsIntegrationAWS) Update(ctx context.Context, req res
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationAWS, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.UpdateAwsIntegration(&secret_service.UpdateAwsIntegrationParams{
+		response, err := r.client.VaultSecrets.UpdateAwsIntegration(&secret_service.UpdateAwsIntegrationParams{
 			Body: &secretmodels.SecretServiceUpdateAwsIntegrationBody{
 				AccessKeys:                integration.accessKeys,
 				Capabilities:              integration.capabilities,
@@ -224,7 +224,7 @@ func (r *resourceVaultSecretsIntegrationAWS) Delete(ctx context.Context, req res
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationAWS, got: %T, this is a bug on the provider", i)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteAwsIntegration(
+		_, err := r.client.VaultSecrets.DeleteAwsIntegration(
 			secret_service.NewDeleteAwsIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_aws_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_aws_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -175,7 +175,7 @@ func awsIntegrationExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetAwsIntegration(
+	response, err := client.VaultSecrets.GetAwsIntegration(
 		secret_service.NewGetAwsIntegrationParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_confluent.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_confluent.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -115,7 +115,7 @@ func (r *resourceVaultSecretsIntegrationConfluent) Read(ctx context.Context, req
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationConfluent, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.GetConfluentIntegration(
+		response, err := r.client.VaultSecrets.GetConfluentIntegration(
 			secret_service.NewGetConfluentIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).
@@ -137,7 +137,7 @@ func (r *resourceVaultSecretsIntegrationConfluent) Create(ctx context.Context, r
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationConfluent, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.CreateConfluentIntegration(&secret_service.CreateConfluentIntegrationParams{
+		response, err := r.client.VaultSecrets.CreateConfluentIntegration(&secret_service.CreateConfluentIntegrationParams{
 			Body: &secretmodels.SecretServiceCreateConfluentIntegrationBody{
 				Capabilities:            integration.capabilities,
 				Name:                    integration.Name.ValueString(),
@@ -163,7 +163,7 @@ func (r *resourceVaultSecretsIntegrationConfluent) Update(ctx context.Context, r
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationConfluent, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.UpdateConfluentIntegration(&secret_service.UpdateConfluentIntegrationParams{
+		response, err := r.client.VaultSecrets.UpdateConfluentIntegration(&secret_service.UpdateConfluentIntegrationParams{
 			Body: &secretmodels.SecretServiceUpdateConfluentIntegrationBody{
 				Capabilities:            integration.capabilities,
 				StaticCredentialDetails: integration.staticCredentialDetails,
@@ -189,7 +189,7 @@ func (r *resourceVaultSecretsIntegrationConfluent) Delete(ctx context.Context, r
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationConfluent, got: %T, this is a bug on the provider", i)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteConfluentIntegration(
+		_, err := r.client.VaultSecrets.DeleteConfluentIntegration(
 			secret_service.NewDeleteConfluentIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_confluent_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_confluent_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -46,7 +46,7 @@ func TestAccVaultSecretsResourceIntegrationConfluent(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteConfluentIntegration(&secret_service.DeleteConfluentIntegrationParams{
+					_, err := client.VaultSecrets.DeleteConfluentIntegration(&secret_service.DeleteConfluentIntegrationParams{
 						Name:           integrationName2,
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
@@ -67,7 +67,7 @@ func TestAccVaultSecretsResourceIntegrationConfluent(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.CreateConfluentIntegration(&secret_service.CreateConfluentIntegrationParams{
+					_, err := client.VaultSecrets.CreateConfluentIntegration(&secret_service.CreateConfluentIntegrationParams{
 						Body: &secretmodels.SecretServiceCreateConfluentIntegrationBody{
 							Capabilities: []*secretmodels.Secrets20231128Capability{secretmodels.Secrets20231128CapabilityROTATION.Pointer()},
 							StaticCredentialDetails: &secretmodels.Secrets20231128ConfluentStaticCredentialsRequest{
@@ -135,7 +135,7 @@ func confluentIntegrationExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetConfluentIntegration(
+	response, err := client.VaultSecrets.GetConfluentIntegration(
 		secret_service.NewGetConfluentIntegrationParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_gcp.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_gcp.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -152,7 +152,7 @@ func (r *resourceVaultSecretsIntegrationGCP) Read(ctx context.Context, req resou
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationGCP, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.GetGcpIntegration(
+		response, err := r.client.VaultSecrets.GetGcpIntegration(
 			secret_service.NewGetGcpIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).
@@ -174,7 +174,7 @@ func (r *resourceVaultSecretsIntegrationGCP) Create(ctx context.Context, req res
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationGCP, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.CreateGcpIntegration(&secret_service.CreateGcpIntegrationParams{
+		response, err := r.client.VaultSecrets.CreateGcpIntegration(&secret_service.CreateGcpIntegrationParams{
 			Body: &secretmodels.SecretServiceCreateGcpIntegrationBody{
 				Capabilities:              integration.capabilities,
 				FederatedWorkloadIdentity: integration.federatedWorkloadIdentity,
@@ -201,7 +201,7 @@ func (r *resourceVaultSecretsIntegrationGCP) Update(ctx context.Context, req res
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationGCP, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.UpdateGcpIntegration(&secret_service.UpdateGcpIntegrationParams{
+		response, err := r.client.VaultSecrets.UpdateGcpIntegration(&secret_service.UpdateGcpIntegrationParams{
 			Body: &secretmodels.SecretServiceUpdateGcpIntegrationBody{
 				Capabilities:              integration.capabilities,
 				FederatedWorkloadIdentity: integration.federatedWorkloadIdentity,
@@ -228,7 +228,7 @@ func (r *resourceVaultSecretsIntegrationGCP) Delete(ctx context.Context, req res
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationGCP, got: %T, this is a bug on the provider", i)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteGcpIntegration(
+		_, err := r.client.VaultSecrets.DeleteGcpIntegration(
 			secret_service.NewDeleteGcpIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_gcp_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_gcp_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -56,7 +56,7 @@ func TestAccVaultSecretsResourceIntegrationGCP(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteGcpIntegration(&secret_service.DeleteGcpIntegrationParams{
+					_, err := client.VaultSecrets.DeleteGcpIntegration(&secret_service.DeleteGcpIntegrationParams{
 						Name:           integrationName2,
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
@@ -77,7 +77,7 @@ func TestAccVaultSecretsResourceIntegrationGCP(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.CreateGcpIntegration(&secret_service.CreateGcpIntegrationParams{
+					_, err := client.VaultSecrets.CreateGcpIntegration(&secret_service.CreateGcpIntegrationParams{
 						Body: &secretmodels.SecretServiceCreateGcpIntegrationBody{
 							Capabilities: []*secretmodels.Secrets20231128Capability{secretmodels.Secrets20231128CapabilityROTATION.Pointer()},
 							FederatedWorkloadIdentity: &secretmodels.Secrets20231128GcpFederatedWorkloadIdentityRequest{
@@ -171,7 +171,7 @@ func gcpIntegrationExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetGcpIntegration(
+	response, err := client.VaultSecrets.GetGcpIntegration(
 		secret_service.NewGetGcpIntegrationParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_mongodbatlas.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_mongodbatlas.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -115,7 +115,7 @@ func (r *resourceVaultSecretsIntegrationMongoDBAtlas) Read(ctx context.Context, 
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationMongoDBAtlas, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.GetMongoDBAtlasIntegration(
+		response, err := r.client.VaultSecrets.GetMongoDBAtlasIntegration(
 			secret_service.NewGetMongoDBAtlasIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).
@@ -137,7 +137,7 @@ func (r *resourceVaultSecretsIntegrationMongoDBAtlas) Create(ctx context.Context
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationMongoDBAtlas, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.CreateMongoDBAtlasIntegration(&secret_service.CreateMongoDBAtlasIntegrationParams{
+		response, err := r.client.VaultSecrets.CreateMongoDBAtlasIntegration(&secret_service.CreateMongoDBAtlasIntegrationParams{
 			Body: &secretmodels.SecretServiceCreateMongoDBAtlasIntegrationBody{
 				Capabilities:            integration.capabilities,
 				Name:                    integration.Name.ValueString(),
@@ -163,7 +163,7 @@ func (r *resourceVaultSecretsIntegrationMongoDBAtlas) Update(ctx context.Context
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationMongoDBAtlas, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.UpdateMongoDBAtlasIntegration(&secret_service.UpdateMongoDBAtlasIntegrationParams{
+		response, err := r.client.VaultSecrets.UpdateMongoDBAtlasIntegration(&secret_service.UpdateMongoDBAtlasIntegrationParams{
 			Body: &secretmodels.SecretServiceUpdateMongoDBAtlasIntegrationBody{
 				Capabilities:            integration.capabilities,
 				StaticCredentialDetails: integration.staticCredentialDetails,
@@ -189,7 +189,7 @@ func (r *resourceVaultSecretsIntegrationMongoDBAtlas) Delete(ctx context.Context
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationMongoDBAtlas, got: %T, this is a bug on the provider", i)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteMongoDBAtlasIntegration(
+		_, err := r.client.VaultSecrets.DeleteMongoDBAtlasIntegration(
 			secret_service.NewDeleteMongoDBAtlasIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_mongodbatlas_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_mongodbatlas_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -53,7 +53,7 @@ func TestAccVaultSecretsResourceIntegrationMongoDBAtlas(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteMongoDBAtlasIntegration(&secret_service.DeleteMongoDBAtlasIntegrationParams{
+					_, err := client.VaultSecrets.DeleteMongoDBAtlasIntegration(&secret_service.DeleteMongoDBAtlasIntegrationParams{
 						Name:           integrationName2,
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
@@ -74,7 +74,7 @@ func TestAccVaultSecretsResourceIntegrationMongoDBAtlas(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.CreateMongoDBAtlasIntegration(&secret_service.CreateMongoDBAtlasIntegrationParams{
+					_, err := client.VaultSecrets.CreateMongoDBAtlasIntegration(&secret_service.CreateMongoDBAtlasIntegrationParams{
 						Body: &secretmodels.SecretServiceCreateMongoDBAtlasIntegrationBody{
 							Capabilities: []*secretmodels.Secrets20231128Capability{secretmodels.Secrets20231128CapabilityROTATION.Pointer()},
 							StaticCredentialDetails: &secretmodels.Secrets20231128MongoDBAtlasStaticCredentialsRequest{
@@ -142,7 +142,7 @@ func mongoDBAtlasIntegrationExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetMongoDBAtlasIntegration(
+	response, err := client.VaultSecrets.GetMongoDBAtlasIntegration(
 		secret_service.NewGetMongoDBAtlasIntegrationParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_twilio.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_twilio.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -120,7 +120,7 @@ func (r *resourceVaultSecretsIntegrationTwilio) Read(ctx context.Context, req re
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationTwilio, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.GetTwilioIntegration(
+		response, err := r.client.VaultSecrets.GetTwilioIntegration(
 			secret_service.NewGetTwilioIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).
@@ -142,7 +142,7 @@ func (r *resourceVaultSecretsIntegrationTwilio) Create(ctx context.Context, req 
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationTwilio, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.CreateTwilioIntegration(&secret_service.CreateTwilioIntegrationParams{
+		response, err := r.client.VaultSecrets.CreateTwilioIntegration(&secret_service.CreateTwilioIntegrationParams{
 			Body: &secretmodels.SecretServiceCreateTwilioIntegrationBody{
 				Capabilities:            integration.capabilities,
 				StaticCredentialDetails: integration.staticCredentialDetails,
@@ -168,7 +168,7 @@ func (r *resourceVaultSecretsIntegrationTwilio) Update(ctx context.Context, req 
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationTwilio, got: %T, this is a bug on the provider", i)
 		}
 
-		response, err := r.client.VaultSecretsPreview.UpdateTwilioIntegration(&secret_service.UpdateTwilioIntegrationParams{
+		response, err := r.client.VaultSecrets.UpdateTwilioIntegration(&secret_service.UpdateTwilioIntegrationParams{
 			Body: &secretmodels.SecretServiceUpdateTwilioIntegrationBody{
 				Capabilities:            integration.capabilities,
 				StaticCredentialDetails: integration.staticCredentialDetails,
@@ -194,7 +194,7 @@ func (r *resourceVaultSecretsIntegrationTwilio) Delete(ctx context.Context, req 
 			return nil, fmt.Errorf("invalid integration type, expected *IntegrationTwilio, got: %T, this is a bug on the provider", i)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteTwilioIntegration(
+		_, err := r.client.VaultSecrets.DeleteTwilioIntegration(
 			secret_service.NewDeleteTwilioIntegrationParamsWithContext(ctx).
 				WithOrganizationID(integration.OrganizationID.ValueString()).
 				WithProjectID(integration.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_integration_twilio_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_integration_twilio_test.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -54,7 +54,7 @@ func TestAccVaultSecretsResourceIntegrationTwilio(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteTwilioIntegration(&secret_service.DeleteTwilioIntegrationParams{
+					_, err := client.VaultSecrets.DeleteTwilioIntegration(&secret_service.DeleteTwilioIntegrationParams{
 						Name:           integrationName2,
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
@@ -75,7 +75,7 @@ func TestAccVaultSecretsResourceIntegrationTwilio(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.CreateTwilioIntegration(&secret_service.CreateTwilioIntegrationParams{
+					_, err := client.VaultSecrets.CreateTwilioIntegration(&secret_service.CreateTwilioIntegrationParams{
 						Body: &secretmodels.SecretServiceCreateTwilioIntegrationBody{
 							Capabilities: []*secretmodels.Secrets20231128Capability{secretmodels.Secrets20231128CapabilityROTATION.Pointer()},
 							StaticCredentialDetails: &secretmodels.Secrets20231128TwilioStaticCredentialsRequest{
@@ -146,7 +146,7 @@ func twilioIntegrationExists(t *testing.T, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetTwilioIntegration(
+	response, err := client.VaultSecrets.GetTwilioIntegration(
 		secret_service.NewGetTwilioIntegrationParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_rotating_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_rotating_secret.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -247,7 +247,7 @@ func (r *resourceVaultSecretsRotatingSecret) Read(ctx context.Context, req resou
 		if !ok {
 			return nil, fmt.Errorf(unsupportedProviderErrorFmt, maps.Keys(rotatingSecretsImpl), secret.SecretProvider.ValueString())
 		}
-		return rotatingSecretImpl.read(ctx, r.client.VaultSecretsPreview, secret)
+		return rotatingSecretImpl.read(ctx, r.client.VaultSecrets, secret)
 	})...)
 }
 
@@ -262,7 +262,7 @@ func (r *resourceVaultSecretsRotatingSecret) Create(ctx context.Context, req res
 		if !ok {
 			return nil, fmt.Errorf(unsupportedProviderErrorFmt, maps.Keys(rotatingSecretsImpl), secret.SecretProvider.ValueString())
 		}
-		return rotatingSecretImpl.create(ctx, r.client.VaultSecretsPreview, secret)
+		return rotatingSecretImpl.create(ctx, r.client.VaultSecrets, secret)
 	})...)
 }
 
@@ -277,7 +277,7 @@ func (r *resourceVaultSecretsRotatingSecret) Update(ctx context.Context, req res
 		if !ok {
 			return nil, fmt.Errorf(unsupportedProviderErrorFmt, maps.Keys(rotatingSecretsImpl), secret.SecretProvider.ValueString())
 		}
-		return rotatingSecretImpl.update(ctx, r.client.VaultSecretsPreview, secret)
+		return rotatingSecretImpl.update(ctx, r.client.VaultSecrets, secret)
 	})...)
 }
 
@@ -288,7 +288,7 @@ func (r *resourceVaultSecretsRotatingSecret) Delete(ctx context.Context, req res
 			return nil, fmt.Errorf(invalidSecretTypeErrorFmt, s)
 		}
 
-		_, err := r.client.VaultSecretsPreview.DeleteAppSecret(
+		_, err := r.client.VaultSecrets.DeleteAppSecret(
 			secret_service.NewDeleteAppSecretParamsWithContext(ctx).
 				WithOrganizationID(secret.OrganizationID.ValueString()).
 				WithProjectID(secret.ProjectID.ValueString()).

--- a/internal/provider/vaultsecrets/resource_vault_secrets_rotating_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_rotating_secret_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -52,7 +52,7 @@ func testAccVaultSecretsResourceRotatingSecretAWS(t *testing.T) {
 				PreConfig: func() {
 					t.Helper()
 					client := acctest.HCPClients(t)
-					_, err := client.VaultSecretsPreview.DeleteAppSecret(&secret_service.DeleteAppSecretParams{
+					_, err := client.VaultSecrets.DeleteAppSecret(&secret_service.DeleteAppSecretParams{
 						OrganizationID: client.Config.OrganizationID,
 						ProjectID:      client.Config.ProjectID,
 						AppName:        appName,
@@ -114,7 +114,7 @@ func awsRotatingSecretExists(t *testing.T, appName, name string) bool {
 
 	client := acctest.HCPClients(t)
 
-	response, err := client.VaultSecretsPreview.GetAwsIAMUserAccessKeyRotatingSecretConfig(
+	response, err := client.VaultSecrets.GetAwsIAMUserAccessKeyRotatingSecretConfig(
 		secret_service.NewGetAwsIAMUserAccessKeyRotatingSecretConfigParamsWithContext(ctx).
 			WithOrganizationID(client.Config.OrganizationID).
 			WithProjectID(client.Config.ProjectID).

--- a/internal/provider/vaultsecrets/rotating_secret_aws.go
+++ b/internal/provider/vaultsecrets/rotating_secret_aws.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/provider/vaultsecrets/rotating_secret_confluent.go
+++ b/internal/provider/vaultsecrets/rotating_secret_confluent.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/provider/vaultsecrets/rotating_secret_gcp.go
+++ b/internal/provider/vaultsecrets/rotating_secret_gcp.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/provider/vaultsecrets/rotating_secret_mongodb_atlas.go
+++ b/internal/provider/vaultsecrets/rotating_secret_mongodb_atlas.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 

--- a/internal/provider/vaultsecrets/rotating_secret_twilio.go
+++ b/internal/provider/vaultsecrets/rotating_secret_twilio.go
@@ -6,8 +6,8 @@ package vaultsecrets
 import (
 	"context"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/client/secret_service"
-	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/preview/2023-11-28/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	secretmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/models"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 )
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Bump sdk version. Removes HVS preview in favor of using API V2 (stable/2023-11-28)

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
