### PR TITLE
VAULT-37308: Update resource_iam_policy to use resource_name

### DIFF
--- a/.github/workflows/_testacc_vaultradar.yml
+++ b/.github/workflows/_testacc_vaultradar.yml
@@ -78,7 +78,7 @@ jobs:
           # RADAR_GITHUB_ENTERPRISE_DOMAIN: ${{ secrets.RADAR_GITHUB_ENTERPRISE_DOMAIN }}
           # RADAR_GITHUB_ENTERPRISE_TOKEN: ${{ secrets.RADAR_GITHUB_ENTERPRISE_TOKEN }}
           # RADAR_GITHUB_ENTERPRISE_TOKEN_2: ${{ secrets.RADAR_GITHUB_ENTERPRISE_TOKEN_2 }}
-          # RADAR_RESOURCE_URI ${{ secrets.RADAR_RESOURCE_URI }}
+          # RADAR_HCP_RESOURCE_NAME ${{ secrets.RADAR_HCP_RESOURCE_NAME }}
         run: |
           go test \
             ./internal/provider/vaultradar \

--- a/docs/resources/vault_radar_resource_iam_binding.md
+++ b/docs/resources/vault_radar_resource_iam_binding.md
@@ -31,9 +31,9 @@ data "hcp_group" "group" {
 # Note: `roles/vault-radar.resource-viewer` and `roles/vault-radar.resource-contributor` are the only roles
 # that can be applied to a policy and/or binding for Vault Radar resources.
 resource "hcp_vault_radar_resource_iam_binding" "binding" {
-  resource_uri = "git://github.com/foo/bar.git"
-  principal_id = data.hcp_group.group.resource_id
-  role         = "roles/vault-radar.resource-viewer"
+  resource_name = "vault-radar/project/<project_id>/scan-target/<scan_target_id>"
+  principal_id  = data.hcp_group.group.resource_id
+  role          = "roles/vault-radar.resource-viewer"
 }
 ```
 
@@ -44,5 +44,5 @@ resource "hcp_vault_radar_resource_iam_binding" "binding" {
 ### Required
 
 - `principal_id` (String) The principal to bind to the given role.
-- `resource_uri` (String) The project's Radar resource URI.
+- `resource_name` (String) The HCP resource name associated with the Radar resource. This is the name of the resource in the format `vault-radar/project/<project_id>/scan-target/<scan_target_id>`.
 - `role` (String) The role name to bind to the given principal.

--- a/docs/resources/vault_radar_resource_iam_policy.md
+++ b/docs/resources/vault_radar_resource_iam_policy.md
@@ -38,8 +38,8 @@ data "hcp_iam_policy" "policy" {
 }
 
 resource "hcp_vault_radar_resource_iam_policy" "policy" {
-  resource_uri = "git://github.com/foo/bar.git"
-  policy_data  = data.hcp_iam_policy.policy.policy_data
+  resource_name = "vault-radar/project/<project_id>/scan-target/<scan_target_id>"
+  policy_data   = data.hcp_iam_policy.policy.policy_data
 }
 ```
 
@@ -50,7 +50,7 @@ resource "hcp_vault_radar_resource_iam_policy" "policy" {
 ### Required
 
 - `policy_data` (String) The policy to apply.
-- `resource_uri` (String) The project's Radar resource URI.
+- `resource_name` (String) The HCP resource name associated with the Radar resource. This is the name of the resource in the format `vault-radar/project/<project_id>/scan-target/<scan_target_id>`.
 
 ### Read-Only
 

--- a/examples/resources/hcp_vault_radar_resource_iam_binding/resource.tf
+++ b/examples/resources/hcp_vault_radar_resource_iam_binding/resource.tf
@@ -9,7 +9,7 @@ data "hcp_group" "group" {
 # Note: `roles/vault-radar.resource-viewer` and `roles/vault-radar.resource-contributor` are the only roles
 # that can be applied to a policy and/or binding for Vault Radar resources.
 resource "hcp_vault_radar_resource_iam_binding" "binding" {
-  resource_uri = "git://github.com/foo/bar.git"
-  principal_id = data.hcp_group.group.resource_id
-  role         = "roles/vault-radar.resource-viewer"
+  resource_name = "vault-radar/project/<project_id>/scan-target/<scan_target_id>"
+  principal_id  = data.hcp_group.group.resource_id
+  role          = "roles/vault-radar.resource-viewer"
 }

--- a/examples/resources/hcp_vault_radar_resource_iam_policy/resource.tf
+++ b/examples/resources/hcp_vault_radar_resource_iam_policy/resource.tf
@@ -16,6 +16,6 @@ data "hcp_iam_policy" "policy" {
 }
 
 resource "hcp_vault_radar_resource_iam_policy" "policy" {
-  resource_uri = "git://github.com/foo/bar.git"
-  policy_data  = data.hcp_iam_policy.policy.policy_data
+  resource_name = "vault-radar/project/<project_id>/scan-target/<scan_target_id>"
+  policy_data   = data.hcp_iam_policy.policy.policy_data
 }

--- a/internal/provider/vaultradar/resource_radar_resource_iam_policy.go
+++ b/internal/provider/vaultradar/resource_radar_resource_iam_policy.go
@@ -5,17 +5,17 @@ package vaultradar
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"maps"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/resource_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
-	rrs "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-radar/preview/2023-05-01/client/resource_service"
-	rrm "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-radar/preview/2023-05-01/models"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -36,14 +36,24 @@ func radarResourceIAMSchema(binding bool) schema.Schema {
 		d = "Updates the Vault Radar Resource IAM policy to bind a role to a new principal. Existing bindings are preserved."
 	}
 
+	// Defined in: https://github.com/CyberAP/nanoid-dictionary#nolookalikessafe
+	nanoidNolookalikesSafeAlphabet := "6789BCDFGHJKLMNPQRTWbcdfghjkmnpqrtwz"
+	nanoidLength := 20
+	resourceNameRegex := fmt.Sprintf(`^vault-radar/project/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/scan-target/[%s]{%d}$`, nanoidNolookalikesSafeAlphabet, nanoidLength)
+
 	return schema.Schema{
 		MarkdownDescription: d,
 		Attributes: map[string]schema.Attribute{
-			"resource_uri": schema.StringAttribute{
+			"resource_name": schema.StringAttribute{
 				Required:    true,
-				Description: "The project's Radar resource URI.",
+				Description: "The HCP resource name associated with the Radar resource. This is the name of the resource in the format `vault-radar/project/<project_id>/scan-target/<scan_target_id>`.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(resourceNameRegex),
+						"must match the format: "+resourceNameRegex,
+					),
 				},
 			},
 		},
@@ -59,9 +69,9 @@ func NewRadarResourceIAMBindingResource() resource.Resource {
 }
 
 type radarResourceIAMPolicyUpdater struct {
-	resourceURI string
-	client      *clients.Client
-	d           iampolicy.TerraformResourceData
+	resourceName string
+	client       *clients.Client
+	d            iampolicy.TerraformResourceData
 }
 
 func newRadarResourceIAMPolicyUpdater(
@@ -69,30 +79,25 @@ func newRadarResourceIAMPolicyUpdater(
 	d iampolicy.TerraformResourceData,
 	clients *clients.Client) (iampolicy.ResourceIamUpdater, diag.Diagnostics) {
 
-	var resourceURI types.String
-	diags := d.GetAttribute(ctx, path.Root("resource_uri"), &resourceURI)
+	var resourceName types.String
+	diags := d.GetAttribute(ctx, path.Root("resource_name"), &resourceName)
 
 	return &radarResourceIAMPolicyUpdater{
-		resourceURI: resourceURI.ValueString(),
-		client:      clients,
-		d:           d,
+		resourceName: resourceName.ValueString(),
+		client:       clients,
+		d:            d,
 	}, diags
 }
 
 func (u *radarResourceIAMPolicyUpdater) GetMutexKey() string {
-	return u.resourceURI
+	return u.resourceName
 }
 
 // GetResourceIamPolicy Fetch the existing IAM policy attached to a resource.
 func (u *radarResourceIAMPolicyUpdater) GetResourceIamPolicy(ctx context.Context) (*models.HashicorpCloudResourcemanagerPolicy, diag.Diagnostics) {
-	rr, lookupDiags := lookupRadarResourceByURI(ctx, u.client, u.resourceURI)
-	if lookupDiags.HasError() {
-		return nil, lookupDiags
-	}
-
 	var diags diag.Diagnostics
 	params := resource_service.NewResourceServiceGetIamPolicyParams()
-	params.ResourceName = &rr.HcpResourceName
+	params.ResourceName = &u.resourceName
 
 	res, err := u.client.ResourceService.ResourceServiceGetIamPolicy(params, nil)
 	if err != nil {
@@ -131,16 +136,11 @@ func (u *radarResourceIAMPolicyUpdater) SetResourceIamPolicy(ctx context.Context
 		return nil, diags
 	}
 
-	rr, diags := lookupRadarResourceByURI(ctx, u.client, u.resourceURI)
-	if diags.HasError() {
-		return nil, diags
-	}
-
 	params := resource_service.NewResourceServiceSetIamPolicyParams()
 
 	params.Body = &models.HashicorpCloudResourcemanagerResourceSetIamPolicyRequest{
 		Policy:       policy,
-		ResourceName: rr.HcpResourceName,
+		ResourceName: u.resourceName,
 	}
 
 	res, err := u.client.ResourceService.ResourceServiceSetIamPolicy(params, nil)
@@ -161,84 +161,3 @@ var (
 	_ iampolicy.NewResourceIamUpdaterFunc = newRadarResourceIAMPolicyUpdater
 	_ iampolicy.ResourceIamUpdater        = &radarResourceIAMPolicyUpdater{}
 )
-
-func lookupRadarResourceByURI(ctx context.Context, client *clients.Client, resourceURI string) (*rrm.VaultRadar20230501Resource, diag.Diagnostics) {
-	projectID := client.Config.ProjectID
-
-	// Filter to find the exact radar resources by URI.
-	filters := []*rrm.VaultRadar20230501Filter{
-		{
-			ID:         "uri",
-			Op:         rrm.NewFilterFilterOperation(rrm.FilterFilterOperationEQ),
-			Value:      []*rrm.VaultRadar20230501FilterValue{{StringValue: resourceURI}},
-			ExactMatch: true,
-		},
-		{
-			ID:         "state",
-			Op:         rrm.NewFilterFilterOperation(rrm.FilterFilterOperationNEQNULLAWARE),
-			Value:      []*rrm.VaultRadar20230501FilterValue{{StringValue: "deleted"}},
-			ExactMatch: true,
-		},
-	}
-
-	body := rrs.ListResourcesBody{
-		Location: &rrs.ListResourcesParamsBodyLocation{
-			OrganizationID: client.Config.OrganizationID,
-		},
-		Search: &rrm.VaultRadar20230501SearchSchema{
-			Limit:   1, // we expect either 0 or 1
-			Page:    1,
-			Filters: filters,
-		},
-	}
-
-	var diags diag.Diagnostics
-	resp, err := clients.ListRadarResources(ctx, client, projectID, body)
-	if err != nil {
-		var srvErr *rrs.ListResourcesDefault
-		ok := errors.As(err, &srvErr)
-		if !ok {
-			diags.AddError("unexpected error while reading response from service.", err.Error())
-			return nil, diags
-		}
-
-		diags.Append(customdiags.NewErrorHTTPStatusCode("failed to retrieve radar resource", err.Error(), srvErr.Code()))
-		return nil, diags
-	}
-
-	resources := resp.GetPayload().Resources
-	if len(resources) == 0 {
-		diags.AddError("unable to find radar resource", "no radar resource could be found with the uri: "+resourceURI)
-		return nil, diags
-	}
-
-	resource := resources[0]
-	diags.Append(validateResource(resource, projectID)...)
-
-	return resources[0], diags
-}
-
-func validateResource(resource *rrm.VaultRadar20230501Resource, projectID string) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if projectID == "" {
-		diags.AddError("hcp project_id unknown", "the project_id where Vault Radar is located must be specified in the hcp provider config.")
-		return diags
-	}
-
-	if resource.HcpResourceStatus != "registered" {
-		diags.AddError("invalid radar resource status", "policy cannot be applied to a resource with status: "+resource.HcpResourceStatus)
-	}
-
-	if resource.State != "created" {
-		diags.AddError("invalid radar resource state", "policy cannot be applied to a resource with state: "+resource.State)
-	}
-
-	// This should never happen, but we check it just in case.
-	prefix := "vault-radar/project/" + projectID + "/scan-target/"
-	if !strings.HasPrefix(resource.HcpResourceName, prefix) {
-		diags.AddError("invalid radar resource name", "got resource name: "+resource.HcpResourceName+", expected it to start with: "+prefix)
-	}
-
-	return diags
-}

--- a/internal/provider/vaultradar/resource_radar_resource_iam_policy_test.go
+++ b/internal/provider/vaultradar/resource_radar_resource_iam_policy_test.go
@@ -23,10 +23,10 @@ func TestRadarResourceIAMPolicy(t *testing.T) {
 	// Requires least one resource set up and registered with HCP.
 	// Requires the following environment variables to be set:
 	projectID := os.Getenv("HCP_PROJECT_ID")
-	resourceURI := os.Getenv("RADAR_RESOURCE_URI")
+	hcpResourceName := os.Getenv("RADAR_HCP_RESOURCE_NAME")
 
-	if projectID == "" || resourceURI == "" {
-		t.Skip("HCP_PROJECT_ID and RADAR_RESOURCE_URI must be set for acceptance tests")
+	if projectID == "" || hcpResourceName == "" {
+		t.Skip("HCP_PROJECT_ID and RADAR_HCP_RESOURCE_NAME must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -34,22 +34,22 @@ func TestRadarResourceIAMPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			// CREATE
 			{
-				Config: createRadarResourceIAMPolicyConfig(projectID, resourceContributor, resourceURI),
+				Config: createRadarResourceIAMPolicyConfig(projectID, resourceContributor, hcpResourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_policy.test", "resource_uri", resourceURI),
+					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_policy.test", "resource_name", hcpResourceName),
 					resource.TestCheckResourceAttrSet("hcp_vault_radar_resource_iam_policy.test", "etag"),
 				),
 			},
 			// UPDATE token
 			{
-				Config: createRadarResourceIAMPolicyConfig(projectID, resourceViewer, resourceURI),
+				Config: createRadarResourceIAMPolicyConfig(projectID, resourceViewer, hcpResourceName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("hcp_vault_radar_resource_iam_policy.test", plancheck.ResourceActionUpdate),
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_policy.test", "resource_uri", resourceURI),
+					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_policy.test", "resource_name", hcpResourceName),
 					resource.TestCheckResourceAttrSet("hcp_vault_radar_resource_iam_policy.test", "etag"),
 				),
 			},
@@ -59,7 +59,7 @@ func TestRadarResourceIAMPolicy(t *testing.T) {
 
 }
 
-func createRadarResourceIAMPolicyConfig(projectID, role, resourceURI string) string {
+func createRadarResourceIAMPolicyConfig(projectID, role, hcpResourceName string) string {
 	return fmt.Sprintf(`
 		# Create a dev group.
 		resource "hcp_group" "group" {
@@ -82,12 +82,12 @@ func createRadarResourceIAMPolicyConfig(projectID, role, resourceURI string) str
 		  }]
 		}
 
-		# Create a Vault Radar Resource IAM policy for the resource uri.
+		# Create a Vault Radar Resource IAM policy for the hcp resource name.
 		resource "hcp_vault_radar_resource_iam_policy" "test" {
-		  resource_uri = %q
+		  resource_name = %q
 		  policy_data = data.hcp_iam_policy.policy.policy_data
 		}
-		`, projectID, role, resourceURI)
+		`, projectID, role, hcpResourceName)
 }
 
 func TestRadarResourceIAMBinding(t *testing.T) {
@@ -95,10 +95,10 @@ func TestRadarResourceIAMBinding(t *testing.T) {
 	// Requires least one resource set up and registered with HCP.
 	// Requires the following environment variables to be set:
 	projectID := os.Getenv("HCP_PROJECT_ID")
-	resourceURI := os.Getenv("RADAR_RESOURCE_URI")
+	hcpResourceName := os.Getenv("RADAR_HCP_RESOURCE_NAME")
 
-	if projectID == "" || resourceURI == "" {
-		t.Skip("HCP_PROJECT_ID and RADAR_RESOURCE_URI must be set for acceptance tests")
+	if projectID == "" || hcpResourceName == "" {
+		t.Skip("HCP_PROJECT_ID and RADAR_HCP_RESOURCE_NAME must be set for acceptance tests")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -106,22 +106,22 @@ func TestRadarResourceIAMBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			// CREATE
 			{
-				Config: createRadarResourceIAMBindingConfig(projectID, resourceContributor, resourceURI),
+				Config: createRadarResourceIAMBindingConfig(projectID, resourceContributor, hcpResourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_binding.test", "resource_uri", resourceURI),
+					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_binding.test", "resource_name", hcpResourceName),
 					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_binding.test", "role", resourceContributor),
 				),
 			},
 			// UPDATE token
 			{
-				Config: createRadarResourceIAMBindingConfig(projectID, resourceViewer, resourceURI),
+				Config: createRadarResourceIAMBindingConfig(projectID, resourceViewer, hcpResourceName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("hcp_vault_radar_resource_iam_binding.test", plancheck.ResourceActionUpdate),
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_binding.test", "resource_uri", resourceURI),
+					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_binding.test", "resource_name", hcpResourceName),
 					resource.TestCheckResourceAttr("hcp_vault_radar_resource_iam_binding.test", "role", resourceViewer),
 				),
 			},
@@ -131,7 +131,7 @@ func TestRadarResourceIAMBinding(t *testing.T) {
 
 }
 
-func createRadarResourceIAMBindingConfig(projectID, role, resourceURI string) string {
+func createRadarResourceIAMBindingConfig(projectID, role, hcpResourceName string) string {
 	return fmt.Sprintf(`
 		# Create a dev group.
 		resource "hcp_group" "group" {
@@ -146,12 +146,12 @@ func createRadarResourceIAMBindingConfig(projectID, role, resourceURI string) st
 		  role         = "roles/vault-radar.developer"
 		}
 			
-		# Create a Vault Radar Resource IAM binding for the resource uri.
+		# Create a Vault Radar Resource IAM binding for the hcp resource name.
 		resource "hcp_vault_radar_resource_iam_binding" "test" {
-		  resource_uri = %q
+		  resource_name = %q
 		    principal_id = hcp_group.group.resource_id
 			role         =  %q
 
 		}
-		`, projectID, resourceURI, role)
+		`, projectID, hcpResourceName, role)
 }


### PR DESCRIPTION
VAULT-37308: Update resource_radar_resource_iam_policy to use resource_name, instead of resource_uri.

**NOTE** This resource_radar_resource_iam_policy is considered **private beta** at this time. Even though this could be considered a breaking change, no one is actually using it yet.

We change the attribute from resource_uri to resource_name.

### :hammer_and_wrench: Description

This is a performance improvement, eliminating the need to look up the resource_name for a given radar resource uri, also initial testing showed that Radar rate limits restrict user ability to use this TF effectively.

### :building_construction: Acceptance tests

- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

Output from acceptance testing:
`
eval $(hcloud envhcp dev)

export TF_ACC=1 
export HCP_CLIENT_ID="<YOURS>"
export HCP_CLIENT_SECRET="<YOURS>"
export HCP_PROJECT_ID="<YOURS>" 
export RADAR_HCP_RESOURCE_NAME="<YOURS>" 

go test internal/provider/vaultradar/resource_radar_resource_iam_policy_test.go -v                                                                                                                                              (trent/VAULT-37308-resource_radar_resource_iam_policy) 
=== RUN   TestRadarResourceIAMPolicy
--- PASS: TestRadarResourceIAMPolicy (13.38s)
=== RUN   TestRadarResourceIAMBinding
--- PASS: TestRadarResourceIAMBinding (13.83s)
PASS
ok      command-line-arguments  27.915s
`

