### PR TITLE
HCPCP-2204: Acceptance Tests - Orchestration

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,28 +1,26 @@
 name: Prerelease
 
 on:
-  # Run Every Wednesday at 01:00 AM UTC
-  # schedule:
-  #   - cron: '0 2 * * 3'
   workflow_dispatch:
     inputs:
       release-as-patch:
         description: "Patch Release (default: Minor)"
         type: boolean
         default: false
-      skip-tests:
-        description: "Skip the E2E test suite for break-glass scenarios"
-        type: boolean
-        default: false
+
 permissions: write-all
 
 jobs:
-  run-tests:
+  test:
     name: Run Tests
     uses: ./.github/workflows/test.yml
-    with:
-      # need to use contains because inputs are null for schedule runs
-      skip-e2e-tests: ${{ contains(inputs.skip-tests, 'true') }}
+    secrets: inherit
+    permissions:
+      contents: read
+
+  testacc:
+    name: Run Acceptance Tests
+    uses: ./.github/workflows/testacc.yml
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,33 +1,16 @@
-name: Run Tests
+name: Test
 
 on:
   workflow_call:
-    inputs:
-      acc-test-pattern:
-        type: string
-        default: 'Test.*'
-      skip-e2e-tests:
-        description: "Skip the E2E test suite"
-        type: boolean
-        default: false
   workflow_dispatch:
-    inputs:
-      acc-test-pattern:
-        type: string
-        default: 'Test.*'
-      skip-e2e-tests:
-        description: "Skip the E2E test suite"
-        type: boolean
-        default: false
-
-concurrency: acceptance-testing-environment
+  pull_request:
 
 permissions:
   contents: read
-    
+
 jobs:
-  run-tests:
-    name: Run Tests
+  unit-tests:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -49,8 +32,6 @@ jobs:
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
           go mod tidy
-          sudo wget https://github.com/jmespath/jp/releases/latest/download/jp-linux-amd64 -O /usr/local/bin/jp
-          sudo chmod +x /usr/local/bin/jp
 
       - name: Run Unit Tests and Linter
         run: make test-ci
@@ -60,44 +41,3 @@ jobs:
         with:
           name: Test Coverage
           path: coverage.html
-
-      - name: Warn If Non-default Pattern
-        if: inputs.acc-test-pattern != 'Test.*'
-        run: |
-          echo "## WARNING: Some tests may have been skipped!" >> $GITHUB_STEP_SUMMARY
-          echo "The default acceptance test pattern is \`Test.*\`, but it was overridden with \`${{ inputs.acc-test-pattern }}\`." >> $GITHUB_STEP_SUMMARY
-
-      - name: Run E2E Tests
-        if: ${{ !inputs.skip-e2e-tests }}
-        env:
-          HCP_API_HOST: ${{ secrets.HCP_API_HOST }}
-          HCP_AUTH_URL: ${{ secrets.HCP_AUTH_URL }}
-          HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
-          HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
-          HCP_ORGANIZATION_ID: ${{ secrets.HCP_ORGANIZATION_ID }}
-          HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
-
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-          AWS_REGION: us-west-1
-
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-
-          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-        run: |
-          AWS_OUTPUT=$(aws sts assume-role --role-arn $AWS_ROLE_ARN --role-session-name e2e-test --duration-seconds 43200)
-          export AWS_ACCESS_KEY_ID=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.AccessKeyId)
-          export AWS_SECRET_ACCESS_KEY=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SecretAccessKey)
-          export AWS_SESSION_TOKEN=$(echo $AWS_OUTPUT | jp --unquoted  Credentials.SessionToken)
-          make testacc-ci TESTARGS='-run=${{ inputs.acc-test-pattern }} -test.v'
-
-      - name: Upload E2E Coverage Artifact
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: Test Coverage
-          path: coverage-e2e.html

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -1,0 +1,42 @@
+name: TestAcc
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+# This prevents more than one run of this workflow from executing at a time.
+# Up to 1 additional run will be queued, with anything futher being cancelled from the queue.
+concurrency:
+  group: testacc
+  cancel-in-progress: false
+
+# Runs all Acceptance test groups in parallel to encompass the entire provider.
+# These will be enabled as they are onboarded.
+jobs:
+  # testacc_platform:
+  #   name: Platform
+  #   uses: ./.github/workflows/_testacc_platform.yml
+  # testacc_iam:
+  #   name: Iam
+  #   uses: ./.github/workflows/_testacc_iam.yml
+  # testacc_boundary:
+  #   name: Boundary
+  #   uses: ./.github/workflows/_testacc_boundary.yml
+  # testacc_consul:
+  #   name: Consul
+  #   uses: ./.github/workflows/_testacc_consul.yml
+  # testacc_packer:
+  #   name: Packer
+  #   uses: ./.github/workflows/_testacc_packer.yml
+  # testacc_vault:
+  #   name: Vault
+  #   uses: ./.github/workflows/_testacc_vault.yml
+  # testacc_vaultsecrets:
+  #   name: Vault Secrets
+  #   uses: ./.github/workflows/_testacc_vaultsecrets.yml
+  # testacc_vaultradar:
+  #   name: Vault Radar
+  #   uses: ./.github/workflows/_testacc_vaultradar.yml
+  # testacc_waypoint:
+  #   name: Waypoint
+  #   uses: ./.github/workflows/_testacc_waypoint.yml

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -3,6 +3,9 @@ name: TestAcc
 on:
   workflow_call:
   workflow_dispatch:
+  # Run Every Wednesday at 01:00 AM UTC
+  # schedule:
+  #   - cron: '0 2 * * 3'
 
 # This prevents more than one run of this workflow from executing at a time.
 # Up to 1 additional run will be queued, with anything futher being cancelled from the queue.


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

* This PR starts laying groundwork for the acceptance test suite, as described in RFC [HCP-483](https://go.hashi.co/rfc/hcp-483), specifically:
  1. Updates the `Test` workflow to remove the acceptance test component. This workflow will now only run unit tests and linting.
  2. Adds a new workflow, `TestAcc` which acts to orchestrate all the Acceptance test groups (once they exist). Each group (represented by its' own workflow) will have a job and thereby execute in parallel.
  3. Updates the `Prerelease` workflow to use the new `TestAcc` workflow so Unit tests and Acceptance tests are still a prerequisite to cutting a release without the option to bypass.
