### PR TITLE
Add Controller Config TTLs Options For Boundary Cluster Resource/Data

### DIFF
--- a/.changelog/1164.txt
+++ b/.changelog/1164.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Updating the provider for HCPb to allow for controller configuration settings upon hcp_boundary_cluster resource/data-source
+Updating the provider for HCP Boundary to allow for controller configuration settings upon hcp_boundary_cluster resource/data-source
 ```

--- a/.changelog/1164.txt
+++ b/.changelog/1164.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Updating the provider for HCPb to allow for controller configuration settings upon hcp_boundary_cluster resource/data-source
+```

--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -34,6 +34,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 ### Read-Only
 
 - `cluster_url` (String) A unique URL identifying the Boundary cluster.
+- `controller_config` (List of Object) (see [below for nested schema](#nestedatt--controller_config))
 - `created_at` (String) The time that the Boundary cluster was created.
 - `id` (String) The ID of this resource.
 - `maintenance_window_config` (List of Object) (see [below for nested schema](#nestedatt--maintenance_window_config))
@@ -47,6 +48,15 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 Optional:
 
 - `default` (String)
+
+
+<a id="nestedatt--controller_config"></a>
+### Nested Schema for `controller_config`
+
+Read-Only:
+
+- `auth_token_time_to_live` (String)
+- `auth_token_time_to_stale` (String)
 
 
 <a id="nestedatt--maintenance_window_config"></a>

--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -33,8 +33,9 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 
 ### Read-Only
 
+- `auth_token_time_to_live` (String) The time to live for the auth token in golang's time.Duration string format.
+- `auth_token_time_to_stale` (String) The time to stale for the auth token in golang's time.Duration string format.
 - `cluster_url` (String) A unique URL identifying the Boundary cluster.
-- `controller_config` (List of Object) (see [below for nested schema](#nestedatt--controller_config))
 - `created_at` (String) The time that the Boundary cluster was created.
 - `id` (String) The ID of this resource.
 - `maintenance_window_config` (List of Object) (see [below for nested schema](#nestedatt--maintenance_window_config))
@@ -48,15 +49,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 Optional:
 
 - `default` (String)
-
-
-<a id="nestedatt--controller_config"></a>
-### Nested Schema for `controller_config`
-
-Read-Only:
-
-- `auth_token_time_to_live` (String)
-- `auth_token_time_to_stale` (String)
 
 
 <a id="nestedatt--maintenance_window_config"></a>

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -22,6 +22,10 @@ resource "hcp_boundary_cluster" "example" {
     end          = 12
     upgrade_type = "SCHEDULED"
   }
+  controller_config {
+    auth_token_time_to_live  = "36h0m0s"
+    auth_token_time_to_stale = "12h0m0s"
+  }
 }
 ```
 
@@ -37,6 +41,7 @@ resource "hcp_boundary_cluster" "example" {
 
 ### Optional
 
+- `controller_config` (Block List, Max: 1) The controller configuration for the Boundary cluster. (see [below for nested schema](#nestedblock--controller_config))
 - `maintenance_window_config` (Block List, Max: 1) The maintenance window configuration for when cluster upgrades can take place. (see [below for nested schema](#nestedblock--maintenance_window_config))
 - `project_id` (String) The ID of the HCP project where the Boundary cluster is located.
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
@@ -50,6 +55,15 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `id` (String) The ID of this resource.
 - `state` (String) The state of the Boundary cluster.
 - `version` (String) The version of the Boundary cluster.
+
+<a id="nestedblock--controller_config"></a>
+### Nested Schema for `controller_config`
+
+Optional:
+
+- `auth_token_time_to_live` (String) The time to live for the auth token in the format of golang's time.Duration string.
+- `auth_token_time_to_stale` (String) The time to stale for the auth token in the format of golang's time.Duration string.
+
 
 <a id="nestedblock--maintenance_window_config"></a>
 ### Nested Schema for `maintenance_window_config`

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -22,10 +22,8 @@ resource "hcp_boundary_cluster" "example" {
     end          = 12
     upgrade_type = "SCHEDULED"
   }
-  controller_config {
-    auth_token_time_to_live  = "36h0m0s"
-    auth_token_time_to_stale = "12h0m0s"
-  }
+  auth_token_time_to_live  = "36h0m0s"
+  auth_token_time_to_stale = "12h0m0s"
 }
 ```
 
@@ -41,7 +39,8 @@ resource "hcp_boundary_cluster" "example" {
 
 ### Optional
 
-- `controller_config` (Block List, Max: 1) The controller configuration for the Boundary cluster. (see [below for nested schema](#nestedblock--controller_config))
+- `auth_token_time_to_live` (String) The time to live for the auth token in golang's time.Duration string format.
+- `auth_token_time_to_stale` (String) The time to stale for the auth token in golang's time.Duration string format.
 - `maintenance_window_config` (Block List, Max: 1) The maintenance window configuration for when cluster upgrades can take place. (see [below for nested schema](#nestedblock--maintenance_window_config))
 - `project_id` (String) The ID of the HCP project where the Boundary cluster is located.
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
@@ -55,15 +54,6 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 - `id` (String) The ID of this resource.
 - `state` (String) The state of the Boundary cluster.
 - `version` (String) The version of the Boundary cluster.
-
-<a id="nestedblock--controller_config"></a>
-### Nested Schema for `controller_config`
-
-Optional:
-
-- `auth_token_time_to_live` (String) The time to live for the auth token in the format of golang's time.Duration string.
-- `auth_token_time_to_stale` (String) The time to stale for the auth token in the format of golang's time.Duration string.
-
 
 <a id="nestedblock--maintenance_window_config"></a>
 ### Nested Schema for `maintenance_window_config`

--- a/examples/resources/hcp_boundary_cluster/resource.tf
+++ b/examples/resources/hcp_boundary_cluster/resource.tf
@@ -8,8 +8,6 @@ resource "hcp_boundary_cluster" "example" {
     end          = 12
     upgrade_type = "SCHEDULED"
   }
-  controller_config {
-    auth_token_time_to_live  = "36h0m0s"
-    auth_token_time_to_stale = "12h0m0s"
-  }
+  auth_token_time_to_live  = "36h0m0s"
+  auth_token_time_to_stale = "12h0m0s"
 }

--- a/examples/resources/hcp_boundary_cluster/resource.tf
+++ b/examples/resources/hcp_boundary_cluster/resource.tf
@@ -8,4 +8,8 @@ resource "hcp_boundary_cluster" "example" {
     end          = 12
     upgrade_type = "SCHEDULED"
   }
+  controller_config {
+    auth_token_time_to_live  = "36h0m0s"
+    auth_token_time_to_stale = "12h0m0s"
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.126.0
+	github.com/hashicorp/hcp-sdk-go v0.129.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
-github.com/hashicorp/hcp-sdk-go v0.126.0 h1:/ByCyXaKrwJwK5SMjp/JFK3ZbVqDxEaADQev3t6odI4=
-github.com/hashicorp/hcp-sdk-go v0.126.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
+github.com/hashicorp/hcp-sdk-go v0.129.0 h1:lxH6eup5kmbGVukg+8p4KjGfb1VoR+vdf3ivVT00ams=
+github.com/hashicorp/hcp-sdk-go v0.129.0/go.mod h1:vQ4fzdL1AmhIAbCw+4zmFe5Hbpajj3NvRWkJoVuxmAk=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/internal/clients/boundary_cluster.go
+++ b/internal/clients/boundary_cluster.go
@@ -114,3 +114,50 @@ func GetBoundaryClusterMaintenanceWindow(
 
 	return resp.Payload.UpgradeType, resp.Payload.MaintenanceWindow, nil
 }
+
+// GetBoundaryClusterControllerConfigByID gets the controllers auth config for TTL and TTS on a Boundary cluster.
+func GetBoundaryClusterControllerConfigByID(
+	ctx context.Context,
+	client *Client,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	boundaryClusterID string,
+) (*boundarymodels.HashicorpCloudBoundary20211221GetControllerConfigurationResponse, error) {
+
+	params := boundary_service.NewBoundaryServiceGetControllerConfigurationParams()
+	params.Context = ctx
+	params.ClusterID = boundaryClusterID
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+
+	resp, err := client.Boundary.BoundaryServiceGetControllerConfiguration(params, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload, nil
+}
+
+// UpdateBoundaryClusterControllerConfig updates the controllers auth config for TTL and TTS on a Boundary cluster.
+func UpdateBoundaryClusterControllerConfig(
+	ctx context.Context,
+	client *Client,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	boundaryClusterID string,
+	updateRequest *boundarymodels.HashicorpCloudBoundary20211221UpdateControllerConfigurationRequest,
+) error {
+
+	params := boundary_service.NewBoundaryServiceUpdateControllerConfigurationParams()
+	params.Context = ctx
+	params.Body = updateRequest
+
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+	params.ClusterID = boundaryClusterID
+
+	_, err := client.Boundary.BoundaryServiceUpdateControllerConfiguration(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/clients/boundary_cluster.go
+++ b/internal/clients/boundary_cluster.go
@@ -121,7 +121,7 @@ func GetBoundaryClusterControllerConfigByID(
 	client *Client,
 	loc *sharedmodels.HashicorpCloudLocationLocation,
 	boundaryClusterID string,
-) (*boundarymodels.HashicorpCloudBoundary20211221GetControllerConfigurationResponse, error) {
+) (*boundarymodels.HashicorpCloudBoundary20211221ControllerConfiguration, error) {
 
 	params := boundary_service.NewBoundaryServiceGetControllerConfigurationParams()
 	params.Context = ctx
@@ -134,7 +134,7 @@ func GetBoundaryClusterControllerConfigByID(
 		return nil, err
 	}
 
-	return resp.Payload, nil
+	return resp.Payload.Config, nil
 }
 
 // UpdateBoundaryClusterControllerConfig updates the controllers auth config for TTL and TTS on a Boundary cluster.
@@ -155,6 +155,29 @@ func UpdateBoundaryClusterControllerConfig(
 	params.ClusterID = boundaryClusterID
 
 	_, err := client.Boundary.BoundaryServiceUpdateControllerConfiguration(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ResetBoundaryClusterControllerConfig resets the controllers auth config for TTL and TTS on a Boundary cluster.
+func ResetBoundaryClusterControllerConfig(
+	ctx context.Context,
+	client *Client,
+	loc *sharedmodels.HashicorpCloudLocationLocation,
+	boundaryClusterID string,
+) error {
+
+	params := boundary_service.NewBoundaryServiceResetControllerConfigurationParams()
+	params.Context = ctx
+
+	params.LocationOrganizationID = loc.OrganizationID
+	params.LocationProjectID = loc.ProjectID
+	params.ClusterID = boundaryClusterID
+
+	_, err := client.Boundary.BoundaryServiceResetControllerConfiguration(params, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/providersdkv2/data_source_boundary_cluster.go
+++ b/internal/providersdkv2/data_source_boundary_cluster.go
@@ -94,6 +94,24 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"controller_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_token_time_to_live": {
+							Description: "The time to live for the auth token in time.Duration format.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"auth_token_time_to_stale": {
+							Description: "The time to stale for the auth token in time.Duration format.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -135,8 +153,13 @@ func dataSourceBoundaryClusterRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("unable to fetch maintenenace window Boundary cluster (%s): %v", clusterID, err)
 	}
 
+	controllerConfig, err := clients.GetBoundaryClusterControllerConfigByID(ctx, client, loc, clusterID)
+	if err != nil {
+		return diag.Errorf("unable to fetch controller config for Boundary cluster (%s): %v", clusterID, err)
+	}
+
 	// cluster found, update resource data
-	if err := setBoundaryClusterResourceData(d, cluster, clusterUpgradeType, clusterMW); err != nil {
+	if err := setBoundaryClusterResourceData(d, cluster, clusterUpgradeType, clusterMW, controllerConfig); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/providersdkv2/data_source_boundary_cluster.go
+++ b/internal/providersdkv2/data_source_boundary_cluster.go
@@ -94,23 +94,15 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"controller_config": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"auth_token_time_to_live": {
-							Description: "The time to live for the auth token in time.Duration format.",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-						"auth_token_time_to_stale": {
-							Description: "The time to stale for the auth token in time.Duration format.",
-							Type:        schema.TypeString,
-							Computed:    true,
-						},
-					},
-				},
+			"auth_token_time_to_live": {
+				Description: "The time to live for the auth token in golang's time.Duration string format.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"auth_token_time_to_stale": {
+				Description: "The time to stale for the auth token in golang's time.Duration string format.",
+				Type:        schema.TypeString,
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/providersdkv2/resource_boundary_cluster_test.go
+++ b/internal/providersdkv2/resource_boundary_cluster_test.go
@@ -35,8 +35,14 @@ var maintenanceWindowConfig = `
 	}
 `
 
+var controllerConfig = `
+	auth_token_time_to_live = "12h0m0s"
+	auth_token_time_to_stale = "1h0m0s"
+`
+
 var boundaryCluster = fmt.Sprintf(boundaryClusterResourceTemplate, "")
 var boundaryClusterWithMaintenanceWindow = fmt.Sprintf(boundaryClusterResourceTemplate, maintenanceWindowConfig)
+var boundaryClusterWithControllerConfig = fmt.Sprintf(boundaryClusterResourceTemplate, controllerConfig)
 
 func setTestAccBoundaryClusterConfig(boundaryCluster string) string {
 	return fmt.Sprintf(`
@@ -69,6 +75,8 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_live"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_stale"),
 				),
 			},
 			{
@@ -98,6 +106,8 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_live"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_stale"),
 				),
 			},
 			{
@@ -111,6 +121,8 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttrPair(boundaryClusterResourceName, "state", boundaryClusterDataSourceName, "state"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
 					resource.TestCheckResourceAttrPair(boundaryClusterResourceName, "version", boundaryClusterDataSourceName, "version"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_live"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_stale"),
 				),
 			},
 			{
@@ -129,6 +141,24 @@ func TestAccBoundaryCluster(t *testing.T) {
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.start", "2"),
 					resource.TestCheckResourceAttr(boundaryClusterResourceName, "maintenance_window_config.0.end", "12"),
 					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_live"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "auth_token_time_to_stale"),
+				),
+			},
+			{
+				// this test step tests creating a boundary cluster with non-default controller config settings.
+				Config: testConfig(setTestAccBoundaryClusterConfig(boundaryClusterWithControllerConfig)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBoundaryClusterExists(boundaryClusterResourceName),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "cluster_id", boundaryUniqueID),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "cluster_url"),
+					testAccCheckFullURL(boundaryClusterResourceName, "cluster_url", ""),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "state"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "tier", "PLUS"),
+					resource.TestCheckResourceAttrSet(boundaryClusterResourceName, "version"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "auth_token_time_to_live", "12h0m0s"),
+					resource.TestCheckResourceAttr(boundaryClusterResourceName, "auth_token_time_to_stale", "1h0m0s"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description
- Added new optional input values for configuring the controller's `auth_token_time_to_live` and `auth_token_time_to_stale` in a valid duration string (following `time.Duration` standards`
   -  `auth_token_time_to_live` defaults to `7` days
   - `auth_token_time_to_stale` defaults to `1` day
   - When specifying either new attribute the other is required along side. 
<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'
ok      github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator (cached) [no tests to run]
=== RUN   TestAccBoundaryCluster
--- PASS: TestAccBoundaryCluster (149.94s)
PASS
ok      github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2      150.526s
...
```
