### PR TITLE
Disable Prerelease via Cron

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,8 +2,8 @@ name: Prerelease
 
 on:
   # Run Every Wednesday at 01:00 AM UTC
-  schedule:
-    - cron: '0 2 * * 3'
+  # schedule:
+  #   - cron: '0 2 * * 3'
   workflow_dispatch:
     inputs:
       release-as-patch:


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->



### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
* This PR disables the automated trigger for Prerelease action (cron schedule) as it will always currently timeout at 6 hours and is creating many hanging resources every time as a result.

### :building_construction: Acceptance tests

- [x] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
