### PR TITLE
Update hcp-sdk-go version

### DIFF
--- a/.changelog/1270.txt
+++ b/.changelog/1270.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+update hcp-sdk-go
+```

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.141.0
+	github.com/hashicorp/hcp-sdk-go v0.142.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/hashicorp/hc-install v0.9.1 h1:gkqTfE3vVbafGQo6VZXcy2v5yoz2bE0+nhZXru
 github.com/hashicorp/hc-install v0.9.1/go.mod h1:pWWvN/IrfeBK4XPeXXYkL6EjMufHkCK5DvwxeLKuBf0=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.141.0 h1:5bRZa54gI4KYWceKWcZJwhy8ZV32ZdqUDLUa6ftUWBQ=
-github.com/hashicorp/hcp-sdk-go v0.141.0/go.mod h1:ZxsZZjErm3E2sj2OjDeVsGJAkWtcRLUS+FrNLGPsUyw=
+github.com/hashicorp/hcp-sdk-go v0.142.0 h1:fODrRtwKeBfcJlsw54ieO7o4PdraHjPMp90sotQQdLM=
+github.com/hashicorp/hcp-sdk-go v0.142.0/go.mod h1:ZxsZZjErm3E2sj2OjDeVsGJAkWtcRLUS+FrNLGPsUyw=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.22.0 h1:G5+4Sz6jYZfRYUCg6eQgDsqTzkNXV+fP8l+uRmZHj64=


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR has changes to update the `hcp-sdk-go` version to the latest tag


