### PR TITLE
docs: streaming to splunk cloud free trials not supported

### DIFF
--- a/docs/resources/log_streaming_destination.md
+++ b/docs/resources/log_streaming_destination.md
@@ -100,5 +100,5 @@ Optional:
 
 Required:
 
-- `endpoint` (String) The Splunk Cloud endpoint to send logs to.
+- `endpoint` (String) The Splunk Cloud endpoint to send logs to. Streaming to free trial instances is not supported.
 - `token` (String, Sensitive) The authentication token that will be used by the platform to access Splunk Cloud.

--- a/internal/provider/logstreaming/resource_hcp_log_streaming_destination.go
+++ b/internal/provider/logstreaming/resource_hcp_log_streaming_destination.go
@@ -67,7 +67,7 @@ func (r *resourceHCPLogStreamingDestination) Schema(_ context.Context, _ resourc
 			"splunk_cloud": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"endpoint": schema.StringAttribute{
-						Description: "The Splunk Cloud endpoint to send logs to.",
+						Description: "The Splunk Cloud endpoint to send logs to. Streaming to free trial instances is not supported.",
 						Required:    true,
 					},
 					"token": schema.StringAttribute{


### PR DESCRIPTION
### :hammer_and_wrench: Description

Documents a `log_streaming_destination` resource limitation, streaming to splunk cloud free trial instances is not supported. 