### PR TITLE
Waypoint/Actions: Add way to assign actions to templates and apps

### DIFF
--- a/.changelog/1213.txt
+++ b/.changelog/1213.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add way to assign actions to a Waypoint template or application on create or update.
+```

--- a/docs/data-sources/waypoint_template.md
+++ b/docs/data-sources/waypoint_template.md
@@ -23,6 +23,7 @@ data "hcp_waypoint_template" "example" {
 
 ### Optional
 
+- `actions` (List of String) List of actions by 'name' to assign to this Template.
 - `id` (String) The ID of the Template.
 - `name` (String) The name of the Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -55,6 +55,7 @@ EOF
 
 ### Optional
 
+- `actions` (List of String) List of actions by 'name' to assign to this Template. Applications created from this template will have these actions assigned to them.
 - `description` (String) A description of the template, along with when and why it should be used, up to 500 characters
 - `labels` (List of String) List of labels attached to this Template.
 - `project_id` (String) The ID of the HCP project where the Waypoint Template is located.

--- a/internal/provider/waypoint/data_source_waypoint_template.go
+++ b/internal/provider/waypoint/data_source_waypoint_template.go
@@ -43,6 +43,7 @@ type DataSourceTemplateModel struct {
 	Labels                 types.List   `tfsdk:"labels"`
 	Description            types.String `tfsdk:"description"`
 	ReadmeMarkdownTemplate types.String `tfsdk:"readme_markdown_template"`
+	Actions                types.List   `tfsdk:"actions"`
 
 	TerraformCloudWorkspace     *tfcWorkspace        `tfsdk:"terraform_cloud_workspace_details"`
 	TerraformNoCodeModuleSource types.String         `tfsdk:"terraform_no_code_module_source"`
@@ -94,6 +95,11 @@ func (d *DataSourceTemplate) Schema(ctx context.Context, req datasource.SchemaRe
 			"readme_markdown_template": schema.StringAttribute{
 				Computed:    true,
 				Description: "Instructions for using the template (markdown format supported)",
+			},
+			"actions": schema.ListAttribute{
+				Optional:    true,
+				Description: "List of actions by 'name' to assign to this Template.",
+				ElementType: types.StringType,
 			},
 			"labels": schema.ListAttribute{
 				Computed:    true,
@@ -241,6 +247,16 @@ func (d *DataSourceTemplate) Read(ctx context.Context, req datasource.ReadReques
 		labels = types.ListNull(types.StringType)
 	}
 	data.Labels = labels
+
+	actions, diags := types.ListValueFrom(ctx, types.StringType, appTemplate.ActionCfgRefs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(actions.Elements()) == 0 {
+		actions = types.ListNull(types.StringType)
+	}
+	data.Actions = actions
 
 	// set data.description if it's not null or appTemplate.description is not
 	// empty

--- a/internal/provider/waypoint/resource_waypoint_action_test.go
+++ b/internal/provider/waypoint/resource_waypoint_action_test.go
@@ -92,6 +92,8 @@ func testAccCheckWaypointActionExists(t *testing.T, resourceName string, actionC
 			actionCfgModel.ID = types.StringValue(actionCfg.ID)
 		}
 
+		t.Logf("actionID: %s, actionName: %s", actionCfg.ID, actionCfg.Name)
+
 		return nil
 	}
 }

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -55,6 +55,58 @@ func TestAcc_Waypoint_Template_basic(t *testing.T) {
 	})
 }
 
+// A test that ensures a template can be assigned with an action, and that
+// action gets created prior to the terraform resource. Creating a template
+// resource will fail if that action does not exist.
+func TestAcc_Waypoint_Create_Template_with_actions(t *testing.T) {
+	// t.Parallel()
+
+	// t.Skip("Skipping this test until we can figure out why it's failing")
+
+	var (
+		appTemplateModel waypoint.TemplateResourceModel
+		actionCfgModel   waypoint.ActionResourceModel
+	)
+	resourceName := "hcp_waypoint_template.actions_template_test"
+	actionResourceName := "hcp_waypoint_action.test"
+	name := generateRandomName()
+	actionName := generateRandomName()
+
+	templateResourceStr := testTemplateWithActionsConfig(name, actionName)
+
+	// Log names
+	t.Logf("Template Name: %s", name)
+	t.Logf("Action Name: %s", actionName)
+	t.Logf("Template with Action resource:\n%s", templateResourceStr)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			if err := testAccCheckWaypointTemplateDestroy(t, &appTemplateModel)(s); err != nil {
+				return err
+			}
+			if err := testAccCheckWaypointActionDestroy(t, &actionCfgModel)(s); err != nil {
+				return err
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testTemplateWithActionsConfig(name, actionName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWaypointTemplateExists(t, resourceName, &appTemplateModel),
+					testAccCheckWaypointTemplateName(t, &appTemplateModel, name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					testAccCheckWaypointActionExists(t, actionResourceName, &actionCfgModel),
+					testAccCheckWaypointActionName(t, &actionCfgModel, actionName),
+					resource.TestCheckResourceAttr(actionResourceName, "name", actionName),
+				),
+			},
+		},
+	})
+}
+
 func TestAcc_Waypoint_template_with_variable_options(t *testing.T) {
 	t.Parallel()
 
@@ -173,6 +225,46 @@ resource "hcp_waypoint_template" "test" {
   labels = ["one", "two"]
   terraform_execution_mode = "remote"
 }`, name)
+}
+
+// TODO(briancain): We can merge this with the other template function
+// and conditionally add the actions field if needed.
+func testTemplateWithActionsConfig(
+	templateName string,
+	actionName string,
+) string {
+	return fmt.Sprintf(`
+resource "hcp_waypoint_action" "test" {
+	name = "%[2]s"
+	description = "Test action"
+	request = {
+	    custom = {
+			method = "GET"
+			url = "https://example.com"
+			headers = {
+				Test-Header = "test"
+			}
+			body = "test"
+		}
+	}
+}
+
+resource "hcp_waypoint_template" "actions_template_test" {
+  name                     = "%[1]s"
+  summary                  = "some summary for fun"
+  readme_markdown_template = base64encode("# Some Readme")
+  terraform_no_code_module_source = "private/waypoint-tfc-testing/waypoint-template-starter/null"
+  terraform_no_code_module_id = "nocode-7ZQjQoaPXvzs6Hvp"
+  terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  terraform_cloud_workspace_details = {
+    name                 = "Default Project"
+    terraform_project_id = "prj-gfVyPJ2q2Aurn25o"
+  }
+  labels = ["one", "two"]
+  terraform_execution_mode = "remote"
+
+  actions = [hcp_waypoint_action.test.id]
+}`, templateName, actionName)
 }
 
 func testTemplateConfigWithVarOpts(name string) string {


### PR DESCRIPTION
### :hammer_and_wrench: Description

This commit introduces a way for the provider to assign actions automatically when creating or updating templates and applications.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

Fixes WAYP-3280