### PR TITLE
Increase project delete timeout

### DIFF
--- a/.changelog/1246.txt
+++ b/.changelog/1246.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Increase project deletion timeout
+```

--- a/internal/provider/resourcemanager/resource_project.go
+++ b/internal/provider/resourcemanager/resource_project.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	billing "github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/preview/2020-11-05/client/billing_account_service"
 	billingModels "github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/preview/2020-11-05/models"
@@ -255,6 +256,9 @@ func (r *resourceProject) Delete(ctx context.Context, req resource.DeleteRequest
 
 	getParams := project_service.NewProjectServiceDeleteParams()
 	getParams.ID = state.ResourceID.ValueString()
+	// Increasing this timeout to account for long syncing times of projects to TFC
+	// This can be removed once client-side blocking is implemented
+	getParams.WithTimeout(45 * time.Second)
 	_, err := r.client.Project.ProjectServiceDelete(getParams, nil)
 	if err != nil {
 		var deleteErr *project_service.ProjectServiceDeleteDefault


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->
As per [this ticket](https://hashicorp.atlassian.net/browse/HCPF-2881), we're increasing the timeout on project deletion to allow for a little more wiggle room with this operation as it relies on TFC syncing in the background and in our testing, we have observed that this particular endpoint has been problematic. See the linked Jira ticket for some testing that I did which show the improvement here.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality? No
- [ ] Have you added an acceptance test for the functionality being added? No
- [ ] Have you run the acceptance tests on this branch? I have not.

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
