### PR TITLE
docs: log_streaming_destination GA, remove public beta note

### DIFF
--- a/.changelog/1207.txt
+++ b/.changelog/1207.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcp_log_streaming_destination: Generally Available
+```

--- a/docs/resources/log_streaming_destination.md
+++ b/docs/resources/log_streaming_destination.md
@@ -7,8 +7,6 @@ description: |-
 
 # hcp_log_streaming_destination (Resource)
 
--> **Note:** This resource is currently in public beta.
-
 The Streaming Destination resource allows users to configure an external log system to stream HCP logs to.
 
 To manage destinations, you must authenticate with an organization-level service principal with

--- a/templates/resources/log_streaming_destination.md.tmpl
+++ b/templates/resources/log_streaming_destination.md.tmpl
@@ -7,8 +7,6 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
--> **Note:** This resource is currently in public beta.
-
 {{ .Description | trimspace }}
 
 To manage destinations, you must authenticate with an organization-level service principal with


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Marks the `hcp_log_streaming_destination` resource as generally available by removing the public beta note from the docs.
