### PR TITLE
manage log_streaming_destination with LogStreamingService client

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -35,7 +35,7 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-operation/stable/2020-05-05/client/operation_service"
 
 	cloud_packer "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client"
-	packer_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/client/packer_service"
 
 	cloud_packer_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2023-01-01/client"
 	packer_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2023-01-01/client/packer_service"
@@ -55,6 +55,7 @@ import (
 
 	cloud_log_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/log_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/streaming_service"
 
 	cloud_webhook "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/client/webhook_service"
@@ -89,6 +90,7 @@ type Client struct {
 	Waypoint                       waypoint_service.ClientService
 	Webhook                        webhook_service.ClientService
 	LogService                     log_service.ClientService
+	LogStreamingService            streaming_service.ClientService
 	ResourceService                resource_service.ClientService
 	RadarSourceRegistrationService radar_src_registration_service.ClientService
 	RadarConnectionService         radar_connection_service.ClientService
@@ -179,6 +181,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 		VaultSecrets:                   cloud_vault_secrets.New(httpClient, nil).SecretService,
 		Waypoint:                       cloud_waypoint.New(httpClient, nil).WaypointService,
 		LogService:                     cloud_log_service.New(httpClient, nil).LogService,
+		LogStreamingService:            cloud_log_service.New(httpClient, nil).StreamingService,
 		Webhook:                        cloud_webhook.New(httpClient, nil).WebhookService,
 		ResourceService:                cloud_resource_manager.New(httpClient, nil).ResourceService,
 		RadarSourceRegistrationService: cloud_vault_radar.New(httpClient, nil).DataSourceRegistrationService,

--- a/internal/clients/logs.go
+++ b/internal/clients/logs.go
@@ -6,57 +6,33 @@ package clients
 import (
 	"context"
 
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/log_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/streaming_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/models"
-	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 )
 
-// CreateLogStreamingDestinationOrgFilter will create an HCP Log Streaming Destination Organization Filter.
-func CreateLogStreamingDestinationOrgFilter(ctx context.Context, client *Client, orgID string, streamingDestinationID string) error {
-	filter := &models.LogService20210330OrganizationFilter{}
-	createParams := log_service.NewLogServiceCreateStreamingDestinationFilterParams()
-	createParams.Context = ctx
-	createParams.DestinationID = streamingDestinationID
-	createParams.OrganizationID = orgID
-	createParams.Body = &models.LogService20210330CreateStreamingDestinationFilterRequest{
-		OrganizationFilter: filter,
-		DestinationID:      streamingDestinationID,
-		OrganizationID:     orgID,
-	}
-
-	_, err := client.LogService.LogServiceCreateStreamingDestinationFilter(createParams, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // GetLogStreamingDestination will get an HCP Log Streaming Destination by its ID and location.
-func GetLogStreamingDestination(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, streamingDestinationID string) (*models.LogService20210330Destination, error) {
-	getParams := log_service.NewLogServiceGetStreamingDestinationParams()
+func GetLogStreamingDestination(ctx context.Context, client *Client, orgID, streamingDestinationID string) (*models.LogService20210330StreamingDestination, error) {
+	getParams := streaming_service.NewStreamingServiceGetDestinationParams()
 	getParams.Context = ctx
 	getParams.DestinationID = streamingDestinationID
-	getParams.LocationOrganizationID = loc.OrganizationID
-	getParams.LocationProjectID = loc.ProjectID
+	getParams.OrganizationID = orgID
 
-	getResponse, err := client.LogService.LogServiceGetStreamingDestination(getParams, nil)
+	getResponse, err := client.LogStreamingService.StreamingServiceGetDestination(getParams, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return getResponse.Payload.Destination, nil
+	return getResponse.GetPayload().Destination, nil
 }
 
 // DeleteLogStreamingDestination will delete an HCP Log Streaming Destination.
-func DeleteLogStreamingDestination(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, streamingDestinationID string) error {
-	deleteParams := log_service.NewLogServiceDeleteStreamingDestinationParams()
+func DeleteLogStreamingDestination(ctx context.Context, client *Client, orgID, streamingDestinationID string) error {
+	deleteParams := streaming_service.NewStreamingServiceDeleteDestinationParams()
 	deleteParams.Context = ctx
 	deleteParams.DestinationID = streamingDestinationID
-	deleteParams.LocationOrganizationID = loc.OrganizationID
-	deleteParams.LocationProjectID = loc.ProjectID
+	deleteParams.OrganizationID = orgID
 
-	_, err := client.LogService.LogServiceDeleteStreamingDestination(deleteParams, nil)
+	_, err := client.LogStreamingService.StreamingServiceDeleteDestination(deleteParams, nil)
 	if err != nil {
 		return err
 	}
@@ -64,22 +40,26 @@ func DeleteLogStreamingDestination(ctx context.Context, client *Client, loc *sha
 	return nil
 }
 
-func UpdateLogStreamingDestination(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, updatePaths []string, destination *models.LogService20210330Destination) error {
-	updateParams := log_service.NewLogServiceUpdateStreamingDestinationParams()
+func UpdateLogStreamingDestination(ctx context.Context, client *Client, updatePaths []string, destination *models.LogService20210330StreamingDestination) error {
+	updateParams := streaming_service.NewStreamingServiceUpdateDestinationParams()
 	updateParams.Context = ctx
-	updateParams.DestinationResourceID = destination.Resource.ID
-	updateParams.DestinationResourceLocationOrganizationID = loc.OrganizationID
-	updateParams.DestinationResourceLocationProjectID = loc.ProjectID
+	updateParams.OrganizationID = destination.OrganizationID
+	updateParams.ID = destination.ID
 
-	updateBody := &models.LogService20210330UpdateStreamingDestinationRequest{
-		Destination: destination,
+	updateBody := &models.LogService20210330UpdateDestinationRequest{
+		OrganizationID:         destination.OrganizationID,
+		ID:                     destination.ID,
+		Name:                   destination.Name,
+		DatadogProvider:        destination.DatadogProvider,
+		CloudwatchLogsProvider: destination.CloudwatchLogsProvider,
+		SplunkCloudProvider:    destination.SplunkCloudProvider,
 		Mask: &models.ProtobufFieldMask{
 			Paths: updatePaths,
 		},
 	}
 
 	updateParams.Body = updateBody
-	_, err := client.LogService.LogServiceUpdateStreamingDestination(updateParams, nil)
+	_, err := client.LogStreamingService.StreamingServiceUpdateDestination(updateParams, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
+++ b/internal/provider/logstreaming/resource_hcp_log_streaming_destination_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -264,12 +263,8 @@ func testAccHCPLogStreamingDestinationExists(t *testing.T, name string) resource
 		}
 
 		client := acctest.HCPClients(t)
-		loc := &sharedmodels.HashicorpCloudLocationLocation{
-			OrganizationID: client.Config.OrganizationID,
-			ProjectID:      client.Config.ProjectID,
-		}
 
-		res, err := clients.GetLogStreamingDestination(context.Background(), client, loc, streamingDestinationID)
+		res, err := clients.GetLogStreamingDestination(context.Background(), client, client.Config.OrganizationID, streamingDestinationID)
 		if err != nil {
 			return fmt.Errorf("unable to read streaming destination %q: %v", streamingDestinationID, err)
 		}
@@ -290,12 +285,7 @@ func testAccHCPLogStreamingDestinationDestroy(t *testing.T, s *terraform.State) 
 
 			streamingDestinationID := rs.Primary.Attributes["streaming_destination_id"]
 
-			loc := &sharedmodels.HashicorpCloudLocationLocation{
-				OrganizationID: client.Config.OrganizationID,
-				ProjectID:      client.Config.ProjectID,
-			}
-
-			_, err := clients.GetLogStreamingDestination(context.Background(), client, loc, streamingDestinationID)
+			_, err := clients.GetLogStreamingDestination(context.Background(), client, client.Config.OrganizationID, streamingDestinationID)
 			if err == nil || !clients.IsResponseCodeNotFound(err) {
 				return fmt.Errorf("didn't get a 404 when reading destroyed streaming destination %q: %v", streamingDestinationID, err)
 			}


### PR DESCRIPTION
Standardize on LogStreamingService Client across UI and Terraform provider. The HCP Audit Log Streaming UI already uses the LogStreamingService client.

<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
