### PR TITLE
[WAYP-3244] Switch to new Waypoint API version

### DIFF
--- a/.changelog/1208.txt
+++ b/.changelog/1208.txt
@@ -1,0 +1,4 @@
+```release-note:deprecation
+The following attribute is deprecated for Waypoint the add-on resource and data source:
+  - `hcp_waypoint_add_on_created_by`
+```

--- a/docs/data-sources/waypoint_add_on.md
+++ b/docs/data-sources/waypoint_add_on.md
@@ -23,7 +23,7 @@ The Waypoint Add-on data source retrieves information on a given Add-on.
 ### Read-Only
 
 - `application_id` (String) The ID of the Application that this Add-on is created for.
-- `created_by` (String) The user who created the Add-on.
+- `created_by` (String, Deprecated) The user who created the Add-on.
 - `definition_id` (String) The ID of the Add-on Definition that this Add-on is created from.
 - `description` (String) A longer description of the Add-on.
 - `install_count` (Number) The number of installed Add-ons for the same Application that share the same Add-on Definition.

--- a/docs/resources/waypoint_add_on.md
+++ b/docs/resources/waypoint_add_on.md
@@ -28,7 +28,7 @@ Waypoint Add-on resource
 ### Read-Only
 
 - `add_on_definition_input_variables` (Attributes Set) Input variables set for the add-on definition. (see [below for nested schema](#nestedatt--add_on_definition_input_variables))
-- `created_by` (String) The user who created the Add-on.
+- `created_by` (String, Deprecated) The user who created the Add-on.
 - `description` (String) A longer description of the Add-on.
 - `id` (String) The ID of the Add-on.
 - `install_count` (Number) The number of installed Add-ons for the same Application that share the same Add-on Definition.

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -50,8 +50,8 @@ import (
 	cloud_vault_secrets "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 
-	cloud_waypoint "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	cloud_waypoint_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 
 	cloud_log_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/log_service"
@@ -87,7 +87,7 @@ type Client struct {
 	Groups                         groups_service.ClientService
 	Vault                          vault_service.ClientService
 	VaultSecrets                   secret_service.ClientService
-	Waypoint                       waypoint_service.ClientService
+	Waypoint                       waypoint_service_v2.ClientService
 	Webhook                        webhook_service.ClientService
 	LogService                     log_service.ClientService
 	LogStreamingService            streaming_service.ClientService
@@ -179,7 +179,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 		Groups:                         cloud_iam.New(httpClient, nil).GroupsService,
 		Vault:                          cloud_vault.New(httpClient, nil).VaultService,
 		VaultSecrets:                   cloud_vault_secrets.New(httpClient, nil).SecretService,
-		Waypoint:                       cloud_waypoint.New(httpClient, nil).WaypointService,
+		Waypoint:                       cloud_waypoint_v2.New(httpClient, nil).WaypointService,
 		LogService:                     cloud_log_service.New(httpClient, nil).LogService,
 		LogStreamingService:            cloud_log_service.New(httpClient, nil).StreamingService,
 		Webhook:                        cloud_webhook.New(httpClient, nil).WebhookService,

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -50,8 +50,8 @@ import (
 	cloud_vault_secrets "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-secrets/stable/2023-11-28/client/secret_service"
 
-	cloud_waypoint_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	cloud_waypoint "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 
 	cloud_log_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/log_service"
@@ -87,7 +87,7 @@ type Client struct {
 	Groups                         groups_service.ClientService
 	Vault                          vault_service.ClientService
 	VaultSecrets                   secret_service.ClientService
-	Waypoint                       waypoint_service_v2.ClientService
+	Waypoint                       waypoint_service.ClientService
 	Webhook                        webhook_service.ClientService
 	LogService                     log_service.ClientService
 	LogStreamingService            streaming_service.ClientService
@@ -179,7 +179,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 		Groups:                         cloud_iam.New(httpClient, nil).GroupsService,
 		Vault:                          cloud_vault.New(httpClient, nil).VaultService,
 		VaultSecrets:                   cloud_vault_secrets.New(httpClient, nil).SecretService,
-		Waypoint:                       cloud_waypoint_v2.New(httpClient, nil).WaypointService,
+		Waypoint:                       cloud_waypoint.New(httpClient, nil).WaypointService,
 		LogService:                     cloud_log_service.New(httpClient, nil).LogService,
 		LogStreamingService:            cloud_log_service.New(httpClient, nil).StreamingService,
 		Webhook:                        cloud_webhook.New(httpClient, nil).WebhookService,

--- a/internal/clients/waypoint.go
+++ b/internal/clients/waypoint.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 )
 
 // GetAction will retrieve an Action using the provided ID by default
 // or by name if the ID is not provided
-func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, actionID string, actionName string) (*waypoint_models_v2.HashicorpCloudWaypointActionConfig, error) {
-	params := &waypoint_service_v2.WaypointServiceGetActionConfigParams{
+func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, actionID string, actionName string) (*waypoint_models.HashicorpCloudWaypointActionConfig, error) {
+	params := &waypoint_service.WaypointServiceGetActionConfigParams{
 		ActionID:                        &actionID,
 		ActionName:                      &actionName,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
@@ -29,8 +29,8 @@ func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpC
 }
 
 // GetApplicationTemplateByName will retrieve a template by name
-func GetApplicationTemplateByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate, error) {
-	params := &waypoint_service_v2.WaypointServiceGetApplicationTemplate2Params{
+func GetApplicationTemplateByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models.HashicorpCloudWaypointApplicationTemplate, error) {
+	params := &waypoint_service.WaypointServiceGetApplicationTemplate2Params{
 		ApplicationTemplateName:         appName,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -44,8 +44,8 @@ func GetApplicationTemplateByName(ctx context.Context, client *Client, loc *shar
 }
 
 // GetApplicationTemplateByID will retrieve a template by ID
-func GetApplicationTemplateByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate, error) {
-	params := &waypoint_service_v2.WaypointServiceGetApplicationTemplateParams{
+func GetApplicationTemplateByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models.HashicorpCloudWaypointApplicationTemplate, error) {
+	params := &waypoint_service.WaypointServiceGetApplicationTemplateParams{
 		ApplicationTemplateID:           appID,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -59,8 +59,8 @@ func GetApplicationTemplateByID(ctx context.Context, client *Client, loc *shared
 }
 
 // GetAddOnDefinitionByName will retrieve an add-on definition by name
-func GetAddOnDefinitionByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition, error) {
-	params := &waypoint_service_v2.WaypointServiceGetAddOnDefinition2Params{
+func GetAddOnDefinitionByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models.HashicorpCloudWaypointAddOnDefinition, error) {
+	params := &waypoint_service.WaypointServiceGetAddOnDefinition2Params{
 		AddOnDefinitionName:             defName,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -74,8 +74,8 @@ func GetAddOnDefinitionByName(ctx context.Context, client *Client, loc *sharedmo
 }
 
 // GetAddOnDefinitionByID will retrieve an add-on definition by ID
-func GetAddOnDefinitionByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition, error) {
-	params := &waypoint_service_v2.WaypointServiceGetAddOnDefinitionParams{
+func GetAddOnDefinitionByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models.HashicorpCloudWaypointAddOnDefinition, error) {
+	params := &waypoint_service.WaypointServiceGetAddOnDefinitionParams{
 		AddOnDefinitionID:               defID,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -89,8 +89,8 @@ func GetAddOnDefinitionByID(ctx context.Context, client *Client, loc *sharedmode
 }
 
 // GetApplicationByName will retrieve an application by name
-func GetApplicationByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models_v2.HashicorpCloudWaypointApplication, error) {
-	params := &waypoint_service_v2.WaypointServiceGetApplication2Params{
+func GetApplicationByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models.HashicorpCloudWaypointApplication, error) {
+	params := &waypoint_service.WaypointServiceGetApplication2Params{
 		ApplicationName:                 appName,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -104,8 +104,8 @@ func GetApplicationByName(ctx context.Context, client *Client, loc *sharedmodels
 }
 
 // GetApplicationByID will retrieve an application by ID
-func GetApplicationByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models_v2.HashicorpCloudWaypointApplication, error) {
-	params := &waypoint_service_v2.WaypointServiceGetApplicationParams{
+func GetApplicationByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models.HashicorpCloudWaypointApplication, error) {
+	params := &waypoint_service.WaypointServiceGetApplicationParams{
 		ApplicationID:                   appID,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -119,8 +119,8 @@ func GetApplicationByID(ctx context.Context, client *Client, loc *sharedmodels.H
 }
 
 // GetAddOnByName will retrieve an add-on by name
-func GetAddOnByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models_v2.HashicorpCloudWaypointAddOn, error) {
-	params := &waypoint_service_v2.WaypointServiceGetAddOn2Params{
+func GetAddOnByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models.HashicorpCloudWaypointAddOn, error) {
+	params := &waypoint_service.WaypointServiceGetAddOn2Params{
 		AddOnName:                       defName,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -134,8 +134,8 @@ func GetAddOnByName(ctx context.Context, client *Client, loc *sharedmodels.Hashi
 }
 
 // GetAddOnByID will retrieve an add-on by ID
-func GetAddOnByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models_v2.HashicorpCloudWaypointAddOn, error) {
-	params := &waypoint_service_v2.WaypointServiceGetAddOnParams{
+func GetAddOnByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models.HashicorpCloudWaypointAddOn, error) {
+	params := &waypoint_service.WaypointServiceGetAddOnParams{
 		AddOnID:                         defID,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -148,8 +148,8 @@ func GetAddOnByID(ctx context.Context, client *Client, loc *sharedmodels.Hashico
 	return getResp.GetPayload().AddOn, nil
 }
 
-func GetInputVariables(ctx context.Context, client *Client, workspaceName string, loc *sharedmodels.HashicorpCloudLocationLocation) ([]*waypoint_models_v2.HashicorpCloudWaypointInputVariable, error) {
-	params := &waypoint_service_v2.WaypointServiceGetTFRunStatusParams{
+func GetInputVariables(ctx context.Context, client *Client, workspaceName string, loc *sharedmodels.HashicorpCloudLocationLocation) ([]*waypoint_models.HashicorpCloudWaypointInputVariable, error) {
+	params := &waypoint_service.WaypointServiceGetTFRunStatusParams{
 		WorkspaceName:                   workspaceName,
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,

--- a/internal/clients/waypoint.go
+++ b/internal/clients/waypoint.go
@@ -11,21 +11,6 @@ import (
 	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 )
 
-// getNamespaceByLocation will retrieve a namespace by location information
-// provided by HCP
-func getNamespaceByLocation(_ context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models_v2.HashicorpCloudWaypointNamespace, error) {
-	namespaceParams := &waypoint_service_v2.WaypointServiceGetNamespaceParams{
-		LocationOrganizationID: loc.OrganizationID,
-		LocationProjectID:      loc.ProjectID,
-	}
-	// get namespace
-	ns, err := client.Waypoint.WaypointServiceGetNamespace(namespaceParams, nil)
-	if err != nil {
-		return nil, err
-	}
-	return ns.GetPayload().Namespace, nil
-}
-
 // GetAction will retrieve an Action using the provided ID by default
 // or by name if the ID is not provided
 func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, actionID string, actionName string) (*waypoint_models_v2.HashicorpCloudWaypointActionConfig, error) {

--- a/internal/clients/waypoint.go
+++ b/internal/clients/waypoint.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 )
 
 // getNamespaceByLocation will retrieve a namespace by location information
 // provided by HCP
-func getNamespaceByLocation(_ context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models.HashicorpCloudWaypointNamespace, error) {
-	namespaceParams := &waypoint_service.WaypointServiceGetNamespaceParams{
+func getNamespaceByLocation(_ context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models_v2.HashicorpCloudWaypointNamespace, error) {
+	namespaceParams := &waypoint_service_v2.WaypointServiceGetNamespaceParams{
 		LocationOrganizationID: loc.OrganizationID,
 		LocationProjectID:      loc.ProjectID,
 	}
@@ -28,16 +28,12 @@ func getNamespaceByLocation(_ context.Context, client *Client, loc *sharedmodels
 
 // GetAction will retrieve an Action using the provided ID by default
 // or by name if the ID is not provided
-func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, actionID string, actionName string) (*waypoint_models.HashicorpCloudWaypointActionConfig, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetActionConfigParams{
-		ActionID:    &actionID,
-		ActionName:  &actionName,
-		NamespaceID: ns.ID,
+func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, actionID string, actionName string) (*waypoint_models_v2.HashicorpCloudWaypointActionConfig, error) {
+	params := &waypoint_service_v2.WaypointServiceGetActionConfigParams{
+		ActionID:                        &actionID,
+		ActionName:                      &actionName,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetActionConfig(params, nil)
@@ -48,15 +44,11 @@ func GetAction(ctx context.Context, client *Client, loc *sharedmodels.HashicorpC
 }
 
 // GetApplicationTemplateByName will retrieve a template by name
-func GetApplicationTemplateByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models.HashicorpCloudWaypointApplicationTemplate, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetApplicationTemplate2Params{
-		ApplicationTemplateName: appName,
-		NamespaceID:             ns.ID,
+func GetApplicationTemplateByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate, error) {
+	params := &waypoint_service_v2.WaypointServiceGetApplicationTemplate2Params{
+		ApplicationTemplateName:         appName,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetApplicationTemplate2(params, nil)
@@ -67,15 +59,11 @@ func GetApplicationTemplateByName(ctx context.Context, client *Client, loc *shar
 }
 
 // GetApplicationTemplateByID will retrieve a template by ID
-func GetApplicationTemplateByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models.HashicorpCloudWaypointApplicationTemplate, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetApplicationTemplateParams{
-		ApplicationTemplateID: appID,
-		NamespaceID:           ns.ID,
+func GetApplicationTemplateByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate, error) {
+	params := &waypoint_service_v2.WaypointServiceGetApplicationTemplateParams{
+		ApplicationTemplateID:           appID,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetApplicationTemplate(params, nil)
@@ -86,15 +74,11 @@ func GetApplicationTemplateByID(ctx context.Context, client *Client, loc *shared
 }
 
 // GetAddOnDefinitionByName will retrieve an add-on definition by name
-func GetAddOnDefinitionByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models.HashicorpCloudWaypointAddOnDefinition, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetAddOnDefinition2Params{
-		AddOnDefinitionName: defName,
-		NamespaceID:         ns.ID,
+func GetAddOnDefinitionByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition, error) {
+	params := &waypoint_service_v2.WaypointServiceGetAddOnDefinition2Params{
+		AddOnDefinitionName:             defName,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetAddOnDefinition2(params, nil)
@@ -105,15 +89,11 @@ func GetAddOnDefinitionByName(ctx context.Context, client *Client, loc *sharedmo
 }
 
 // GetAddOnDefinitionByID will retrieve an add-on definition by ID
-func GetAddOnDefinitionByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models.HashicorpCloudWaypointAddOnDefinition, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetAddOnDefinitionParams{
-		AddOnDefinitionID: defID,
-		NamespaceID:       ns.ID,
+func GetAddOnDefinitionByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition, error) {
+	params := &waypoint_service_v2.WaypointServiceGetAddOnDefinitionParams{
+		AddOnDefinitionID:               defID,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetAddOnDefinition(params, nil)
@@ -124,15 +104,11 @@ func GetAddOnDefinitionByID(ctx context.Context, client *Client, loc *sharedmode
 }
 
 // GetApplicationByName will retrieve an application by name
-func GetApplicationByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models.HashicorpCloudWaypointApplication, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetApplication2Params{
-		ApplicationName: appName,
-		NamespaceID:     ns.ID,
+func GetApplicationByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appName string) (*waypoint_models_v2.HashicorpCloudWaypointApplication, error) {
+	params := &waypoint_service_v2.WaypointServiceGetApplication2Params{
+		ApplicationName:                 appName,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetApplication2(params, nil)
@@ -143,15 +119,11 @@ func GetApplicationByName(ctx context.Context, client *Client, loc *sharedmodels
 }
 
 // GetApplicationByID will retrieve an application by ID
-func GetApplicationByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models.HashicorpCloudWaypointApplication, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetApplicationParams{
-		ApplicationID: appID,
-		NamespaceID:   ns.ID,
+func GetApplicationByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, appID string) (*waypoint_models_v2.HashicorpCloudWaypointApplication, error) {
+	params := &waypoint_service_v2.WaypointServiceGetApplicationParams{
+		ApplicationID:                   appID,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetApplication(params, nil)
@@ -162,15 +134,11 @@ func GetApplicationByID(ctx context.Context, client *Client, loc *sharedmodels.H
 }
 
 // GetAddOnByName will retrieve an add-on by name
-func GetAddOnByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models.HashicorpCloudWaypointAddOn, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetAddOn2Params{
-		AddOnName:   defName,
-		NamespaceID: ns.ID,
+func GetAddOnByName(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defName string) (*waypoint_models_v2.HashicorpCloudWaypointAddOn, error) {
+	params := &waypoint_service_v2.WaypointServiceGetAddOn2Params{
+		AddOnName:                       defName,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetAddOn2(params, nil)
@@ -181,15 +149,11 @@ func GetAddOnByName(ctx context.Context, client *Client, loc *sharedmodels.Hashi
 }
 
 // GetAddOnByID will retrieve an add-on by ID
-func GetAddOnByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models.HashicorpCloudWaypointAddOn, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetAddOnParams{
-		AddOnID:     defID,
-		NamespaceID: ns.ID,
+func GetAddOnByID(ctx context.Context, client *Client, loc *sharedmodels.HashicorpCloudLocationLocation, defID string) (*waypoint_models_v2.HashicorpCloudWaypointAddOn, error) {
+	params := &waypoint_service_v2.WaypointServiceGetAddOnParams{
+		AddOnID:                         defID,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetAddOn(params, nil)
@@ -199,15 +163,11 @@ func GetAddOnByID(ctx context.Context, client *Client, loc *sharedmodels.Hashico
 	return getResp.GetPayload().AddOn, nil
 }
 
-func GetInputVariables(ctx context.Context, client *Client, workspaceName string, loc *sharedmodels.HashicorpCloudLocationLocation) ([]*waypoint_models.HashicorpCloudWaypointInputVariable, error) {
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		return nil, err
-	}
-
-	params := &waypoint_service.WaypointServiceGetTFRunStatusParams{
-		WorkspaceName: workspaceName,
-		NamespaceID:   ns.ID,
+func GetInputVariables(ctx context.Context, client *Client, workspaceName string, loc *sharedmodels.HashicorpCloudLocationLocation) ([]*waypoint_models_v2.HashicorpCloudWaypointInputVariable, error) {
+	params := &waypoint_service_v2.WaypointServiceGetTFRunStatusParams{
+		WorkspaceName:                   workspaceName,
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
 	getResp, err := client.Waypoint.WaypointServiceGetTFRunStatus(params, nil)

--- a/internal/provider/waypoint/data_source_waypoint_action.go
+++ b/internal/provider/waypoint/data_source_waypoint_action.go
@@ -142,7 +142,6 @@ func (d *DataSourceAction) Read(ctx context.Context, req datasource.ReadRequest,
 		ProjectID:      projectID,
 	}
 
-	//var actionModel *waypoint_models.HashicorpCloudWaypointActionConfig
 	var actionModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
 	var err error
 

--- a/internal/provider/waypoint/data_source_waypoint_action.go
+++ b/internal/provider/waypoint/data_source_waypoint_action.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -142,7 +142,8 @@ func (d *DataSourceAction) Read(ctx context.Context, req datasource.ReadRequest,
 		ProjectID:      projectID,
 	}
 
-	var actionModel *waypoint_models.HashicorpCloudWaypointActionConfig
+	//var actionModel *waypoint_models.HashicorpCloudWaypointActionConfig
+	var actionModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
 	var err error
 
 	actionModel, err = clients.GetAction(ctx, client, loc, data.ID.ValueString(), data.Name.ValueString())

--- a/internal/provider/waypoint/data_source_waypoint_action.go
+++ b/internal/provider/waypoint/data_source_waypoint_action.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -142,7 +142,7 @@ func (d *DataSourceAction) Read(ctx context.Context, req datasource.ReadRequest,
 		ProjectID:      projectID,
 	}
 
-	var actionModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
+	var actionModel *waypoint_models.HashicorpCloudWaypointActionConfig
 	var err error
 
 	actionModel, err = clients.GetAction(ctx, client, loc, data.ID.ValueString(), data.Name.ValueString())

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -257,6 +257,8 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 		state.ReadmeMarkdown = types.StringNull()
 	}
 
+	state.CreatedBy = types.StringNull()
+
 	// If we can process status as an int64, add it to the plan
 	statusNum, err := strconv.ParseInt(addOn.Count, 10, 64)
 	if err != nil {

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -105,8 +105,9 @@ func (d *DataSourceAddOn) Schema(ctx context.Context, req datasource.SchemaReque
 				ElementType: types.StringType,
 			},
 			"created_by": schema.StringAttribute{
-				Description: "The user who created the Add-on.",
-				Computed:    true,
+				Description:        "The user who created the Add-on.",
+				Computed:           true,
+				DeprecationMessage: "This attribute is deprecated and will be removed in a future version of the provider.",
 			},
 			"install_count": schema.Int64Attribute{
 				Description: "The number of installed Add-ons for the same Application that share the same " +
@@ -213,7 +214,7 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 		ProjectID:      client.Config.ProjectID,
 	}
 
-	var addOn *waypoint_models.HashicorpCloudWaypointAddOn
+	var addOn *waypoint_models_v2.HashicorpCloudWaypointAddOn
 	var err error
 
 	if state.ID.IsNull() {
@@ -255,8 +256,6 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 	if addOn.ReadmeMarkdown.String() == "" {
 		state.ReadmeMarkdown = types.StringNull()
 	}
-
-	state.CreatedBy = types.StringValue(addOn.CreatedBy)
 
 	// If we can process status as an int64, add it to the plan
 	statusNum, err := strconv.ParseInt(addOn.Count, 10, 64)

--- a/internal/provider/waypoint/data_source_waypoint_add_on.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -214,7 +214,7 @@ func (d *DataSourceAddOn) Read(ctx context.Context, req datasource.ReadRequest, 
 		ProjectID:      client.Config.ProjectID,
 	}
 
-	var addOn *waypoint_models_v2.HashicorpCloudWaypointAddOn
+	var addOn *waypoint_models.HashicorpCloudWaypointAddOn
 	var err error
 
 	if state.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -198,7 +198,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 		ProjectID:      projectID,
 	}
 
-	var definition *waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition
+	var definition *waypoint_models.HashicorpCloudWaypointAddOnDefinition
 	var err error
 
 	if state.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/data_source_waypoint_add_on_definition.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypointModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -198,7 +198,7 @@ func (d *DataSourceAddOnDefinition) Read(ctx context.Context, req datasource.Rea
 		ProjectID:      projectID,
 	}
 
-	var definition *waypointModels.HashicorpCloudWaypointAddOnDefinition
+	var definition *waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition
 	var err error
 
 	if state.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_application.go
+++ b/internal/provider/waypoint/data_source_waypoint_application.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -198,7 +198,7 @@ func (d *DataSourceApplication) Read(ctx context.Context, req datasource.ReadReq
 		ProjectID:      projectID,
 	}
 
-	var application *waypoint_models_v2.HashicorpCloudWaypointApplication
+	var application *waypoint_models.HashicorpCloudWaypointApplication
 	var err error
 
 	if data.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_application.go
+++ b/internal/provider/waypoint/data_source_waypoint_application.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -198,7 +198,7 @@ func (d *DataSourceApplication) Read(ctx context.Context, req datasource.ReadReq
 		ProjectID:      projectID,
 	}
 
-	var application *waypoint_models.HashicorpCloudWaypointApplication
+	var application *waypoint_models_v2.HashicorpCloudWaypointApplication
 	var err error
 
 	if data.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_template.go
+++ b/internal/provider/waypoint/data_source_waypoint_template.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -206,7 +206,7 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 		ProjectID:      projectID,
 	}
 
-	var appTemplate *waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate
+	var appTemplate *waypoint_models.HashicorpCloudWaypointApplicationTemplate
 	var err error
 
 	if data.ID.IsNull() {

--- a/internal/provider/waypoint/data_source_waypoint_template.go
+++ b/internal/provider/waypoint/data_source_waypoint_template.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -206,7 +206,7 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 		ProjectID:      projectID,
 	}
 
-	var appTemplate *waypoint_models.HashicorpCloudWaypointApplicationTemplate
+	var appTemplate *waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate
 	var err error
 
 	if data.ID.IsNull() {

--- a/internal/provider/waypoint/resource_waypoint_action.go
+++ b/internal/provider/waypoint/resource_waypoint_action.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -158,24 +158,10 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	orgID := r.client.Config.OrganizationID
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
-		ProjectID:      projectID,
-	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
-
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceCreateActionConfigBody{
-		ActionConfig: &waypoint_models.HashicorpCloudWaypointActionConfig{
-			Request: &waypoint_models.HashicorpCloudWaypointActionConfigRequest{},
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateActionConfigBody{
+		ActionConfig: &waypoint_models_v2.HashicorpCloudWaypointActionConfig{
+			Request: &waypoint_models_v2.HashicorpCloudWaypointActionConfigRequest{},
 		},
 	}
 
@@ -189,9 +175,9 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// This is a proxy for the request type, as Custom.Method is required for Custom requests
 	if !plan.Request.Custom.Method.IsUnknown() && !plan.Request.Custom.Method.IsNull() {
-		modelBody.ActionConfig.Request.Custom = &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustom{}
+		modelBody.ActionConfig.Request.Custom = &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustom{}
 
-		method := waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
+		method := waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
 		modelBody.ActionConfig.Request.Custom.Method = &method
 
 		if !plan.Request.Custom.Headers.IsUnknown() && !plan.Request.Custom.Headers.IsNull() {
@@ -202,7 +188,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 				return
 			}
 			for key, value := range elements {
-				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
+				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
 					Key:   key,
 					Value: value.ValueString(),
 				})
@@ -217,9 +203,10 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 	}
 
-	params := &waypoint_service.WaypointServiceCreateActionConfigParams{
-		NamespaceID: ns.ID,
-		Body:        modelBody,
+	params := &waypoint_service_v2.WaypointServiceCreateActionConfigParams{
+		NamespaceLocationOrganizationID: orgID,
+		NamespaceLocationProjectID:      projectID,
+		Body:                            modelBody,
 	}
 
 	aCfg, err := r.client.Waypoint.WaypointServiceCreateActionConfig(params, nil)
@@ -228,7 +215,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	var aCfgModel *waypoint_models.HashicorpCloudWaypointActionConfig
+	var aCfgModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
 	if aCfg.Payload != nil {
 		aCfgModel = aCfg.Payload.ActionConfig
 	}
@@ -355,24 +342,10 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	orgID := r.client.Config.OrganizationID
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
-		ProjectID:      projectID,
-	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
-
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceUpdateActionConfigBody{
-		ActionConfig: &waypoint_models.HashicorpCloudWaypointActionConfig{
-			Request: &waypoint_models.HashicorpCloudWaypointActionConfigRequest{},
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateActionConfigBody{
+		ActionConfig: &waypoint_models_v2.HashicorpCloudWaypointActionConfig{
+			Request: &waypoint_models_v2.HashicorpCloudWaypointActionConfigRequest{},
 		},
 	}
 
@@ -384,9 +357,9 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// This is a proxy for the request type, as Custom.Method is required for Custom requests
 	if !plan.Request.Custom.Method.IsUnknown() && !plan.Request.Custom.Method.IsNull() {
-		modelBody.ActionConfig.Request.Custom = &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustom{}
+		modelBody.ActionConfig.Request.Custom = &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustom{}
 
-		method := waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
+		method := waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
 		modelBody.ActionConfig.Request.Custom.Method = &method
 
 		if !plan.Request.Custom.Headers.IsUnknown() && !plan.Request.Custom.Headers.IsNull() {
@@ -397,7 +370,7 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 				return
 			}
 			for key, value := range elements {
-				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
+				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
 					Key:   key,
 					Value: value.ValueString(),
 				})
@@ -412,9 +385,10 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
-	params := &waypoint_service.WaypointServiceUpdateActionConfigParams{
-		NamespaceID: ns.ID,
-		Body:        modelBody,
+	params := &waypoint_service_v2.WaypointServiceUpdateActionConfigParams{
+		NamespaceLocationOrganizationID: orgID,
+		NamespaceLocationProjectID:      projectID,
+		Body:                            modelBody,
 	}
 
 	actionCfg, err := r.client.Waypoint.WaypointServiceUpdateActionConfig(params, nil)
@@ -423,7 +397,7 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	var aCfgModel *waypoint_models.HashicorpCloudWaypointActionConfig
+	var aCfgModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
 	if actionCfg.Payload != nil {
 		aCfgModel = actionCfg.Payload.ActionConfig
 	}
@@ -485,23 +459,14 @@ func (r *ActionResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting Action",
-			err.Error(),
-		)
-		return
+	params := &waypoint_service_v2.WaypointServiceDeleteActionConfigParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		ActionID:                        data.ID.ValueStringPointer(),
+		ActionName:                      data.Name.ValueStringPointer(),
 	}
 
-	params := &waypoint_service.WaypointServiceDeleteActionConfigParams{
-		NamespaceID: ns.ID,
-		ActionID:    data.ID.ValueStringPointer(),
-		ActionName:  data.Name.ValueStringPointer(),
-	}
-
-	_, err = r.client.Waypoint.WaypointServiceDeleteActionConfig(params, nil)
+	_, err := r.client.Waypoint.WaypointServiceDeleteActionConfig(params, nil)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			tflog.Info(ctx, "Action not found for organization during delete call, ignoring")
@@ -521,7 +486,7 @@ func (r *ActionResource) ImportState(ctx context.Context, req resource.ImportSta
 func readCustomAction(
 	ctx context.Context,
 	data *ActionResourceModel,
-	actionCfg *waypoint_models.HashicorpCloudWaypointActionConfig,
+	actionCfg *waypoint_models_v2.HashicorpCloudWaypointActionConfig,
 ) diag.Diagnostics {
 	data.Request.Custom = &customRequest{}
 	headerMap := make(map[string]string)

--- a/internal/provider/waypoint/resource_waypoint_action.go
+++ b/internal/provider/waypoint/resource_waypoint_action.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -159,9 +159,9 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	orgID := r.client.Config.OrganizationID
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateActionConfigBody{
-		ActionConfig: &waypoint_models_v2.HashicorpCloudWaypointActionConfig{
-			Request: &waypoint_models_v2.HashicorpCloudWaypointActionConfigRequest{},
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceCreateActionConfigBody{
+		ActionConfig: &waypoint_models.HashicorpCloudWaypointActionConfig{
+			Request: &waypoint_models.HashicorpCloudWaypointActionConfigRequest{},
 		},
 	}
 
@@ -175,9 +175,9 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// This is a proxy for the request type, as Custom.Method is required for Custom requests
 	if !plan.Request.Custom.Method.IsUnknown() && !plan.Request.Custom.Method.IsNull() {
-		modelBody.ActionConfig.Request.Custom = &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustom{}
+		modelBody.ActionConfig.Request.Custom = &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustom{}
 
-		method := waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
+		method := waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
 		modelBody.ActionConfig.Request.Custom.Method = &method
 
 		if !plan.Request.Custom.Headers.IsUnknown() && !plan.Request.Custom.Headers.IsNull() {
@@ -188,7 +188,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 				return
 			}
 			for key, value := range elements {
-				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
+				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
 					Key:   key,
 					Value: value.ValueString(),
 				})
@@ -203,7 +203,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 	}
 
-	params := &waypoint_service_v2.WaypointServiceCreateActionConfigParams{
+	params := &waypoint_service.WaypointServiceCreateActionConfigParams{
 		NamespaceLocationOrganizationID: orgID,
 		NamespaceLocationProjectID:      projectID,
 		Body:                            modelBody,
@@ -215,7 +215,7 @@ func (r *ActionResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	var aCfgModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
+	var aCfgModel *waypoint_models.HashicorpCloudWaypointActionConfig
 	if aCfg.Payload != nil {
 		aCfgModel = aCfg.Payload.ActionConfig
 	}
@@ -343,9 +343,9 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	orgID := r.client.Config.OrganizationID
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateActionConfigBody{
-		ActionConfig: &waypoint_models_v2.HashicorpCloudWaypointActionConfig{
-			Request: &waypoint_models_v2.HashicorpCloudWaypointActionConfigRequest{},
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceUpdateActionConfigBody{
+		ActionConfig: &waypoint_models.HashicorpCloudWaypointActionConfig{
+			Request: &waypoint_models.HashicorpCloudWaypointActionConfigRequest{},
 		},
 	}
 
@@ -357,9 +357,9 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// This is a proxy for the request type, as Custom.Method is required for Custom requests
 	if !plan.Request.Custom.Method.IsUnknown() && !plan.Request.Custom.Method.IsNull() {
-		modelBody.ActionConfig.Request.Custom = &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustom{}
+		modelBody.ActionConfig.Request.Custom = &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustom{}
 
-		method := waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
+		method := waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomMethod(plan.Request.Custom.Method.ValueString())
 		modelBody.ActionConfig.Request.Custom.Method = &method
 
 		if !plan.Request.Custom.Headers.IsUnknown() && !plan.Request.Custom.Headers.IsNull() {
@@ -370,7 +370,7 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 				return
 			}
 			for key, value := range elements {
-				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models_v2.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
+				modelBody.ActionConfig.Request.Custom.Headers = append(modelBody.ActionConfig.Request.Custom.Headers, &waypoint_models.HashicorpCloudWaypointActionConfigFlavorCustomHeader{
 					Key:   key,
 					Value: value.ValueString(),
 				})
@@ -385,7 +385,7 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
-	params := &waypoint_service_v2.WaypointServiceUpdateActionConfigParams{
+	params := &waypoint_service.WaypointServiceUpdateActionConfigParams{
 		NamespaceLocationOrganizationID: orgID,
 		NamespaceLocationProjectID:      projectID,
 		Body:                            modelBody,
@@ -397,7 +397,7 @@ func (r *ActionResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	var aCfgModel *waypoint_models_v2.HashicorpCloudWaypointActionConfig
+	var aCfgModel *waypoint_models.HashicorpCloudWaypointActionConfig
 	if actionCfg.Payload != nil {
 		aCfgModel = actionCfg.Payload.ActionConfig
 	}
@@ -459,7 +459,7 @@ func (r *ActionResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceDeleteActionConfigParams{
+	params := &waypoint_service.WaypointServiceDeleteActionConfigParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		ActionID:                        data.ID.ValueStringPointer(),
@@ -486,7 +486,7 @@ func (r *ActionResource) ImportState(ctx context.Context, req resource.ImportSta
 func readCustomAction(
 	ctx context.Context,
 	data *ActionResourceModel,
-	actionCfg *waypoint_models_v2.HashicorpCloudWaypointActionConfig,
+	actionCfg *waypoint_models.HashicorpCloudWaypointActionConfig,
 ) diag.Diagnostics {
 	data.Request.Custom = &customRequest{}
 	headerMap := make(map[string]string)

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -402,6 +402,8 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
+	plan.CreatedBy = types.StringNull()
+
 	// If we can process status as an int64, add it to the plan
 	statusNum, err := strconv.ParseInt(addOn.Count, 10, 64)
 	if err != nil {
@@ -537,6 +539,8 @@ func (r *AddOnResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 	state.Labels = labels
+
+	state.CreatedBy = types.StringNull()
 
 	// If we can process status as an int64, add it to the plan
 	statusNum, err := strconv.ParseInt(addOn.Count, 10, 64)
@@ -691,6 +695,8 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			plan.ApplicationID = types.StringValue(addOn.Application.ID)
 		}
 	}
+
+	plan.CreatedBy = types.StringNull()
 
 	// If we can process status as an int64, add it to the plan
 	statusNum, err := strconv.ParseInt(addOn.Count, 10, 64)

--- a/internal/provider/waypoint/resource_waypoint_add_on.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -276,7 +276,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	// Prepare the input variables that the user provided to the application
 	// creation request
-	ivs := make([]*waypoint_models_v2.HashicorpCloudWaypointInputVariable, 0)
+	ivs := make([]*waypoint_models.HashicorpCloudWaypointInputVariable, 0)
 
 	var inputVarsSlice []InputVar
 	diags := plan.InputVars.ElementsAs(ctx, &inputVarsSlice, false)
@@ -286,7 +286,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 	for _, v := range inputVarsSlice {
 		// add the input variable to the list of input variables for the app
 		// creation API call
-		ivs = append(ivs, &waypoint_models_v2.HashicorpCloudWaypointInputVariable{
+		ivs = append(ivs, &waypoint_models.HashicorpCloudWaypointInputVariable{
 			Name:         v.Name.ValueString(),
 			Value:        v.Value.ValueString(),
 			VariableType: v.VariableType.ValueString(),
@@ -311,7 +311,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 	// An application ref can only have one of ID or Name set,
 	// we ask for ID, so we will set ID
 	applicationID := plan.ApplicationID.ValueString()
-	applicationRefModel := &waypoint_models_v2.HashicorpCloudWaypointRefApplication{}
+	applicationRefModel := &waypoint_models.HashicorpCloudWaypointRefApplication{}
 	if applicationID != "" {
 		applicationRefModel.ID = applicationID
 	} else {
@@ -325,7 +325,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 	// Similarly, a definition ref can only have one of ID or Name set,
 	// we ask for ID, so we will set ID
 	definitionID := plan.DefinitionID.ValueString()
-	definitionRefModel := &waypoint_models_v2.HashicorpCloudWaypointRefAddOnDefinition{}
+	definitionRefModel := &waypoint_models.HashicorpCloudWaypointRefAddOnDefinition{}
 	if definitionID != "" {
 		definitionRefModel.ID = definitionID
 	} else {
@@ -336,14 +336,14 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnBody{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnBody{
 		Name:        plan.Name.ValueString(),
 		Application: applicationRefModel,
 		Definition:  definitionRefModel,
 		Variables:   ivs,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceCreateAddOnParams{
+	params := &waypoint_service.WaypointServiceCreateAddOnParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -354,7 +354,7 @@ func (r *AddOnResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	var addOn *waypoint_models_v2.HashicorpCloudWaypointAddOn
+	var addOn *waypoint_models.HashicorpCloudWaypointAddOn
 	if responseAddOn.Payload != nil {
 		addOn = responseAddOn.Payload.AddOn
 	}
@@ -632,11 +632,11 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		ProjectID:      projectID,
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateAddOnBody{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceUpdateAddOnBody{
 		Name: plan.Name.ValueString(),
 	}
 
-	params := &waypoint_service_v2.WaypointServiceUpdateAddOnParams{
+	params := &waypoint_service.WaypointServiceUpdateAddOnParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -648,7 +648,7 @@ func (r *AddOnResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	var addOn *waypoint_models_v2.HashicorpCloudWaypointAddOn
+	var addOn *waypoint_models.HashicorpCloudWaypointAddOn
 	if def.Payload != nil {
 		addOn = def.Payload.AddOn
 	}
@@ -751,7 +751,7 @@ func (r *AddOnResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceDestroyAddOnParams{
+	params := &waypoint_service.WaypointServiceDestroyAddOnParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		AddOnID:                         state.ID.ValueString(),
@@ -778,7 +778,7 @@ func (r *AddOnResource) ImportState(ctx context.Context, req resource.ImportStat
 
 // readOutputs accepts a list of output values in the type returned by the Waypoint API and returns a list of output
 // values in the custom outputValue type used in this provider
-func readOutputs(ovs []*waypoint_models_v2.HashicorpCloudWaypointTFOutputValue) []*outputValue {
+func readOutputs(ovs []*waypoint_models.HashicorpCloudWaypointTFOutputValue) []*outputValue {
 	ol := make([]*outputValue, len(ovs))
 	for i, ov := range ovs {
 		ol[i] = &outputValue{

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	waypointModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -228,20 +228,6 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	orgID := r.client.Config.OrganizationID
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
-		ProjectID:      projectID,
-	}
-
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
 
 	var stringLabels []string
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
@@ -255,7 +241,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		}
 	}
 
-	var varOpts []*waypointModels.HashicorpCloudWaypointTFModuleVariable
+	var varOpts []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags := v.Options.ElementsAs(ctx, &strOpts, false)
@@ -264,7 +250,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 			return
 		}
 
-		varOpts = append(varOpts, &waypointModels.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -272,8 +258,8 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		})
 	}
 
-	modelBody := &waypointModels.HashicorpCloudWaypointWaypointServiceCreateAddOnDefinitionBody{
-		AddOnDefinition: &waypointModels.HashicorpCloudWaypointAddOnDefinition{
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnDefinitionBody{
+		AddOnDefinition: &waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition{
 			Name:            plan.Name.ValueString(),
 			Summary:         plan.Summary.ValueString(),
 			Description:     plan.Description.ValueString(),
@@ -302,7 +288,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 			// Set a default if none provided
 			workspaceDetails.TerraformProjectID = plan.TerraformProjectID
 		}
-		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypointModels.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      workspaceDetails.Name.ValueString(),
 			ProjectID: workspaceDetails.TerraformProjectID.ValueString(),
 		}
@@ -320,9 +306,10 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		modelBody.AddOnDefinition.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service.WaypointServiceCreateAddOnDefinitionParams{
-		NamespaceID: ns.ID,
-		Body:        modelBody,
+	params := &waypoint_service_v2.WaypointServiceCreateAddOnDefinitionParams{
+		NamespaceLocationOrganizationID: orgID,
+		NamespaceLocationProjectID:      projectID,
+		Body:                            modelBody,
 	}
 	def, err := r.client.Waypoint.WaypointServiceCreateAddOnDefinition(params, nil)
 	if err != nil {
@@ -330,7 +317,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	var addOnDefinition *waypointModels.HashicorpCloudWaypointAddOnDefinition
+	var addOnDefinition *waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition
 	if def.Payload != nil {
 		addOnDefinition = def.Payload.AddOnDefinition
 	}
@@ -505,20 +492,6 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	orgID := r.client.Config.OrganizationID
-	loc := &sharedmodels.HashicorpCloudLocationLocation{
-		OrganizationID: orgID,
-		ProjectID:      projectID,
-	}
-
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
 
 	stringLabels := []string{}
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
@@ -532,7 +505,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		}
 	}
 
-	varOpts := []*waypointModels.HashicorpCloudWaypointTFModuleVariable{}
+	varOpts := []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags := v.Options.ElementsAs(ctx, &strOpts, false)
@@ -540,7 +513,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		varOpts = append(varOpts, &waypointModels.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -549,8 +522,8 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// TODO: add support for Tags
-	modelBody := &waypointModels.HashicorpCloudWaypointWaypointServiceUpdateAddOnDefinitionBody{
-		AddOnDefinition: &waypointModels.HashicorpCloudWaypointAddOnDefinition{
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateAddOnDefinitionBody{
+		AddOnDefinition: &waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition{
 			Name:            plan.Name.ValueString(),
 			Summary:         plan.Summary.ValueString(),
 			Description:     plan.Description.ValueString(),
@@ -579,7 +552,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			// Grab the top level project ID if this was not provided
 			workspaceDetails.TerraformProjectID = plan.TerraformProjectID
 		}
-		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypointModels.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      workspaceDetails.Name.ValueString(),
 			ProjectID: workspaceDetails.TerraformProjectID.ValueString(),
 		}
@@ -597,10 +570,11 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		modelBody.AddOnDefinition.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service.WaypointServiceUpdateAddOnDefinitionParams{
-		NamespaceID:               ns.ID,
-		Body:                      modelBody,
-		ExistingAddOnDefinitionID: plan.ID.ValueString(),
+	params := &waypoint_service_v2.WaypointServiceUpdateAddOnDefinitionParams{
+		NamespaceLocationOrganizationID: orgID,
+		NamespaceLocationProjectID:      projectID,
+		Body:                            modelBody,
+		ExistingAddOnDefinitionID:       plan.ID.ValueString(),
 	}
 	def, err := r.client.Waypoint.WaypointServiceUpdateAddOnDefinition(params, nil)
 	if err != nil {
@@ -608,7 +582,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	var addOnDefinition *waypointModels.HashicorpCloudWaypointAddOnDefinition
+	var addOnDefinition *waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition
 	if def.Payload != nil {
 		addOnDefinition = def.Payload.AddOnDefinition
 	}
@@ -696,22 +670,13 @@ func (r *AddOnDefinitionResource) Delete(ctx context.Context, req resource.Delet
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting TFC Config",
-			err.Error(),
-		)
-		return
+	params := &waypoint_service_v2.WaypointServiceDeleteAddOnDefinitionParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		AddOnDefinitionID:               state.ID.ValueString(),
 	}
 
-	params := &waypoint_service.WaypointServiceDeleteAddOnDefinitionParams{
-		NamespaceID:       ns.ID,
-		AddOnDefinitionID: state.ID.ValueString(),
-	}
-
-	_, err = r.client.Waypoint.WaypointServiceDeleteAddOnDefinition(params, nil)
+	_, err := r.client.Waypoint.WaypointServiceDeleteAddOnDefinition(params, nil)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			tflog.Info(ctx, "Add-on Definition not found for organization during delete call, ignoring")

--- a/internal/provider/waypoint/resource_waypoint_add_on_definition.go
+++ b/internal/provider/waypoint/resource_waypoint_add_on_definition.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -241,7 +241,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		}
 	}
 
-	var varOpts []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable
+	var varOpts []*waypoint_models.HashicorpCloudWaypointTFModuleVariable
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags := v.Options.ElementsAs(ctx, &strOpts, false)
@@ -250,7 +250,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -258,8 +258,8 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		})
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnDefinitionBody{
-		AddOnDefinition: &waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceCreateAddOnDefinitionBody{
+		AddOnDefinition: &waypoint_models.HashicorpCloudWaypointAddOnDefinition{
 			Name:            plan.Name.ValueString(),
 			Summary:         plan.Summary.ValueString(),
 			Description:     plan.Description.ValueString(),
@@ -288,7 +288,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 			// Set a default if none provided
 			workspaceDetails.TerraformProjectID = plan.TerraformProjectID
 		}
-		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      workspaceDetails.Name.ValueString(),
 			ProjectID: workspaceDetails.TerraformProjectID.ValueString(),
 		}
@@ -306,7 +306,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		modelBody.AddOnDefinition.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service_v2.WaypointServiceCreateAddOnDefinitionParams{
+	params := &waypoint_service.WaypointServiceCreateAddOnDefinitionParams{
 		NamespaceLocationOrganizationID: orgID,
 		NamespaceLocationProjectID:      projectID,
 		Body:                            modelBody,
@@ -317,7 +317,7 @@ func (r *AddOnDefinitionResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	var addOnDefinition *waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition
+	var addOnDefinition *waypoint_models.HashicorpCloudWaypointAddOnDefinition
 	if def.Payload != nil {
 		addOnDefinition = def.Payload.AddOnDefinition
 	}
@@ -505,7 +505,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		}
 	}
 
-	varOpts := []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{}
+	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags := v.Options.ElementsAs(ctx, &strOpts, false)
@@ -513,7 +513,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -522,8 +522,8 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// TODO: add support for Tags
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateAddOnDefinitionBody{
-		AddOnDefinition: &waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceUpdateAddOnDefinitionBody{
+		AddOnDefinition: &waypoint_models.HashicorpCloudWaypointAddOnDefinition{
 			Name:            plan.Name.ValueString(),
 			Summary:         plan.Summary.ValueString(),
 			Description:     plan.Description.ValueString(),
@@ -552,7 +552,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 			// Grab the top level project ID if this was not provided
 			workspaceDetails.TerraformProjectID = plan.TerraformProjectID
 		}
-		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+		modelBody.AddOnDefinition.TerraformCloudWorkspaceDetails = &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 			Name:      workspaceDetails.Name.ValueString(),
 			ProjectID: workspaceDetails.TerraformProjectID.ValueString(),
 		}
@@ -570,7 +570,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		modelBody.AddOnDefinition.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service_v2.WaypointServiceUpdateAddOnDefinitionParams{
+	params := &waypoint_service.WaypointServiceUpdateAddOnDefinitionParams{
 		NamespaceLocationOrganizationID: orgID,
 		NamespaceLocationProjectID:      projectID,
 		Body:                            modelBody,
@@ -582,7 +582,7 @@ func (r *AddOnDefinitionResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	var addOnDefinition *waypoint_models_v2.HashicorpCloudWaypointAddOnDefinition
+	var addOnDefinition *waypoint_models.HashicorpCloudWaypointAddOnDefinition
 	if def.Payload != nil {
 		addOnDefinition = def.Payload.AddOnDefinition
 	}
@@ -670,7 +670,7 @@ func (r *AddOnDefinitionResource) Delete(ctx context.Context, req resource.Delet
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceDeleteAddOnDefinitionParams{
+	params := &waypoint_service.WaypointServiceDeleteAddOnDefinitionParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		AddOnDefinitionID:               state.ID.ValueString(),

--- a/internal/provider/waypoint/resource_waypoint_application.go
+++ b/internal/provider/waypoint/resource_waypoint_application.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -283,7 +283,7 @@ func (r *ApplicationResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Prepare the input variables that the user provided to the application
 	// creation request
-	ivs := make([]*waypoint_models_v2.HashicorpCloudWaypointInputVariable, 0)
+	ivs := make([]*waypoint_models.HashicorpCloudWaypointInputVariable, 0)
 
 	var inputVarsSlice []InputVar
 	diags := plan.InputVars.ElementsAs(ctx, &inputVarsSlice, false)
@@ -293,7 +293,7 @@ func (r *ApplicationResource) Create(ctx context.Context, req resource.CreateReq
 	for _, v := range inputVarsSlice {
 		// add the input variable to the list of input variables for the app
 		// creation API call
-		ivs = append(ivs, &waypoint_models_v2.HashicorpCloudWaypointInputVariable{
+		ivs = append(ivs, &waypoint_models.HashicorpCloudWaypointInputVariable{
 			Name:         v.Name.ValueString(),
 			Value:        v.Value.ValueString(),
 			VariableType: v.VariableType.ValueString(),
@@ -305,28 +305,28 @@ func (r *ApplicationResource) Create(ctx context.Context, req resource.CreateReq
 
 	var (
 		actionIDs  []string
-		actionRefs []*waypoint_models_v2.HashicorpCloudWaypointActionCfgRef
+		actionRefs []*waypoint_models.HashicorpCloudWaypointActionCfgRef
 	)
 	diags = plan.Actions.ElementsAs(ctx, &actionIDs, false)
 	if diags.HasError() {
 		return
 	}
 	for _, n := range actionIDs {
-		actionRefs = append(actionRefs, &waypoint_models_v2.HashicorpCloudWaypointActionCfgRef{
+		actionRefs = append(actionRefs, &waypoint_models.HashicorpCloudWaypointActionCfgRef{
 			ID: n,
 		})
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationFromTemplateBody{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationFromTemplateBody{
 		Name:          plan.Name.ValueString(),
 		ActionCfgRefs: actionRefs,
-		ApplicationTemplate: &waypoint_models_v2.HashicorpCloudWaypointRefApplicationTemplate{
+		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointRefApplicationTemplate{
 			ID: plan.TemplateID.ValueString(),
 		},
 		Variables: ivs,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceCreateApplicationFromTemplateParams{
+	params := &waypoint_service.WaypointServiceCreateApplicationFromTemplateParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -337,7 +337,7 @@ func (r *ApplicationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	var application *waypoint_models_v2.HashicorpCloudWaypointApplication
+	var application *waypoint_models.HashicorpCloudWaypointApplication
 	if app.Payload != nil {
 		application = app.Payload.Application
 	}
@@ -553,7 +553,7 @@ func (r *ApplicationResource) Read(ctx context.Context, req resource.ReadRequest
 // template input variables are those that are set by the template or by HCP
 // Waypoint.
 func splitInputs(
-	inputVars []*waypoint_models_v2.HashicorpCloudWaypointInputVariable,
+	inputVars []*waypoint_models.HashicorpCloudWaypointInputVariable,
 	varTypes map[string]string,
 ) ([]*InputVar, []*InputVar) {
 	applicationInputVars := make([]*InputVar, 0)
@@ -633,21 +633,21 @@ func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateReq
 	if diags.HasError() {
 		return
 	}
-	var actionRefs []*waypoint_models_v2.HashicorpCloudWaypointActionCfgRef
+	var actionRefs []*waypoint_models.HashicorpCloudWaypointActionCfgRef
 	for _, n := range strActions {
-		actionRefs = append(actionRefs, &waypoint_models_v2.HashicorpCloudWaypointActionCfgRef{
+		actionRefs = append(actionRefs, &waypoint_models.HashicorpCloudWaypointActionCfgRef{
 			ID: n,
 		})
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateApplicationBody{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceUpdateApplicationBody{
 		// this is the updated name
 		Name:           plan.Name.ValueString(),
 		ReadmeMarkdown: readmeBytes,
 		ActionCfgRefs:  actionRefs,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceUpdateApplicationParams{
+	params := &waypoint_service.WaypointServiceUpdateApplicationParams{
 		ApplicationID:                   plan.ID.ValueString(),
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
@@ -659,7 +659,7 @@ func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	var application *waypoint_models_v2.HashicorpCloudWaypointApplication
+	var application *waypoint_models.HashicorpCloudWaypointApplication
 	if app.Payload != nil {
 		application = app.Payload.Application
 	}
@@ -737,7 +737,7 @@ func (r *ApplicationResource) Delete(ctx context.Context, req resource.DeleteReq
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceDestroyApplicationParams{
+	params := &waypoint_service.WaypointServiceDestroyApplicationParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		ApplicationID:                   data.ID.ValueString(),

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -277,23 +277,13 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
-
 	strLabels := []string{}
 	diags := plan.Labels.ElementsAs(ctx, &strLabels, false)
 	if diags.HasError() {
 		return
 	}
 
-	var varOpts []*waypoint_models.HashicorpCloudWaypointTFModuleVariable
+	var varOpts []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags = v.Options.ElementsAs(ctx, &strOpts, false)
@@ -301,7 +291,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -311,27 +301,27 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 
 	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.Name.ValueString()
-	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+	tfWsDetails := &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
 		ProjectID: tfProjID,
 	}
 
 	var (
 		actionIDs []string
-		actions   []*waypoint_models.HashicorpCloudWaypointActionCfgRef
+		actions   []*waypoint_models_v2.HashicorpCloudWaypointActionCfgRef
 	)
 	diags = plan.Actions.ElementsAs(ctx, &actionIDs, false)
 	if diags.HasError() {
 		return
 	}
 	for _, n := range actionIDs {
-		actions = append(actions, &waypoint_models.HashicorpCloudWaypointActionCfgRef{
+		actions = append(actions, &waypoint_models_v2.HashicorpCloudWaypointActionCfgRef{
 			ID: n,
 		})
 	}
 
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceCreateApplicationTemplateBody{
-		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointApplicationTemplate{
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationTemplateBody{
+		ApplicationTemplate: &waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate{
 			ActionCfgRefs:                  actions,
 			Name:                           plan.Name.ValueString(),
 			Summary:                        plan.Summary.ValueString(),
@@ -359,9 +349,10 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		modelBody.ApplicationTemplate.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service.WaypointServiceCreateApplicationTemplateParams{
-		NamespaceID: ns.ID,
-		Body:        modelBody,
+	params := &waypoint_service_v2.WaypointServiceCreateApplicationTemplateParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		Body:                            modelBody,
 	}
 	createTplResp, err := r.client.Waypoint.WaypointServiceCreateApplicationTemplate(params, nil)
 	if err != nil {
@@ -369,7 +360,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	var appTemplate *waypoint_models.HashicorpCloudWaypointApplicationTemplate
+	var appTemplate *waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate
 	if createTplResp.Payload != nil {
 		appTemplate = createTplResp.Payload.ApplicationTemplate
 	}
@@ -456,7 +447,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 
 func readVarOpts(
 	ctx context.Context,
-	v []*waypoint_models.HashicorpCloudWaypointTFModuleVariable,
+	v []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable,
 	d *diag.Diagnostics,
 ) ([]*tfcVariableOption, error) {
 	var varOpts []*tfcVariableOption
@@ -607,16 +598,6 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
-
 	strLabels := []string{}
 	diags := plan.Labels.ElementsAs(ctx, &strLabels, false)
 	if diags.HasError() {
@@ -628,14 +609,14 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	if diags.HasError() {
 		return
 	}
-	var actions []*waypoint_models.HashicorpCloudWaypointActionCfgRef
+	var actions []*waypoint_models_v2.HashicorpCloudWaypointActionCfgRef
 	for _, n := range strActions {
-		actions = append(actions, &waypoint_models.HashicorpCloudWaypointActionCfgRef{
+		actions = append(actions, &waypoint_models_v2.HashicorpCloudWaypointActionCfgRef{
 			ID: n,
 		})
 	}
 
-	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
+	varOpts := []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags = v.Options.ElementsAs(ctx, &strOpts, false)
@@ -643,7 +624,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -653,13 +634,13 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 
 	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.Name.ValueString()
-	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+	tfWsDetails := &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
 		ProjectID: tfProjID,
 	}
 
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceUpdateApplicationTemplateBody{
-		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointApplicationTemplate{
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateApplicationTemplateBody{
+		ApplicationTemplate: &waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate{
 			ActionCfgRefs:                  actions,
 			Name:                           plan.Name.ValueString(),
 			Summary:                        plan.Summary.ValueString(),
@@ -687,10 +668,11 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		modelBody.ApplicationTemplate.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service.WaypointServiceUpdateApplicationTemplateParams{
-		NamespaceID:                   ns.ID,
-		Body:                          modelBody,
-		ExistingApplicationTemplateID: plan.ID.ValueString(),
+	params := &waypoint_service_v2.WaypointServiceUpdateApplicationTemplateParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		Body:                            modelBody,
+		ExistingApplicationTemplateID:   plan.ID.ValueString(),
 	}
 	app, err := r.client.Waypoint.WaypointServiceUpdateApplicationTemplate(params, nil)
 	if err != nil {
@@ -698,7 +680,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	var appTemplate *waypoint_models.HashicorpCloudWaypointApplicationTemplate
+	var appTemplate *waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate
 	if app.Payload != nil {
 		appTemplate = app.Payload.ApplicationTemplate
 	}
@@ -795,22 +777,13 @@ func (r *TemplateResource) Delete(ctx context.Context, req resource.DeleteReques
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting TFC Config",
-			err.Error(),
-		)
-		return
+	params := &waypoint_service_v2.WaypointServiceDeleteApplicationTemplateParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		ApplicationTemplateID:           data.ID.ValueString(),
 	}
 
-	params := &waypoint_service.WaypointServiceDeleteApplicationTemplateParams{
-		NamespaceID:           ns.ID,
-		ApplicationTemplateID: data.ID.ValueString(),
-	}
-
-	_, err = r.client.Waypoint.WaypointServiceDeleteApplicationTemplate(params, nil)
+	_, err := r.client.Waypoint.WaypointServiceDeleteApplicationTemplate(params, nil)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			tflog.Info(ctx, "Template not found for organization during delete call, ignoring")

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -283,7 +283,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	var varOpts []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable
+	var varOpts []*waypoint_models.HashicorpCloudWaypointTFModuleVariable
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags = v.Options.ElementsAs(ctx, &strOpts, false)
@@ -291,7 +291,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -301,27 +301,27 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 
 	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.Name.ValueString()
-	tfWsDetails := &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
 		ProjectID: tfProjID,
 	}
 
 	var (
 		actionIDs []string
-		actions   []*waypoint_models_v2.HashicorpCloudWaypointActionCfgRef
+		actions   []*waypoint_models.HashicorpCloudWaypointActionCfgRef
 	)
 	diags = plan.Actions.ElementsAs(ctx, &actionIDs, false)
 	if diags.HasError() {
 		return
 	}
 	for _, n := range actionIDs {
-		actions = append(actions, &waypoint_models_v2.HashicorpCloudWaypointActionCfgRef{
+		actions = append(actions, &waypoint_models.HashicorpCloudWaypointActionCfgRef{
 			ID: n,
 		})
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationTemplateBody{
-		ApplicationTemplate: &waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceCreateApplicationTemplateBody{
+		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointApplicationTemplate{
 			ActionCfgRefs:                  actions,
 			Name:                           plan.Name.ValueString(),
 			Summary:                        plan.Summary.ValueString(),
@@ -349,7 +349,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		modelBody.ApplicationTemplate.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service_v2.WaypointServiceCreateApplicationTemplateParams{
+	params := &waypoint_service.WaypointServiceCreateApplicationTemplateParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -360,7 +360,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	var appTemplate *waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate
+	var appTemplate *waypoint_models.HashicorpCloudWaypointApplicationTemplate
 	if createTplResp.Payload != nil {
 		appTemplate = createTplResp.Payload.ApplicationTemplate
 	}
@@ -447,7 +447,7 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 
 func readVarOpts(
 	ctx context.Context,
-	v []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable,
+	v []*waypoint_models.HashicorpCloudWaypointTFModuleVariable,
 	d *diag.Diagnostics,
 ) ([]*tfcVariableOption, error) {
 	var varOpts []*tfcVariableOption
@@ -609,14 +609,14 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 	if diags.HasError() {
 		return
 	}
-	var actions []*waypoint_models_v2.HashicorpCloudWaypointActionCfgRef
+	var actions []*waypoint_models.HashicorpCloudWaypointActionCfgRef
 	for _, n := range strActions {
-		actions = append(actions, &waypoint_models_v2.HashicorpCloudWaypointActionCfgRef{
+		actions = append(actions, &waypoint_models.HashicorpCloudWaypointActionCfgRef{
 			ID: n,
 		})
 	}
 
-	varOpts := []*waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{}
+	varOpts := []*waypoint_models.HashicorpCloudWaypointTFModuleVariable{}
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
 		diags = v.Options.ElementsAs(ctx, &strOpts, false)
@@ -624,7 +624,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 
-		varOpts = append(varOpts, &waypoint_models_v2.HashicorpCloudWaypointTFModuleVariable{
+		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{
 			Name:         v.Name.ValueString(),
 			VariableType: v.VariableType.ValueString(),
 			Options:      strOpts,
@@ -634,13 +634,13 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 
 	tfProjID := plan.TerraformProjectID.ValueString()
 	tfWsName := plan.Name.ValueString()
-	tfWsDetails := &waypoint_models_v2.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
+	tfWsDetails := &waypoint_models.HashicorpCloudWaypointTerraformCloudWorkspaceDetails{
 		Name:      tfWsName,
 		ProjectID: tfProjID,
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateApplicationTemplateBody{
-		ApplicationTemplate: &waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceUpdateApplicationTemplateBody{
+		ApplicationTemplate: &waypoint_models.HashicorpCloudWaypointApplicationTemplate{
 			ActionCfgRefs:                  actions,
 			Name:                           plan.Name.ValueString(),
 			Summary:                        plan.Summary.ValueString(),
@@ -668,7 +668,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		modelBody.ApplicationTemplate.ReadmeMarkdownTemplate = readmeBytes
 	}
 
-	params := &waypoint_service_v2.WaypointServiceUpdateApplicationTemplateParams{
+	params := &waypoint_service.WaypointServiceUpdateApplicationTemplateParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -680,7 +680,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	var appTemplate *waypoint_models_v2.HashicorpCloudWaypointApplicationTemplate
+	var appTemplate *waypoint_models.HashicorpCloudWaypointApplicationTemplate
 	if app.Payload != nil {
 		appTemplate = app.Payload.ApplicationTemplate
 	}
@@ -777,7 +777,7 @@ func (r *TemplateResource) Delete(ctx context.Context, req resource.DeleteReques
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceDeleteApplicationTemplateParams{
+	params := &waypoint_service.WaypointServiceDeleteApplicationTemplateParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		ApplicationTemplateID:           data.ID.ValueString(),

--- a/internal/provider/waypoint/resource_waypoint_tfc_config.go
+++ b/internal/provider/waypoint/resource_waypoint_tfc_config.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
-	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/models"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -133,26 +133,17 @@ func (r *TfcConfigResource) Create(ctx context.Context, req resource.CreateReque
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating TFC Config",
-			err.Error(),
-		)
-		return
-	}
-
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceCreateTFCConfigBody{
-		TfcConfig: &waypoint_models.HashicorpCloudWaypointTFCConfig{
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateTFCConfigBody{
+		TfcConfig: &waypoint_models_v2.HashicorpCloudWaypointTFCConfig{
 			OrganizationName: plan.TfcOrgName.ValueString(),
 			Token:            plan.Token.ValueString(),
 		},
 	}
 
-	params := &waypoint_service.WaypointServiceCreateTFCConfigParams{
-		NamespaceID: ns.ID,
-		Body:        modelBody,
+	params := &waypoint_service_v2.WaypointServiceCreateTFCConfigParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		Body:                            modelBody,
 	}
 
 	config, err := r.client.Waypoint.WaypointServiceCreateTFCConfig(params, nil)
@@ -197,18 +188,9 @@ func (r *TfcConfigResource) Read(ctx context.Context, req resource.ReadRequest, 
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"error getting namespace by location",
-			err.Error(),
-		)
-		return
-	}
-
-	params := &waypoint_service.WaypointServiceGetTFCConfigParams{
-		NamespaceID: ns.ID,
+	params := &waypoint_service_v2.WaypointServiceGetTFCConfigParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 	config, err := r.client.Waypoint.WaypointServiceGetTFCConfig(params, nil)
 	if err != nil {
@@ -257,26 +239,17 @@ func (r *TfcConfigResource) Update(ctx context.Context, req resource.UpdateReque
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error updating TFC Config",
-			err.Error(),
-		)
-		return
-	}
-
-	modelBody := &waypoint_models.HashicorpCloudWaypointWaypointServiceUpdateTFCConfigBody{
-		TfcConfig: &waypoint_models.HashicorpCloudWaypointTFCConfig{
+	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateTFCConfigBody{
+		TfcConfig: &waypoint_models_v2.HashicorpCloudWaypointTFCConfig{
 			OrganizationName: plan.TfcOrgName.ValueString(),
 			Token:            plan.Token.ValueString(),
 		},
 	}
 
-	params := &waypoint_service.WaypointServiceUpdateTFCConfigParams{
-		NamespaceID: ns.ID,
-		Body:        modelBody,
+	params := &waypoint_service_v2.WaypointServiceUpdateTFCConfigParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
+		Body:                            modelBody,
 	}
 
 	config, err := r.client.Waypoint.WaypointServiceUpdateTFCConfig(params, nil)
@@ -320,21 +293,12 @@ func (r *TfcConfigResource) Delete(ctx context.Context, req resource.DeleteReque
 		ProjectID:      projectID,
 	}
 
-	client := r.client
-	ns, err := getNamespaceByLocation(ctx, client, loc)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting TFC Config",
-			err.Error(),
-		)
-		return
+	params := &waypoint_service_v2.WaypointServiceDeleteTFCConfigParams{
+		NamespaceLocationOrganizationID: loc.OrganizationID,
+		NamespaceLocationProjectID:      loc.ProjectID,
 	}
 
-	params := &waypoint_service.WaypointServiceDeleteTFCConfigParams{
-		NamespaceID: ns.ID,
-	}
-
-	_, err = r.client.Waypoint.WaypointServiceDeleteTFCConfig(params, nil)
+	_, err := r.client.Waypoint.WaypointServiceDeleteTFCConfig(params, nil)
 	if err != nil {
 		if clients.IsResponseCodeNotFound(err) {
 			tflog.Info(ctx, "TFC Config not found for organization during delete call, ignoring")
@@ -350,9 +314,9 @@ func (r *TfcConfigResource) Delete(ctx context.Context, req resource.DeleteReque
 
 // getNamespaceByLocation will retrieve a namespace by location information
 // provided by HCP
-func getNamespaceByLocation(_ context.Context, client *clients.Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models.HashicorpCloudWaypointNamespace, error) {
+func getNamespaceByLocation(_ context.Context, client *clients.Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models_v2.HashicorpCloudWaypointNamespace, error) {
 	// TODO:(clint) consolidate this either in the wrapper or something
-	namespaceParams := &waypoint_service.WaypointServiceGetNamespaceParams{
+	namespaceParams := &waypoint_service_v2.WaypointServiceGetNamespaceParams{
 		LocationOrganizationID: loc.OrganizationID,
 		LocationProjectID:      loc.ProjectID,
 	}

--- a/internal/provider/waypoint/resource_waypoint_tfc_config.go
+++ b/internal/provider/waypoint/resource_waypoint_tfc_config.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
-	waypoint_models_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	waypoint_models "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/models"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -133,14 +133,14 @@ func (r *TfcConfigResource) Create(ctx context.Context, req resource.CreateReque
 		ProjectID:      projectID,
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceCreateTFCConfigBody{
-		TfcConfig: &waypoint_models_v2.HashicorpCloudWaypointTFCConfig{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceCreateTFCConfigBody{
+		TfcConfig: &waypoint_models.HashicorpCloudWaypointTFCConfig{
 			OrganizationName: plan.TfcOrgName.ValueString(),
 			Token:            plan.Token.ValueString(),
 		},
 	}
 
-	params := &waypoint_service_v2.WaypointServiceCreateTFCConfigParams{
+	params := &waypoint_service.WaypointServiceCreateTFCConfigParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -188,7 +188,7 @@ func (r *TfcConfigResource) Read(ctx context.Context, req resource.ReadRequest, 
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceGetTFCConfigParams{
+	params := &waypoint_service.WaypointServiceGetTFCConfigParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 	}
@@ -239,14 +239,14 @@ func (r *TfcConfigResource) Update(ctx context.Context, req resource.UpdateReque
 		ProjectID:      projectID,
 	}
 
-	modelBody := &waypoint_models_v2.HashicorpCloudWaypointV20241122WaypointServiceUpdateTFCConfigBody{
-		TfcConfig: &waypoint_models_v2.HashicorpCloudWaypointTFCConfig{
+	modelBody := &waypoint_models.HashicorpCloudWaypointV20241122WaypointServiceUpdateTFCConfigBody{
+		TfcConfig: &waypoint_models.HashicorpCloudWaypointTFCConfig{
 			OrganizationName: plan.TfcOrgName.ValueString(),
 			Token:            plan.Token.ValueString(),
 		},
 	}
 
-	params := &waypoint_service_v2.WaypointServiceUpdateTFCConfigParams{
+	params := &waypoint_service.WaypointServiceUpdateTFCConfigParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 		Body:                            modelBody,
@@ -293,7 +293,7 @@ func (r *TfcConfigResource) Delete(ctx context.Context, req resource.DeleteReque
 		ProjectID:      projectID,
 	}
 
-	params := &waypoint_service_v2.WaypointServiceDeleteTFCConfigParams{
+	params := &waypoint_service.WaypointServiceDeleteTFCConfigParams{
 		NamespaceLocationOrganizationID: loc.OrganizationID,
 		NamespaceLocationProjectID:      loc.ProjectID,
 	}
@@ -314,9 +314,9 @@ func (r *TfcConfigResource) Delete(ctx context.Context, req resource.DeleteReque
 
 // getNamespaceByLocation will retrieve a namespace by location information
 // provided by HCP
-func getNamespaceByLocation(_ context.Context, client *clients.Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models_v2.HashicorpCloudWaypointNamespace, error) {
+func getNamespaceByLocation(_ context.Context, client *clients.Client, loc *sharedmodels.HashicorpCloudLocationLocation) (*waypoint_models.HashicorpCloudWaypointNamespace, error) {
 	// TODO:(clint) consolidate this either in the wrapper or something
-	namespaceParams := &waypoint_service_v2.WaypointServiceGetNamespaceParams{
+	namespaceParams := &waypoint_service.WaypointServiceGetNamespaceParams{
 		LocationOrganizationID: loc.OrganizationID,
 		LocationProjectID:      loc.ProjectID,
 	}

--- a/internal/provider/waypoint/resource_waypoint_tfc_config_test.go
+++ b/internal/provider/waypoint/resource_waypoint_tfc_config_test.go
@@ -10,8 +10,7 @@ import (
 	"testing"
 	"time"
 
-	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2023-08-18/client/waypoint_service"
+	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -66,26 +65,10 @@ func testAccCheckWaypointTfcConfigExists(t *testing.T, resourceName string, tfcC
 		orgID := client.Config.OrganizationID
 		tfcConfig.ProjectID = types.StringValue(projectID)
 
-		loc := &sharedmodels.HashicorpCloudLocationLocation{
-			OrganizationID: orgID,
-			ProjectID:      projectID,
-		}
-
 		// Fetch the project
-
-		namespaceParams := &waypoint_service.WaypointServiceGetNamespaceParams{
-			LocationOrganizationID: loc.OrganizationID,
-			LocationProjectID:      loc.ProjectID,
-		}
-		// get namespace
-		ns, err := client.Waypoint.WaypointServiceGetNamespace(namespaceParams, nil)
-		if err != nil {
-			return err
-		}
-
-		namespace := ns.GetPayload().Namespace
-		params := &waypoint_service.WaypointServiceGetTFCConfigParams{
-			NamespaceID: namespace.ID,
+		params := &waypoint_service_v2.WaypointServiceGetTFCConfigParams{
+			NamespaceLocationOrganizationID: projectID,
+			NamespaceLocationProjectID:      orgID,
 		}
 		config, err := client.Waypoint.WaypointServiceGetTFCConfig(params, nil)
 		if err != nil {
@@ -104,19 +87,9 @@ func testAccCheckWaypointTfcConfigDestroy(t *testing.T, tfcConfig *waypoint.TfcC
 		projectID := tfcConfig.ProjectID.ValueString()
 		orgID := client.Config.OrganizationID
 
-		namespaceParams := &waypoint_service.WaypointServiceGetNamespaceParams{
-			LocationOrganizationID: orgID,
-			LocationProjectID:      projectID,
-		}
-		// get namespace
-		ns, err := client.Waypoint.WaypointServiceGetNamespace(namespaceParams, nil)
-		if err != nil {
-			return err
-		}
-
-		namespace := ns.GetPayload().Namespace
-		params := &waypoint_service.WaypointServiceGetTFCConfigParams{
-			NamespaceID: namespace.ID,
+		params := &waypoint_service_v2.WaypointServiceGetTFCConfigParams{
+			NamespaceLocationOrganizationID: orgID,
+			NamespaceLocationProjectID:      projectID,
 		}
 
 		// Fetch the config

--- a/internal/provider/waypoint/resource_waypoint_tfc_config_test.go
+++ b/internal/provider/waypoint/resource_waypoint_tfc_config_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	waypoint_service_v2 "github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-waypoint-service/preview/2024-11-22/client/waypoint_service"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -66,7 +66,7 @@ func testAccCheckWaypointTfcConfigExists(t *testing.T, resourceName string, tfcC
 		tfcConfig.ProjectID = types.StringValue(projectID)
 
 		// Fetch the project
-		params := &waypoint_service_v2.WaypointServiceGetTFCConfigParams{
+		params := &waypoint_service.WaypointServiceGetTFCConfigParams{
 			NamespaceLocationOrganizationID: projectID,
 			NamespaceLocationProjectID:      orgID,
 		}
@@ -87,7 +87,7 @@ func testAccCheckWaypointTfcConfigDestroy(t *testing.T, tfcConfig *waypoint.TfcC
 		projectID := tfcConfig.ProjectID.ValueString()
 		orgID := client.Config.OrganizationID
 
-		params := &waypoint_service_v2.WaypointServiceGetTFCConfigParams{
+		params := &waypoint_service.WaypointServiceGetTFCConfigParams{
 			NamespaceLocationOrganizationID: orgID,
 			NamespaceLocationProjectID:      projectID,
 		}


### PR DESCRIPTION
### :hammer_and_wrench: Description

Waypoint API calls are now all made to the new 20241122 version of the API. 

In addition, the CreatedBy resource is now marked as deprecated so that it can be completely removed in a future update to the Waypoint provider.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Output from acceptance testing:

```sh
$ make testacc TESTARGS='-run=TestAccWaypoint'

=== RUN   TestAccWaypointData_Add_On_Definition_basic
--- PASS: TestAccWaypointData_Add_On_Definition_basic (19.93s)
=== RUN   TestAccWaypointData_Add_On_basic
--- PASS: TestAccWaypointData_Add_On_basic (22.11s)
=== RUN   TestAccWaypoint_AddOn_DataSource_WithInputVars
--- PASS: TestAccWaypoint_AddOn_DataSource_WithInputVars (22.78s)
=== RUN   TestAccWaypoint_Application_DataSource_basic
--- PASS: TestAccWaypoint_Application_DataSource_basic (19.26s)
=== RUN   TestAccWaypoint_Application_DataSource_WithInputVars
--- PASS: TestAccWaypoint_Application_DataSource_WithInputVars (17.72s)
=== RUN   TestAccWaypointData_Template_basic
--- PASS: TestAccWaypointData_Template_basic (16.67s)
=== RUN   TestAccWaypointData_template_with_variable_options
--- PASS: TestAccWaypointData_template_with_variable_options (11.84s)
=== RUN   TestAccWaypoint_Action_basic
    resource_waypoint_action_test.go:25: Waypoint Action tests skipped unless env 'HCP_WAYP_ACTION_TEST' set
--- SKIP: TestAccWaypoint_Action_basic (0.00s)
=== RUN   TestAccWaypoint_Add_On_Definition_basic
--- PASS: TestAccWaypoint_Add_On_Definition_basic (13.64s)
=== RUN   TestAccWaypoint_Add_On_basic
--- PASS: TestAccWaypoint_Add_On_basic (13.58s)
=== RUN   TestAccWaypoint_AddOnInputVariables
--- PASS: TestAccWaypoint_AddOnInputVariables (13.01s)
=== RUN   TestAccWaypoint_AddOnInputVariables_OnDefinition
--- PASS: TestAccWaypoint_AddOnInputVariables_OnDefinition (14.23s)
=== RUN   TestAccWaypoint_Application_basic
--- PASS: TestAccWaypoint_Application_basic (10.20s)
=== RUN   TestAccWaypoint_ApplicationInputVariables
--- PASS: TestAccWaypoint_ApplicationInputVariables (11.33s)
=== RUN   TestAccWaypoint_ApplicationInputVariables_OnTemplate
--- PASS: TestAccWaypoint_ApplicationInputVariables_OnTemplate (10.87s)
=== RUN   TestAccWaypoint_Template_basic
--- PASS: TestAccWaypoint_Template_basic (14.42s)
=== RUN   TestAccWaypoint_template_with_variable_options
--- PASS: TestAccWaypoint_template_with_variable_options (8.73s)
...
```
