### PR TITLE
Add stale PR workflow

### DIFF
--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *" # end of every day
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      with:
+        ascending: true
+        operations-per-run: 100
+        days-before-stale: 15
+        days-before-close: 7
+        stale-pr-message: "This PR is more than 2 weeks old. Please remove the
+          stale label, update, or comment if this PR is still valid and
+          relevant, otherwise it will be closed in 7 days."


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Add stale PR workflow

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
