### PR TITLE
Add unique name for azurerm_role_definition in Azure HVN invalid config test

### DIFF
--- a/.changelog/1269.txt
+++ b/.changelog/1269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed Platform Acceptance test failure by making `azurerm_role_definition.name` unique. 
+```

--- a/internal/providersdkv2/resource_hvn_route_test.go
+++ b/internal/providersdkv2/resource_hvn_route_test.go
@@ -495,17 +495,17 @@ func testHvnRouteGateway(t *testing.T, adConfig string) {
 // Test Azure Route with invalid config
 func TestAcc_Platform_HvnRouteAzureInvalidConfig(t *testing.T) {
 	t.Parallel()
-
-	testHvnRouteInvalidConfig(t, hvnRouteAzureAdConfig("fail"))
+	hvnRouteUniqueName := testAccUniqueNameWithPrefix("p-az-invalid")
+	testHvnRouteInvalidConfig(t, hvnRouteUniqueName, hvnRouteAzureAdConfig(hvnRouteUniqueName))
 }
 
 func TestAccHvnRouteAzureInvalidConfigInternal(t *testing.T) {
 	t.Skip("Internal test should not be run on CI.")
 
-	testHvnRouteInvalidConfig(t, "") // No AD SP; create manually via Doormat
+	testHvnRouteInvalidConfig(t, "", "") // No AD SP; create manually via Doormat
 }
 
-func testHvnRouteInvalidConfig(t *testing.T, adConfig string) {
+func testHvnRouteInvalidConfig(t *testing.T, hvnRouteUniqueName string, adConfig string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t, map[string]bool{"aws": false, "azure": true}) },
 		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
@@ -517,7 +517,7 @@ func testHvnRouteInvalidConfig(t *testing.T, adConfig string) {
 		Steps: []resource.TestStep{
 			// Testing invalid azure_config based on next_hop_type value
 			{
-				Config:      testConfig(testAccHvnRouteConfigAzure("fail", azConfigInvalidNextHopType, adConfig)),
+				Config:      testConfig(testAccHvnRouteConfigAzure(hvnRouteUniqueName, azConfigInvalidNextHopType, adConfig)),
 				ExpectError: regexp.MustCompile(`azure configuration is invalid: Next hop IP addresses are only allowed in routes where next hop type is VIRTUAL_APPLIANCE`),
 			},
 		},


### PR DESCRIPTION
As a part of [#inc-4707](https://hashicorp.enterprise.slack.com/archives/C08PZKCRXHB) , We had to delete some lingering HVNs and fix `TestAcc_Platform_HvnRouteAzureInvalidConfig` specific case for testing invalid Azure configuration for an HVN route produces the expected error. 

The [prerelease run](https://github.com/hashicorp/terraform-provider-hcp/actions/runs/14727461991/job/41333483204) due to 

`    resource_hvn_route_test.go:509: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1
        
        Error: A resource with the ID "/subscriptions/***/resourceGroups/fail" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_resource_group" for more information.
        
          with azurerm_resource_group.rg,
          on terraform_plugin_test.tf line 69, in resource "azurerm_resource_group" "rg":
          69: 	resource "azurerm_resource_group" "rg" {
`

This was due to duplication of `fail` resourceGroup. When we checked the subscription, we were not able to identify such groups. So, we decided to introduce unique name for `azurerm_role_definition` in every runs.  We are using `testAccUniqueNameWithPrefix` for generating a unique name.


<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
