### PR TITLE
Restore status page check

### DIFF
--- a/.changelog/1297.txt
+++ b/.changelog/1297.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-diagnostics: Restore status page check and make it optional via provider config bool disable_status_check or env HCP_DISABLE_STATUS_CHECK.
+diagnostics: Restore status page check and make it optional via provider config bool skip_status_check or env HCP_SKIP_STATUS_CHECK.
 ```

--- a/.changelog/1297.txt
+++ b/.changelog/1297.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-Restore status page check.
+diagnostics: Restore status page check and make it optional via provider config bool disable_status_check or env HCP_DISABLE_STATUS_CHECK.
 ```

--- a/.changelog/1297.txt
+++ b/.changelog/1297.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Restore status page check.
+```

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,10 +34,6 @@
 # all Waypoint resources and clients are owned by the waypoint team
 **/waypoint @hashicorp/cloud-waypoint
 
-# Statuspage.io configuration is owned by the Core SRE team
-/internal/provider/statuspage.go @hashicorp/core-sre
-/internal/providersdkv2/statuspage.go @hashicorp/core-sre
-
 # all Vault Radar resources and clients are owned by the vault-scanning team
 *vaultradar*  @hashicorp/vault-scanning
 *vault_radar* @hashicorp/vault-scanning

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,9 @@
 # all Waypoint resources and clients are owned by the waypoint team
 **/waypoint @hashicorp/cloud-waypoint
 
+# Status page configuration is owned by the FIRE team
+/internal/statuspage/ @hashicorp/team-fire
+
 # all Vault Radar resources and clients are owned by the vault-scanning team
 *vaultradar*  @hashicorp/vault-scanning
 *vault_radar* @hashicorp/vault-scanning

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/vaultsecrets"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/waypoint"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/webhook"
+	"github.com/hashicorp/terraform-provider-hcp/internal/statuspage"
 )
 
 // This is an implementation using the Provider framework
@@ -223,6 +224,13 @@ func NewFrameworkProvider(version string) func() provider.Provider {
 }
 
 func (p *ProviderFramework) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	// In order to avoid disrupting testing and development, the HCP status check only runs on prod.
+	// HCP_API_HOST is used to point the provider at test environments. When unset, the provider points to prod.
+	if os.Getenv("HCP_API_HOST") == "" || os.Getenv("HCP_API_HOST") == "api.cloud.hashicorp.com" {
+		// This helper verifies HCP's status and returns a warning for degraded performance
+		resp.Diagnostics.Append(statuspage.IsHCPOperationalFramework()...)
+	}
+
 	// Sets up HCP SDK client.
 	var data ProviderFrameworkModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -109,11 +109,11 @@ func New() func() *schema.Provider {
 						},
 					},
 				},
-				"disable_status_check": {
+				"skip_status_check": {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Default:     false,
-					Description: "Disable the HCP status page check. When set to true, the provider will not check the HCP status page for service outages or return warnings.",
+					Description: "When set to true, the provider will skip checking the HCP status page for service outages or returning warnings.",
 				},
 			},
 			ProviderMetaSchema: map[string]*schema.Schema{
@@ -134,10 +134,11 @@ func New() func() *schema.Provider {
 func configure(p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		var diags diag.Diagnostics
-		// Determine if status check is disabled via provider configuration or environment variable
-		disableStatusCheck := d.Get("disable_status_check").(bool) || os.Getenv("HCP_DISABLE_STATUS_CHECK") == "true"
-		if !disableStatusCheck {
-			// This helper verifies HCP's status and returns a warning for degraded performance
+		// Determine if status check should be skipped via provider configuration or environment variable.
+		// Previously, skipping depended on the value of HCP_API_HOST but is now controlled explicitly by users.
+		skipStatusCheck := d.Get("skip_status_check").(bool) || os.Getenv("HCP_SKIP_STATUS_CHECK") == "true"
+		if !skipStatusCheck {
+			// This helper verifies HCP's status and returns a warning for degraded performance.
 			diags = statuspage.IsHCPOperationalSDKv2()
 		}
 

--- a/internal/statuspage/statuspage.go
+++ b/internal/statuspage/statuspage.go
@@ -1,0 +1,174 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statuspage
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	frameworkDiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	sdkv2Diag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+const (
+	statuspageURL = "https://status.hashicorp.com/api/v1/summary"
+	warnSummary   = "You may experience issues using HCP."
+	warnDetailFmt = "HCP is reporting the following:\n\n%s\n\nPlease check https://status.hashicorp.com for more details."
+)
+
+// IDs from the incident.io status page for components relevant to this provider
+var hcpComponentNames = map[string]string{
+	"HCP API":           "01JK8R0BRY4185T4NHJFAXP35D",
+	"HCP Boundary":      "01JK8R0BRYHN4JYQ1H3WC42RWV",
+	"HCP Packer":        "01JK8R0BRYR9EYAGMNJ5EKC6CS",
+	"HCP Portal":        "01JK8R0BRYKPJS5K35R2ZCSHV0",
+	"HCP Vault Radar":   "01JK8R0BRYDYZFQH1V8ZSJKDFF",
+	"HCP Vault Secrets": "01JK8R0BRYY1ZM4NCA18A5T43A",
+	"HCP Waypoint":      "01JK8R0BRY0Q21819AYRKH5GZZ",
+}
+
+// These groups contain many regions and have a top-level ID that is not returned in the API response
+var hcpGroupNames = []string{
+	"HCP Consul Dedicated",
+	"HCP Vault Dedicated",
+}
+
+type statuspage struct {
+	OngoingIncidents []incident `json:"ongoing_incidents"`
+}
+
+type incident struct {
+	Name               string              `json:"name"`
+	Status             string              `json:"status"`
+	AffectedComponents []affectedComponent `json:"affected_components"`
+}
+
+type affectedComponent struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	GroupName     string `json:"group_name,omitempty"`
+	CurrentStatus string `json:"current_status"`
+}
+
+type statusCheckResult struct {
+	errorMessage  string
+	operational   bool
+	statusMessage string
+}
+
+// Determine whether the components returned in the API are relevant
+func isHCPComponentAffected(comp affectedComponent) bool {
+	if comp.CurrentStatus == "operational" {
+		return false
+	}
+	expectedID, ok := hcpComponentNames[comp.Name]
+	if ok && expectedID == comp.ID {
+		return true
+	}
+	return slices.Contains(hcpGroupNames, comp.GroupName)
+}
+
+func checkHCPStatus() statusCheckResult {
+	result := statusCheckResult{
+		operational: true,
+	}
+
+	req, err := http.NewRequest("GET", statuspageURL, nil)
+	if err != nil {
+		result.errorMessage = fmt.Sprintf("Unable to create request to verify HCP status: %s", err)
+		return result
+	}
+
+	var cl = http.Client{
+		Timeout: 3 * time.Second,
+	}
+	resp, err := cl.Do(req)
+	if err != nil {
+		result.errorMessage = fmt.Sprintf("Unable to complete request to verify HCP status: %s", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	jsBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		result.errorMessage = fmt.Sprintf("Unable to read response to verify HCP status: %s", err)
+		return result
+	}
+
+	sp := statuspage{}
+	err = json.Unmarshal(jsBytes, &sp)
+	if err != nil {
+		result.errorMessage = fmt.Sprintf("Unable to unmarshal response to verify HCP status: %s", err)
+		return result
+	}
+
+	var statusBuilder strings.Builder
+
+	for _, inc := range sp.OngoingIncidents {
+		reported := make([]string, 0, len(inc.AffectedComponents))
+		for _, comp := range inc.AffectedComponents {
+			if isHCPComponentAffected(comp) {
+				result.operational = false
+				prefix := comp.Name
+				if comp.GroupName != "" {
+					prefix = fmt.Sprintf("%s (%s)", comp.GroupName, comp.Name)
+				}
+				reported = append(reported, fmt.Sprintf("%s: %s", prefix, comp.CurrentStatus))
+			}
+		}
+
+		if len(reported) > 0 {
+			fmt.Fprintf(&statusBuilder, "\n[Status: %s] %s\n- %s\n",
+				inc.Status, inc.Name, strings.Join(reported, ", "))
+		}
+	}
+
+	result.statusMessage = statusBuilder.String()
+	return result
+}
+
+func IsHCPOperationalFramework() (diags frameworkDiag.Diagnostics) {
+
+	result := checkHCPStatus()
+
+	if result.errorMessage != "" {
+		diags.AddWarning(warnSummary, result.errorMessage)
+		return diags
+	}
+
+	if !result.operational {
+		diags.AddWarning(warnSummary, fmt.Sprintf(warnDetailFmt, result.statusMessage))
+	}
+
+	return diags
+}
+
+func IsHCPOperationalSDKv2() (diags sdkv2Diag.Diagnostics) {
+
+	result := checkHCPStatus()
+
+	if result.errorMessage != "" {
+		diags = append(diags, sdkv2Diag.Diagnostic{
+			Severity: sdkv2Diag.Warning,
+			Summary:  warnSummary,
+			Detail:   result.errorMessage,
+		})
+		return diags
+	}
+
+	if !result.operational {
+		diags = append(diags, sdkv2Diag.Diagnostic{
+			Severity: sdkv2Diag.Warning,
+			Summary:  warnSummary,
+			Detail:   fmt.Sprintf(warnDetailFmt, result.statusMessage),
+		})
+	}
+
+	return diags
+}

--- a/internal/statuspage/statuspage.go
+++ b/internal/statuspage/statuspage.go
@@ -26,7 +26,8 @@ const (
 	warnDetailFmt = "HCP is reporting the following:\n\n%s\n\nPlease check https://status.hashicorp.com for more details."
 )
 
-// IDs from the incident.io status page for components relevant to this provider
+// Creating components on the incident.io status page generates a unique ID that can be found in the DOM and API response
+// Component names are not unique, so we include both here to ensure we report on the correct components
 var hcpComponentNames = map[string]string{
 	"HCP API":           "01JK8R0BRY4185T4NHJFAXP35D",
 	"HCP Boundary":      "01JK8R0BRYHN4JYQ1H3WC42RWV",
@@ -37,7 +38,8 @@ var hcpComponentNames = map[string]string{
 	"HCP Waypoint":      "01JK8R0BRY0Q21819AYRKH5GZZ",
 }
 
-// These groups contain many regions and have a top-level ID that is not returned in the API response
+// Components can be grouped into named folders, in this case containing many cloud regions
+// Groups have a top-level ID that are not returned in the API response so we rely on the group names
 var hcpGroupNames = []string{
 	"HCP Consul Dedicated",
 	"HCP Vault Dedicated",

--- a/internal/statuspage/statuspage_test.go
+++ b/internal/statuspage/statuspage_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statuspage
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	frameworkDiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	sdkv2Diag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper functions to create test data
+func testComponent(name string, status string) affectedComponent {
+	id := hcpComponentNames[name]
+	return affectedComponent{
+		ID:            id,
+		Name:          name,
+		CurrentStatus: status,
+	}
+}
+
+func testGroupedComponent(groupName, status string) affectedComponent {
+	return affectedComponent{
+		ID:            "region-id",
+		Name:          "region-name",
+		GroupName:     groupName,
+		CurrentStatus: status,
+	}
+}
+
+func inc(name, status string, components ...affectedComponent) incident {
+	return incident{
+		Name:               name,
+		Status:             status,
+		AffectedComponents: components,
+	}
+}
+
+// createTestServer creates and manages a test HTTP server
+func createTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	prevURL := statuspageURL
+	statuspageURL = server.URL
+
+	t.Cleanup(func() {
+		server.Close()
+		statuspageURL = prevURL
+	})
+}
+
+// stubStatusPage configures a test server to return a simulated status page response
+func stubStatusPage(t *testing.T, incidents []incident) {
+	t.Helper()
+	createTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(statuspage{OngoingIncidents: incidents}); err != nil {
+			t.Fatalf("Failed to encode status page response: %v", err)
+		}
+	})
+}
+
+// Different error scenarios
+func simulateError(t *testing.T, errorType string) {
+	t.Helper()
+	switch errorType {
+	case "timeout":
+		oldTimeout := clientTimeout
+		t.Cleanup(func() {
+			clientTimeout = oldTimeout
+		})
+		clientTimeout = 1 * time.Millisecond
+
+		createTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(5 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+		})
+
+	case "serviceDown":
+		createTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+	}
+}
+
+// TestIsHCPComponentAffected tests the component evaluation function
+func TestIsHCPComponentAffected(t *testing.T) {
+	testCases := []struct {
+		name       string
+		component  affectedComponent
+		isAffected bool
+	}{
+		{
+			name:       "operational HCP component",
+			component:  testComponent("HCP API", "operational"),
+			isAffected: false,
+		},
+		{
+			name:       "non-operational HCP component",
+			component:  testComponent("HCP Portal", "degraded_performance"),
+			isAffected: true,
+		},
+		{
+			name:       "operational HCP group component",
+			component:  testGroupedComponent("HCP Vault Dedicated", "operational"),
+			isAffected: false,
+		},
+		{
+			name:       "non-operational HCP group component",
+			component:  testGroupedComponent("HCP Consul Dedicated", "partial_outage"),
+			isAffected: true,
+		},
+		{
+			name:       "non-HCP component",
+			component:  testComponent("Other", "major_outage"),
+			isAffected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isHCPComponentAffected(tc.component)
+			assert.Equal(t, tc.isAffected, result)
+		})
+	}
+}
+
+// TestCheckHCPStatus tests the main status checking function
+func TestCheckHCPStatus(t *testing.T) {
+	testCases := []struct {
+		name              string
+		setup             func(t *testing.T)
+		expectOutage      bool
+		expectDiagnostics bool
+		messageContains   []string
+		messageExcludes   []string
+	}{
+		{
+			name:              "fully operational",
+			setup:             func(t *testing.T) { stubStatusPage(t, nil) },
+			expectOutage:      false,
+			expectDiagnostics: false,
+			messageContains:   nil,
+		},
+		{
+			name: "single non-operational HCP component",
+			setup: func(t *testing.T) {
+				stubStatusPage(t, []incident{
+					inc("API Outage", "investigating",
+						testComponent("HCP API", "major_outage"))})
+			},
+			expectOutage:      true,
+			expectDiagnostics: true,
+			messageContains:   []string{"API Outage - HCP API: major_outage"},
+		},
+		{
+			name: "non-operational HCP components from multiple incidents",
+			setup: func(t *testing.T) {
+				stubStatusPage(t, []incident{
+					inc("API Outage", "investigating",
+						testComponent("HCP API", "major_outage")),
+					inc("Portal Issues", "identified",
+						testComponent("HCP Portal", "partial_outage")),
+				})
+			},
+			expectOutage:      true,
+			expectDiagnostics: true,
+			messageContains:   []string{"API Outage - HCP API: major_outage", "Portal Issues - HCP Portal: partial_outage"},
+		},
+		{
+			name: "non-operational HCP componentGroup",
+			setup: func(t *testing.T) {
+				stubStatusPage(t, []incident{
+					inc("Consul incident", "investigating",
+						testGroupedComponent("HCP Consul Dedicated", "major_outage")),
+				})
+			},
+			expectOutage:      true,
+			expectDiagnostics: true,
+			messageContains:   []string{"Consul incident - HCP Consul Dedicated (region-name): major_outage"},
+		},
+		{
+			name: "only HCP when mixed components",
+			setup: func(t *testing.T) {
+				stubStatusPage(t, []incident{
+					inc("Mixed Outage", "investigating",
+						testComponent("Other", "major_outage"),
+						testComponent("HCP Packer", "partial_outage")),
+				})
+			},
+			expectOutage:      true,
+			expectDiagnostics: true,
+			messageContains:   []string{"Mixed Outage - HCP Packer: partial_outage"},
+			messageExcludes:   []string{"Other"},
+		},
+		{
+			name:              "service unavailable",
+			setup:             func(t *testing.T) { simulateError(t, "serviceDown") },
+			expectOutage:      false,
+			expectDiagnostics: true,
+			messageContains:   []string{"Unable to unmarshal response"},
+		},
+		{
+			name:              "request timeout",
+			setup:             func(t *testing.T) { simulateError(t, "timeout") },
+			expectOutage:      false,
+			expectDiagnostics: true,
+			messageContains:   []string{"Unable to complete request"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+			result := checkHCPStatus()
+
+			assert.Equal(t, tc.expectOutage, result.statusMessage != "", "Operational status mismatch")
+			assert.Equal(t, tc.expectDiagnostics, result.hasDiagnostics(), "Diagnostics presence mismatch")
+
+			if tc.expectDiagnostics {
+				message := result.diagnosticMessage()
+				assert.NotEmpty(t, message, "Expected diagnostic message to be non-empty")
+
+				for _, s := range tc.messageContains {
+					assert.Contains(t, message, s, "Diagnostic message should contain '%s'", s)
+				}
+				for _, s := range tc.messageExcludes {
+					assert.NotContains(t, message, s, "Diagnostic message should not contain '%s'", s)
+				}
+			} else {
+				assert.Empty(t, result.diagnosticMessage(), "Expected no diagnostic message")
+			}
+		})
+	}
+}
+
+// Define test scenarios that can be shared between Framework and SDKv2 tests
+
+func TestIsHCPOperational(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		setupFn         func(t *testing.T)
+		expectDiags     bool
+		expectedSummary string
+		detailContains  []string
+		detailExcludes  []string
+	}{
+		{
+			name: "one warn overall during HCP outages",
+			setupFn: func(t *testing.T) {
+				stubStatusPage(t, []incident{
+					inc("API Outage", "investigating", testComponent("HCP API", "degraded_performance")),
+					inc("Consul Issues", "identified", testGroupedComponent("HCP Consul Dedicated", "partial_outage")),
+					inc("Unrelated Incident", "investigating", testComponent("Other", "major_outage")),
+				})
+			},
+			expectDiags:     true,
+			expectedSummary: warnSummary,
+			detailContains:  []string{"API Outage", "Consul Issues"},
+			detailExcludes:  []string{"Unrelated Incident"},
+		},
+		{
+			name:            "setup failure warn",
+			setupFn:         func(t *testing.T) { simulateError(t, "serviceDown") },
+			expectDiags:     true,
+			expectedSummary: warnSummary,
+			detailContains:  []string{"Unable to unmarshal response"},
+		},
+		{
+			name:        "fully operational",
+			setupFn:     func(t *testing.T) { stubStatusPage(t, nil) },
+			expectDiags: false,
+		},
+	}
+
+	t.Run("Framework", func(t *testing.T) {
+		for _, scenario := range scenarios {
+			t.Run(scenario.name, func(t *testing.T) {
+				scenario.setupFn(t)
+				diags := IsHCPOperationalFramework()
+
+				if !scenario.expectDiags {
+					assert.Empty(t, diags, "Should have no diagnostics when operational")
+					return
+				}
+
+				assert.Len(t, diags, 1, "Should have one diagnostic")
+				assert.Equal(t, frameworkDiag.SeverityWarning, diags[0].Severity(), "Should use warning severity")
+				assert.Equal(t, scenario.expectedSummary, diags[0].Summary(), "Should have expected summary")
+
+				detail := diags[0].Detail()
+				for _, expectedText := range scenario.detailContains {
+					assert.Contains(t, detail, expectedText, "Should contain expected text")
+				}
+				for _, excludedText := range scenario.detailExcludes {
+					assert.NotContains(t, detail, excludedText, "Should not contain excluded text")
+				}
+			})
+		}
+	})
+
+	t.Run("SDKv2", func(t *testing.T) {
+		for _, scenario := range scenarios {
+			t.Run(scenario.name, func(t *testing.T) {
+				scenario.setupFn(t)
+				diags := IsHCPOperationalSDKv2()
+
+				if !scenario.expectDiags {
+					assert.Empty(t, diags, "Should have no diagnostics when operational")
+					return
+				}
+
+				assert.Len(t, diags, 1, "Should have one diagnostic")
+				assert.Equal(t, sdkv2Diag.Warning, diags[0].Severity, "Should use warning severity")
+				assert.Equal(t, scenario.expectedSummary, diags[0].Summary, "Should have expected summary")
+
+				detail := diags[0].Detail
+				for _, expectedText := range scenario.detailContains {
+					assert.Contains(t, detail, expectedText, "Should contain expected text")
+				}
+				for _, excludedText := range scenario.detailExcludes {
+					assert.NotContains(t, detail, excludedText, "Should not contain excluded text")
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

Follow up to #1216 that restores status page checking using new API.
Compared to the previous approach this expands the component list under consideration, adds a missing http timeout, co-locates declared incident names alongside impacted components for more context, and shares logic to reduce duplication across the provider implementations.

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.