### PR TITLE
Remove beta tag from HCP vault secrets data sources

### DIFF
--- a/docs/data-sources/vault_secrets_dynamic_secret.md
+++ b/docs/data-sources/vault_secrets_dynamic_secret.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_vault_secrets_dynamic_secret (Data Source)
 
--> **Note:** This data source is currently in beta.
-
 This data source generates a new dynamic secret instance.
 
 ## Example Usage

--- a/docs/data-sources/vault_secrets_rotating_secret.md
+++ b/docs/data-sources/vault_secrets_rotating_secret.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_vault_secrets_rotating_secret (Data Source)
 
--> **Note:** This data source is currently in public beta.
-
 This data source retrieves a single rotating secret with its latest version.
 
 ## Example Usage

--- a/templates/data-sources/vault_secrets_dynamic_secret.md.tmpl
+++ b/templates/data-sources/vault_secrets_dynamic_secret.md.tmpl
@@ -7,8 +7,6 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** This data source is currently in beta.
-
 {{ .Description | trimspace }}
 
 ## Example Usage

--- a/templates/data-sources/vault_secrets_rotating_secret.md.tmpl
+++ b/templates/data-sources/vault_secrets_rotating_secret.md.tmpl
@@ -7,8 +7,6 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** This data source is currently in public beta.
-
 {{ .Description | trimspace }}
 
 ## Example Usage


### PR DESCRIPTION
### :hammer_and_wrench: Description

The feature are no longer in Beta so we are removing the note in the docs.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

Not necessary for a doc PR.
