### PR TITLE
Add RequiresReplace attribute for secret_name in hvs secret resource

### DIFF
--- a/.changelog/1157.txt
+++ b/.changelog/1157.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fix a bug when updating HVS secret name
+Fix a bug where updating an HVS secret name or app name would not recreate the resource as expected
 ```

--- a/.changelog/1157.txt
+++ b/.changelog/1157.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug when updating HVS secret name
+```

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
@@ -76,6 +76,9 @@ func (r *resourceVaultsecretsSecret) Schema(_ context.Context, _ resource.Schema
 						"must contain only ASCII letters, numbers, and underscores; must not start with a number",
 					),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"secret_value": schema.StringAttribute{
 				Description: "The value of the secret",

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret.go
@@ -64,6 +64,9 @@ func (r *resourceVaultsecretsSecret) Schema(_ context.Context, _ resource.Schema
 						"must contain only ASCII letters, numbers, and hyphens; must not start or end with a hyphen",
 					),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"secret_name": schema.StringAttribute{
 				Description: "The name of the secret",

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -5,6 +5,9 @@ package vaultsecrets_test
 
 import (
 	"fmt"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,10 +17,12 @@ import (
 func TestAccVaultSecretsResourceSecret(t *testing.T) {
 	testAppName1 := generateRandomSlug()
 	testAppName2 := generateRandomSlug()
+	secretName1 := "acc_tests_secret_1"
+	secretName2 := "acc_tests_secret_2"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-
+			// Create secretName1 in testAppName1
 			{
 				PreConfig: func() {
 					createTestApp(t, testAppName1)
@@ -25,15 +30,33 @@ func TestAccVaultSecretsResourceSecret(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "hcp_vault_secrets_secret" "example" {
 					app_name = %q
-					secret_name = "test_secret"
+					secret_name = %q
 					secret_value = "super secret"
-				}`, testAppName1),
+				}`, testAppName1, secretName1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName1),
-					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "test_secret"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", secretName1),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
 				),
 			},
+			// Changing secret name should cause recreation.
+			// Validate that secretName2 is created and secretName1 is destroyed.
+			{
+				Config: fmt.Sprintf(`
+				resource "hcp_vault_secrets_secret" "example" {
+					app_name = %q
+					secret_name = %q
+					secret_value = "super secret"
+				}`, testAppName1, secretName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName1),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", secretName2),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
+					testAccCheckSecretExists(t, testAppName1, secretName1),
+				),
+			},
+			// Changing app name should also cause secret recreation.
+			// Validate secretName2 is created in testAppName2 and is destroyed in testAppName1
 			{
 				Config: fmt.Sprintf(`
 				resource "hcp_project" "example" {
@@ -48,17 +71,45 @@ func TestAccVaultSecretsResourceSecret(t *testing.T) {
 
 				resource "hcp_vault_secrets_secret" "example" {
 					app_name = hcp_vault_secrets_app.example.app_name
-					secret_name = "test_secret"
+					secret_name = %q
 					secret_value = "super secret"
 					project_id = hcp_project.example.resource_id
-				}`, testAppName2),
+				}`, testAppName2, secretName2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "app_name", testAppName2),
-					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", "test_secret"),
+					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_name", secretName2),
 					resource.TestCheckResourceAttr("hcp_vault_secrets_secret.example", "secret_value", "super secret"),
 					resource.TestCheckResourceAttrSet("hcp_vault_secrets_secret.example", "project_id"),
+					testAccCheckSecretExists(t, testAppName1, secretName2),
 				),
 			},
 		},
 	})
+}
+
+func testAccCheckSecretExists(t *testing.T, appName string, secretName string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if secretExists(t, appName, secretName) {
+			return fmt.Errorf("test secret %s was not destroyed", secretName)
+		}
+		return nil
+	}
+}
+
+func secretExists(t *testing.T, appName string, secretName string) bool {
+	t.Helper()
+
+	client := acctest.HCPClients(t)
+
+	response, err := client.VaultSecrets.GetAppSecret(
+		secret_service.NewGetAppSecretParamsWithContext(ctx).
+			WithOrganizationID(client.Config.OrganizationID).
+			WithProjectID(client.Config.ProjectID).
+			WithAppName(appName).
+			WithSecretName(secretName), nil)
+	if err != nil && !clients.IsResponseCodeNotFound(err) {
+		t.Fatal(err)
+	}
+
+	return !clients.IsResponseCodeNotFound(err) && response != nil && response.Payload != nil && response.Payload.Secret != nil
 }

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -5,10 +5,11 @@ package vaultsecrets_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"

--- a/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
+++ b/internal/provider/vaultsecrets/resource_vault_secrets_secret_test.go
@@ -85,6 +85,10 @@ func TestAccVaultSecretsResourceSecret(t *testing.T) {
 				),
 			},
 		},
+		CheckDestroy: func(s *terraform.State) error {
+			deleteTestApp(t, testAppName1)
+			return nil
+		},
 	})
 }
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

If you change the name of a hcp_vault_secrets_secret it is expected that the secret with the previous name gets deleted and the a secret with the new name gets created. However, the TF provider treats it as an update and creates the new secret while not deleting the previous one. This change adds a fix for this.

JIRA: https://hashicorp.atlassian.net/browse/HV-3235
<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Local test where I changed the app name and secret name, terraform plan shows 2 to be added and 2 to be destroyed
<img width="1119" alt="Screenshot 2024-12-18 at 2 07 17 PM" src="https://github.com/user-attachments/assets/060ec005-48b7-4461-be0b-182a10d9e2a9" />
