### PR TITLE
[WAYP-3107] Add module ID to Waypoint resources

### DIFF
--- a/.changelog/1146.txt
+++ b/.changelog/1146.txt
@@ -1,0 +1,4 @@
+```release-note:breaking-change
+waypoint: Add new required field for no-code module ID to Waypoint template and
+add-on definition resources.
+```

--- a/docs/data-sources/waypoint_add_on_definition.md
+++ b/docs/data-sources/waypoint_add_on_definition.md
@@ -30,6 +30,7 @@ The Waypoint Add-on Definition data source retrieves information on a given Add-
 - `terraform_agent_pool_id` (String) The ID of the Terraform agent pool.
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details. (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `terraform_execution_mode` (String) The execution mode for the Terraform Cloud workspace.
+- `terraform_no_code_module_id` (String) The ID of the Terraform no-code module to use for running Terraform operations
 - `terraform_no_code_module_source` (String) Terraform No Code Module source
 - `variable_options` (Attributes List) List of variable options for the Add-on Definition. (see [below for nested schema](#nestedatt--variable_options))
 

--- a/docs/data-sources/waypoint_template.md
+++ b/docs/data-sources/waypoint_template.md
@@ -30,6 +30,7 @@ The Waypoint Template data source retrieves information on a given Template.
 - `terraform_agent_pool_id` (String) Terraform agent pool ID
 - `terraform_cloud_workspace_details` (Attributes) Terraform Cloud Workspace details (see [below for nested schema](#nestedatt--terraform_cloud_workspace_details))
 - `terraform_execution_mode` (String) Terraform execution mode
+- `terraform_no_code_module_id` (String) The ID of the Terraform no-code module to use for running Terraform operations
 - `terraform_no_code_module_source` (String) Terraform No Code Module source
 - `variable_options` (Attributes List) List of variable options for the template (see [below for nested schema](#nestedatt--variable_options))
 

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -19,6 +19,7 @@ Waypoint Add-on Definition resource
 - `description` (String) A longer description of the Add-on Definition.
 - `name` (String) The name of the Add-on Definition.
 - `summary` (String) A short summary of the Add-on Definition.
+- `terraform_no_code_module_id` (String) The ID of the Terraform no-code module to use for running Terraform operations. This is in the format of 'nocode-<ID>'.
 - `terraform_no_code_module_source` (String) Terraform Cloud no-code Module Source, expected to be in one of the following formats: "app.terraform.io/hcp_waypoint_example/ecs-advanced-microservice/aws" or "private/hcp_waypoint_example/ecs-advanced-microservice/aws".
 - `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.
 

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -18,6 +18,7 @@ Waypoint Template resource
 
 - `name` (String) The name of the Template.
 - `summary` (String) A brief description of the template, up to 110 characters.
+- `terraform_no_code_module_id` (String) The ID of the Terraform no-code module to use for running Terraform operations. This is in the format of 'nocode-<ID>'.
 - `terraform_no_code_module_source` (String) Terraform Cloud No-Code Module details
 - `terraform_project_id` (String) The ID of the Terraform Cloud Project to create workspaces in. The ID is found on the Terraform Cloud Project settings page.
 

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -46,6 +46,7 @@ type DataSourceAddOnDefinitionModel struct {
 
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
+	TerraformNoCodeModuleID     types.String         `tfsdk:"terraform_no_code_module_id"`
 	TerraformVariableOptions    []*tfcVariableOption `tfsdk:"variable_options"`
 	TerraformExecutionMode      types.String         `tfsdk:"terraform_execution_mode"`
 	TerraformAgentPoolID        types.String         `tfsdk:"terraform_agent_pool_id"`
@@ -150,6 +151,10 @@ func (d *DataSourceAddOnDefinition) Schema(ctx context.Context, req datasource.S
 				Computed:    true,
 				Description: "The ID of the Terraform agent pool.",
 			},
+			"terraform_no_code_module_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the Terraform no-code module to use for running Terraform operations",
+			},
 		},
 	}
 }
@@ -212,6 +217,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 	state.Summary = types.StringValue(definition.Summary)
 	state.Description = types.StringValue(definition.Description)
 	state.TerraformNoCodeModuleSource = types.StringValue(definition.ModuleSource)
+	state.TerraformNoCodeModuleID = types.StringValue(definition.ModuleID)
 
 	if definition.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -218,6 +218,8 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 	state.Description = types.StringValue(definition.Description)
 	state.TerraformNoCodeModuleSource = types.StringValue(definition.ModuleSource)
 	state.TerraformNoCodeModuleID = types.StringValue(definition.ModuleID)
+	state.TerraformExecutionMode = types.StringValue(definition.TfExecutionMode)
+	state.TerraformAgentPoolID = types.StringValue(definition.TfAgentPoolID)
 
 	if definition.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition_test.go
@@ -40,6 +40,7 @@ func TestAccWaypointData_Add_On_Definition_basic(t *testing.T) {
 				Config: testDataAddOnDefinitionConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "terraform_no_code_module_id", "nocode-7ZQjQoaPXvzs6Hvp"),
 					resource.TestCheckResourceAttr(dataSourceName, "terraform_execution_mode", "remote"),
 				),
 			},

--- a/internal/provider/waypoint/data_source_waypoint_template.go
+++ b/internal/provider/waypoint/data_source_waypoint_template.go
@@ -46,6 +46,7 @@ type DataSourceTemplateModel struct {
 
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
+	TerraformNoCodeModuleID     types.String         `tfsdk:"terraform_no_code_module_id"`
 	VariableOptions             []*tfcVariableOption `tfsdk:"variable_options"`
 	TerraformExecutionMode      types.String         `tfsdk:"terraform_execution_mode"`
 	TerraformAgentPoolID        types.String         `tfsdk:"terraform_agent_pool_id"`
@@ -150,6 +151,10 @@ func (d *DataSourceTemplate) Schema(ctx context.Context, req datasource.SchemaRe
 				Computed:    true,
 				Description: "Terraform agent pool ID",
 			},
+			"terraform_no_code_module_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the Terraform no-code module to use for running Terraform operations",
+			},
 		},
 	}
 }
@@ -211,6 +216,7 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 	data.ProjectID = types.StringValue(client.Config.ProjectID)
 	data.Summary = types.StringValue(appTemplate.Summary)
 	data.TerraformNoCodeModuleSource = types.StringValue(appTemplate.ModuleSource)
+	data.TerraformNoCodeModuleID = types.StringValue(appTemplate.ModuleID)
 
 	if appTemplate.TerraformCloudWorkspaceDetails != nil {
 		tfcWorkspace := &tfcWorkspace{

--- a/internal/provider/waypoint/data_source_waypoint_template_test.go
+++ b/internal/provider/waypoint/data_source_waypoint_template_test.go
@@ -40,6 +40,7 @@ func TestAccWaypointData_Template_basic(t *testing.T) {
 				Config: testDataAppTemplateConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "terraform_no_code_module_id", "nocode-7ZQjQoaPXvzs6Hvp"),
 					resource.TestCheckResourceAttr(dataSourceName, "terraform_execution_mode", "remote"),
 				),
 			},

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -35,6 +35,7 @@ func TestAccWaypoint_Add_On_Definition_basic(t *testing.T) {
 					testAccCheckWaypointAddOnDefinitionExists(t, resourceName, &addOnDefinitionModel),
 					testAccCheckWaypointAddOnDefinitionName(t, &addOnDefinitionModel, name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "terraform_no_code_module_id", "nocode-7ZQjQoaPXvzs6Hvp"),
 					resource.TestCheckResourceAttr(resourceName, "terraform_execution_mode", "remote"),
 				),
 			},

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition_test.go
@@ -134,6 +134,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
   summary = "some summary for fun"
   description = "some description for fun"
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"

--- a/internal/provider/waypoint/resource_waypoint_add_on_test.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_test.go
@@ -191,6 +191,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -209,6 +210,7 @@ resource "hcp_waypoint_add_on_definition" "test" {
   summary = "some summary for fun"
   description = "some description for fun"
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -230,6 +232,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -249,6 +252,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   description = "some description for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_no_code_module_id     = "nocode-JSMkg9ztLBYgg1eW"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -311,6 +315,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -330,6 +335,7 @@ resource "hcp_waypoint_add_on_definition" "test_var_opts" {
   description = "some description"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_no_code_module_id     = "nocode-JSMkg9ztLBYgg1eW"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"

--- a/internal/provider/waypoint/resource_waypoint_application_test.go
+++ b/internal/provider/waypoint/resource_waypoint_application_test.go
@@ -193,6 +193,7 @@ resource "hcp_waypoint_template" "test" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -214,6 +215,7 @@ resource "hcp_waypoint_template" "test_var_opts" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_no_code_module_id     = "nocode-JSMkg9ztLBYgg1eW"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -273,6 +275,7 @@ resource "hcp_waypoint_template" "test_var_opts" {
   summary = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_no_code_module_id     = "nocode-JSMkg9ztLBYgg1eW"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -159,6 +159,7 @@ resource "hcp_waypoint_template" "test" {
   summary                  = "some summary for fun"
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -176,6 +177,7 @@ resource "hcp_waypoint_template" "var_opts_test" {
   summary                  = "A template with a variable with options."
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -37,6 +37,7 @@ func TestAccWaypoint_Template_basic(t *testing.T) {
 					testAccCheckWaypointTemplateExists(t, resourceName, &appTemplateModel),
 					testAccCheckWaypointTemplateName(t, &appTemplateModel, name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "terraform_no_code_module_id", "nocode-7ZQjQoaPXvzs6Hvp"),
 					resource.TestCheckResourceAttr(resourceName, "terraform_execution_mode", "remote"),
 				),
 			},
@@ -193,7 +194,7 @@ resource "hcp_waypoint_template" "var_opts_test" {
         "courier",
         "lone-wanderer",
         "sole-survivor",
-	  ]
+      ]
     },
     {
       name          = "faction"

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -177,7 +177,7 @@ resource "hcp_waypoint_template" "var_opts_test" {
   summary                  = "A template with a variable with options."
   readme_markdown_template = base64encode("# Some Readme")
   terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-vault-dweller/null"
-  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
+  terraform_no_code_module_id = "nocode-JSMkg9ztLBYgg1eW"
   terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
   terraform_cloud_workspace_details = {
     name                 = "Default Project"
@@ -188,7 +188,12 @@ resource "hcp_waypoint_template" "var_opts_test" {
 	  name          = "vault_dweller_name"
 	  variable_type = "string"
       user_editable = true
-      options       = []
+      options       = [
+        "lucy",
+        "courier",
+        "lone-wanderer",
+        "sole-survivor",
+	  ]
     },
     {
       name          = "faction"


### PR DESCRIPTION
BREAKING CHANGE: The no-code module ID is required when creating a template or add-on definition for Waypoint.

This PR also contains a fix for the add-on definition data source, for reading the execution mode.

<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS="-run=TestAccWaypoint"
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
TF_ACC=1 go test ./internal/... -v -run=TestAccWaypoint -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/customdiags	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	0.609s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming	0.610s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/datasources/artifact	0.762s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/datasources/version	0.814s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/resources/bucket	0.949s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	0.500s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultradar	0.578s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	0.654s [no tests to run]
=== RUN   TestAccWaypoint_Action_DataSource_basic
    data_source_waypoint_action_test.go:20: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_DataSource_basic (0.00s)
=== RUN   TestAccWaypointData_Add_On_Definition_basic
--- PASS: TestAccWaypointData_Add_On_Definition_basic (8.91s)
=== RUN   TestAccWaypointData_Add_On_basic
--- PASS: TestAccWaypointData_Add_On_basic (18.69s)
=== RUN   TestAccWaypoint_AddOn_DataSource_WithInputVars
--- PASS: TestAccWaypoint_AddOn_DataSource_WithInputVars (18.07s)
=== RUN   TestAccWaypoint_Application_DataSource_basic
--- PASS: TestAccWaypoint_Application_DataSource_basic (11.88s)
=== RUN   TestAccWaypoint_Application_DataSource_WithInputVars
--- PASS: TestAccWaypoint_Application_DataSource_WithInputVars (11.45s)
=== RUN   TestAccWaypointData_Template_basic
--- PASS: TestAccWaypointData_Template_basic (8.76s)
=== RUN   TestAccWaypointData_template_with_variable_options
--- PASS: TestAccWaypointData_template_with_variable_options (5.53s)
=== RUN   TestAccWaypoint_Action_basic
    resource_waypoint_action_test.go:25: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_basic (0.00s)
=== RUN   TestAccWaypoint_Add_On_Definition_basic
--- PASS: TestAccWaypoint_Add_On_Definition_basic (5.91s)
=== RUN   TestAccWaypoint_Add_On_basic
--- PASS: TestAccWaypoint_Add_On_basic (8.94s)
=== RUN   TestAccWaypoint_AddOnInputVariables
--- PASS: TestAccWaypoint_AddOnInputVariables (8.81s)
=== RUN   TestAccWaypoint_AddOnInputVariables_OnDefinition
--- PASS: TestAccWaypoint_AddOnInputVariables_OnDefinition (9.43s)
=== RUN   TestAccWaypoint_Application_basic
--- PASS: TestAccWaypoint_Application_basic (7.40s)
=== RUN   TestAccWaypoint_ApplicationInputVariables
--- PASS: TestAccWaypoint_ApplicationInputVariables (5.71s)
=== RUN   TestAccWaypoint_ApplicationInputVariables_OnTemplate
--- PASS: TestAccWaypoint_ApplicationInputVariables_OnTemplate (6.21s)
=== RUN   TestAccWaypoint_Template_basic
--- PASS: TestAccWaypoint_Template_basic (6.48s)
=== RUN   TestAccWaypoint_template_with_variable_options
--- PASS: TestAccWaypoint_template_with_variable_options (3.11s)
=== RUN   TestAccWaypointTfcConfig_basic
    resource_waypoint_tfc_config_test.go:25: Skipping nonfunctional TFC Config test
--- SKIP: TestAccWaypointTfcConfig_basic (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint	145.925s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook	0.836s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	0.724s [no tests to run]

...
```
