### PR TITLE
Do not call ElementAs when parsing `tfe_waypoint_template.variable_options.options`

### DIFF
--- a/.changelog/1241.txt
+++ b/.changelog/1241.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a bug when `tfe_waypoint_template.variable_options` did not specify `options` list.
+```

--- a/internal/provider/waypoint/resource_waypoint_template.go
+++ b/internal/provider/waypoint/resource_waypoint_template.go
@@ -286,9 +286,11 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	var varOpts []*waypoint_models.HashicorpCloudWaypointTFModuleVariable
 	for _, v := range plan.TerraformVariableOptions {
 		strOpts := []string{}
-		diags = v.Options.ElementsAs(ctx, &strOpts, false)
-		if diags.HasError() {
-			return
+		if len(v.Options.Elements()) != 0 {
+			diags = v.Options.ElementsAs(ctx, &strOpts, false)
+			if diags.HasError() {
+				return
+			}
 		}
 
 		varOpts = append(varOpts, &waypoint_models.HashicorpCloudWaypointTFModuleVariable{

--- a/internal/provider/waypoint/resource_waypoint_template_test.go
+++ b/internal/provider/waypoint/resource_waypoint_template_test.go
@@ -285,13 +285,6 @@ resource "hcp_waypoint_template" "var_opts_test" {
       name          = "faction"
       variable_type = "string"
       user_editable = true
-      options       = [
-        "ncr",
-        "brotherhood-of-steel",
-        "caesars-legion",
-        "raiders",
-        "institute"
-      ]
     }
   ]
 }`, name)


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Closes: #1240 

Instead of adding a new test I just modified the existing test to validate setting no `options` works. I'm not able to run acc tests without access to your env.

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
See explanation above
...
```

Some lint checks fail but not related to my files:
```shell
make fmtcheck
==> Checking that code complies with gofmt requirements...
golangci-lint run --config ./golangci-config.yml 
internal/clients/iampolicy/resource_iam_binding.go:107:5: S1009: should omit nil check; len() for nil maps is defined as zero (gosimple)
	if resp.Schema.Attributes == nil || len(resp.Schema.Attributes) == 0 {
	   ^
internal/clients/iampolicy/resource_iam_policy.go:114:5: S1009: should omit nil check; len() for nil maps is defined as zero (gosimple)
	if resp.Schema.Attributes == nil || len(resp.Schema.Attributes) == 0 {
	   ^
internal/provider/packer/testutils/testclient/operation.go:48:11: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			return fmt.Errorf(msg)
			       ^
internal/provider/packer/testutils/testclient/operation.go:51:11: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			return fmt.Errorf(msg)
			       ^
internal/providersdkv2/test_helpers_for_packer_test.go:113:11: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			return fmt.Errorf(msg)
```
