### PR TITLE
HCPF-2274:  Handle DEADLINE_EXCEEDED Retries for projects create, setName and setDescription

### DIFF
--- a/.changelog/1181.txt
+++ b/.changelog/1181.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Update hcp_project calls to retry when encountering a 502, 503, or 504 error.
+```

--- a/internal/clients/group.go
+++ b/internal/clients/group.go
@@ -22,15 +22,8 @@ func CreateGroupRetry(client *Client, params *groups_service.GroupsServiceCreate
 		return err
 	}
 
-	getCode := func(err error) (int, error) {
-		serviceErr, ok := err.(*groups_service.GroupsServiceCreateGroupDefault)
-		if !ok {
-			return 0, err
-		}
-		return serviceErr.Code(), nil
-	}
-
-	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
+	serviceErr := &groups_service.GroupsServiceCreateGroupDefault{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
 
 	return res, err
 }
@@ -44,15 +37,8 @@ func UpdateGroupRetry(client *Client, params *groups_service.GroupsServiceUpdate
 		return err
 	}
 
-	getCode := func(err error) (int, error) {
-		serviceErr, ok := err.(*groups_service.GroupsServiceUpdateGroup2Default)
-		if !ok {
-			return 0, err
-		}
-		return serviceErr.Code(), nil
-	}
-
-	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
+	serviceErr := &groups_service.GroupsServiceUpdateGroup2Default{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
 
 	return res, err
 }
@@ -66,15 +52,8 @@ func DeleteGroupRetry(client *Client, params *groups_service.GroupsServiceDelete
 		return err
 	}
 
-	getCode := func(err error) (int, error) {
-		serviceErr, ok := err.(*groups_service.GroupsServiceDeleteGroupDefault)
-		if !ok {
-			return 0, err
-		}
-		return serviceErr.Code(), nil
-	}
-
-	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
+	serviceErr := &groups_service.GroupsServiceDeleteGroupDefault{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
 
 	return res, err
 }
@@ -90,48 +69,8 @@ func UpdateGroupMembersRetry(client *Client, params *groups_service.GroupsServic
 		return err
 	}
 
-	getCode := func(err error) (int, error) {
-		serviceErr, ok := err.(*groups_service.GroupsServiceUpdateGroupMembersDefault)
-		if !ok {
-			return 0, err
-		}
-		return serviceErr.Code(), nil
-	}
-
-	err := backoff.Retry(newBackoffOp(op, getCode), newBackoff())
+	serviceErr := &groups_service.GroupsServiceUpdateGroupMembersDefault{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
 
 	return res, err
-}
-
-// newBackoff creates a new exponential backoff with default values.
-func newBackoff() backoff.BackOff {
-	// Create a new exponential backoff with explicit default values.
-	return backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(backoff.DefaultInitialInterval),
-		backoff.WithRandomizationFactor(backoff.DefaultRandomizationFactor),
-		backoff.WithMultiplier(backoff.DefaultMultiplier),
-		backoff.WithMaxInterval(backoff.DefaultMaxInterval),
-		backoff.WithMaxElapsedTime(backoff.DefaultMaxElapsedTime),
-	)
-}
-
-func newBackoffOp(op func() error, getCode func(error) (int, error)) func() error {
-	return func() error {
-		err := op()
-
-		if err == nil {
-			return nil
-		}
-
-		code, codeErr := getCode(err)
-		if codeErr != nil {
-			return backoff.Permanent(codeErr)
-		}
-
-		if !shouldRetryErrorCode(code, groupErrorCodesToRetry[:]) {
-			return backoff.Permanent(err)
-		}
-
-		return err
-	}
 }

--- a/internal/clients/project.go
+++ b/internal/clients/project.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/project_service"
 	resourcemodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
 )
@@ -51,4 +53,49 @@ func CreateProject(ctx context.Context, client *Client, name, organizationID str
 	}
 
 	return createProjectResp.Payload.Project, nil
+}
+
+// CreateProjectWithRetry wraps the projects service client with an exponential backoff retry mechanism.
+func CreateProjectWithRetry(client *Client, params *project_service.ProjectServiceCreateParams) (*project_service.ProjectServiceCreateOK, error) {
+	var res *project_service.ProjectServiceCreateOK
+	op := func() error {
+		var err error
+		res, err = client.Project.ProjectServiceCreate(params, nil)
+		return err
+	}
+
+	serviceErr := &project_service.ProjectServiceCreateDefault{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
+
+	return res, err
+}
+
+// SetProjectNameWithRetry wraps the projects service client with an exponential backoff retry mechanism.
+func SetProjectNameWithRetry(client *Client, params *project_service.ProjectServiceSetNameParams) (*project_service.ProjectServiceSetNameOK, error) {
+	var res *project_service.ProjectServiceSetNameOK
+	op := func() error {
+		var err error
+		res, err = client.Project.ProjectServiceSetName(params, nil)
+		return err
+	}
+
+	serviceErr := &project_service.ProjectServiceSetNameDefault{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
+
+	return res, err
+}
+
+// SetProjectDescriptionWithRetry wraps the projects service client with an exponential backoff retry mechanism.
+func SetProjectDescriptionWithRetry(client *Client, params *project_service.ProjectServiceSetDescriptionParams) (*project_service.ProjectServiceSetDescriptionOK, error) {
+	var res *project_service.ProjectServiceSetDescriptionOK
+	op := func() error {
+		var err error
+		res, err = client.Project.ProjectServiceSetDescription(params, nil)
+		return err
+	}
+
+	serviceErr := &project_service.ProjectServiceSetDescriptionDefault{}
+	err := backoff.Retry(newBackoffOp(op, serviceErr), newBackoff())
+
+	return res, err
 }

--- a/internal/clients/service_error.go
+++ b/internal/clients/service_error.go
@@ -1,0 +1,17 @@
+package clients
+
+import (
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+)
+
+type ServiceError interface {
+	IsSuccess() bool
+	IsRedirect() bool
+	IsClientError() bool
+	IsServerError() bool
+	IsCode(code int) bool
+	Code() int
+	Error() string
+	String() string
+	GetPayload() *models.GoogleRPCStatus
+}

--- a/internal/provider/resourcemanager/resource_project.go
+++ b/internal/provider/resourcemanager/resource_project.go
@@ -125,7 +125,7 @@ func (r *resourceProject) Create(ctx context.Context, req resource.CreateRequest
 		},
 	}
 
-	res, err := r.client.Project.ProjectServiceCreate(createParams, nil)
+	res, err := clients.CreateProjectWithRetry(r.client, createParams)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating project", err.Error())
 		return
@@ -220,7 +220,7 @@ func (r *resourceProject) Update(ctx context.Context, req resource.UpdateRequest
 			Name: plan.Name.ValueString(),
 		}
 
-		_, err := r.client.Project.ProjectServiceSetName(setNameReq, nil)
+		_, err := clients.SetProjectNameWithRetry(r.client, setNameReq)
 		if err != nil {
 			resp.Diagnostics.AddError("Error updating project name", err.Error())
 			return
@@ -235,7 +235,7 @@ func (r *resourceProject) Update(ctx context.Context, req resource.UpdateRequest
 			Description: plan.Description.ValueString(),
 		}
 
-		_, err := r.client.Project.ProjectServiceSetDescription(setDescReq, nil)
+		_, err := clients.SetProjectDescriptionWithRetry(r.client, setDescReq)
 		if err != nil {
 			resp.Diagnostics.AddError("Error updating project description", err.Error())
 			return


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

Adds a retry wrapper around projects `create`, `setName` and `setDescription` clients. This wrapper uses exponential backoff to handle the retry.

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccProjectResource'
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml
TF_ACC=1 go test ./internal/... -v -run=TestAccProjectResource -timeout 360m -parallel=10
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/iampolicy	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/clients/packerv2	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/customdiags	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/helpers	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/customtypes	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/clients	0.606s [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/modifiers	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/consul	0.727s [no tests to run]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/configbuilder/packerconfig	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testcheck	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/testutils/testclient	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/base	[no test files]
?   	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/utils/location	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/hcpvalidator	0.870s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/input	0.195s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider	1.266s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/iam	1.104s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming	1.437s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/datasources/artifact	1.826s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/datasources/version	2.145s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/packer/resources/bucket	2.471s [no tests to run]
=== RUN   TestAccProjectResource
--- PASS: TestAccProjectResource (12.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager	14.313s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultradar	2.520s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets	3.257s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint	2.874s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook	3.741s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook/validator	3.238s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-hcp/internal/providersdkv2	4.129s [no tests to run]
...
```
