### PR TITLE
docs: waypoint actions in beta update

### DIFF
--- a/docs/data-sources/waypoint_action.md
+++ b/docs/data-sources/waypoint_action.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_action `Data Source`
 
--> **Note:** HCP Waypoint is currently in public beta.
+-> **Note:** HCP Waypoint actions is currently in beta.
 
 The Waypoint Action data source retrieves information on a given Action.
 

--- a/docs/data-sources/waypoint_add_on.md
+++ b/docs/data-sources/waypoint_add_on.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_add_on `Data Source`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 The Waypoint Add-on data source retrieves information on a given Add-on.
 

--- a/docs/data-sources/waypoint_add_on_definition.md
+++ b/docs/data-sources/waypoint_add_on_definition.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_add_on_definition `Data Source`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 The Waypoint Add-on Definition data source retrieves information on a given Add-on Definition.
 

--- a/docs/data-sources/waypoint_application.md
+++ b/docs/data-sources/waypoint_application.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_application `Data Source`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 The Waypoint Application data source retrieves information on a given Application.
 

--- a/docs/data-sources/waypoint_template.md
+++ b/docs/data-sources/waypoint_template.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_template `Data Source`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 The Waypoint Template data source retrieves information on a given Template.
 

--- a/docs/resources/waypoint_action.md
+++ b/docs/resources/waypoint_action.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_action `Resource`
 
--> **Note:** HCP Waypoint is currently in public beta.
+-> **Note:** HCP Waypoint actions is currently in beta.
 
 The Waypoint Action resource manages the lifecycle of an Action.
 

--- a/docs/resources/waypoint_add_on.md
+++ b/docs/resources/waypoint_add_on.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_add_on `Resource`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 Waypoint Add-on resource
 

--- a/docs/resources/waypoint_add_on_definition.md
+++ b/docs/resources/waypoint_add_on_definition.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_add_on_definition `Resource`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 Waypoint Add-on Definition resource
 

--- a/docs/resources/waypoint_application.md
+++ b/docs/resources/waypoint_application.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_application `Resource`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 The Waypoint Application resource managed the lifecycle of an Application that's based off of a Template.
 

--- a/docs/resources/waypoint_template.md
+++ b/docs/resources/waypoint_template.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_template `Resource`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 Waypoint Template resource
 

--- a/docs/resources/waypoint_tfc_config.md
+++ b/docs/resources/waypoint_tfc_config.md
@@ -7,7 +7,7 @@ description: |-
 
 # hcp_waypoint_tfc_config `Resource`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 TFC Configuration used by Waypoint to administer TFC workspaces and applications.
 

--- a/templates/data-sources/waypoint_action.md.tmpl
+++ b/templates/data-sources/waypoint_action.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+-> **Note:** HCP Waypoint actions is currently in beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/waypoint_add_on.md.tmpl
+++ b/templates/data-sources/waypoint_add_on.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/waypoint_add_on_definition.md.tmpl
+++ b/templates/data-sources/waypoint_add_on_definition.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/waypoint_application.md.tmpl
+++ b/templates/data-sources/waypoint_application.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/data-sources/waypoint_template.md.tmpl
+++ b/templates/data-sources/waypoint_template.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/waypoint_action.md.tmpl
+++ b/templates/resources/waypoint_action.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+-> **Note:** HCP Waypoint actions is currently in beta.
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/waypoint_add_on.md.tmpl
+++ b/templates/resources/waypoint_add_on.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/waypoint_add_on_definition.md.tmpl
+++ b/templates/resources/waypoint_add_on_definition.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/waypoint_application.md.tmpl
+++ b/templates/resources/waypoint_application.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/waypoint_template.md.tmpl
+++ b/templates/resources/waypoint_template.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 

--- a/templates/resources/waypoint_tfc_config.md.tmpl
+++ b/templates/resources/waypoint_tfc_config.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # {{.Name}} `{{.Type}}`
 
--> **Note:** HCP Waypoint is currently in public beta.
+
 
 {{ .Description | trimspace }}
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

# Description

- Updated templates and docs to remove the note `-> **Note:** HCP Waypoint is currently in public beta.`.
- Updated the waypoint actions docs to specify that actions is currently in beta.


