### PR TITLE
Hcpf 3080/update state only if setting policy succeeds

### DIFF
--- a/internal/clients/iampolicy/resource_iam_policy.go
+++ b/internal/clients/iampolicy/resource_iam_policy.go
@@ -129,10 +129,11 @@ func (r *resourcePolicy) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Copy the existing state and then override with the new policy. This
-	// allows the attributes set by the ResourceIamUpdater to carry forward.
+	resp.Diagnostics.Append(setIamPolicyData(ctx, &req.Plan, updater)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.State.Raw = req.Plan.Raw
-	resp.Diagnostics.Append(setIamPolicyData(ctx, &req.Plan, &resp.State, updater)...)
 }
 
 func (r *resourcePolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -162,10 +163,11 @@ func (r *resourcePolicy) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	// Copy the existing state and then override with the new policy. This
-	// allows the attributes set by the ResourceIamUpdater to carry forward.
+	resp.Diagnostics.Append(setIamPolicyData(ctx, &req.Plan, updater)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	resp.State.Raw = req.Plan.Raw
-	resp.Diagnostics.Append(setIamPolicyData(ctx, &req.Plan, &resp.State, updater)...)
 }
 
 func (r *resourcePolicy) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -201,7 +203,7 @@ func (r *resourcePolicy) ImportState(ctx context.Context, req resource.ImportSta
 	}
 }
 
-func setIamPolicyData(ctx context.Context, in, out TerraformResourceData, updater ResourceIamUpdater) diag.Diagnostics {
+func setIamPolicyData(ctx context.Context, in TerraformResourceData, updater ResourceIamUpdater) diag.Diagnostics {
 
 	// Get the encoded policy
 	var diags diag.Diagnostics
@@ -234,7 +236,7 @@ func setIamPolicyData(ctx context.Context, in, out TerraformResourceData, update
 		return diags
 	}
 
-	diags.Append(storeIamPolicyData(ctx, out, updatedPolicy)...)
+	diags.Append(storeIamPolicyData(ctx, in, updatedPolicy)...)
 	return diags
 }
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.