### PR TITLE
VAULT-37310: Enable ACC for a few Vault Radar Tests

### DIFF
--- a/.github/workflows/_testacc_vaultradar.yml
+++ b/.github/workflows/_testacc_vaultradar.yml
@@ -78,8 +78,8 @@ jobs:
           # RADAR_GITHUB_ENTERPRISE_DOMAIN: ${{ secrets.RADAR_GITHUB_ENTERPRISE_DOMAIN }}
           # RADAR_GITHUB_ENTERPRISE_TOKEN: ${{ secrets.RADAR_GITHUB_ENTERPRISE_TOKEN }}
           # RADAR_GITHUB_ENTERPRISE_TOKEN_2: ${{ secrets.RADAR_GITHUB_ENTERPRISE_TOKEN_2 }}
-          # RADAR_HCP_RESOURCE_NAME ${{ secrets.RADAR_HCP_RESOURCE_NAME }}
-          # RADAR_RESOURCES_URI_LIKE_FILTER ${{ secrets.RADAR_RESOURCES_URI_LIKE_FILTER }}
+          RADAR_HCP_RESOURCE_NAME: "vault-radar/project/4213bd26-e28e-4e89-b298-6a2abcaf26ca/scan-target/GJLCPNqkmmdbTCMCbdcz"
+          RADAR_RESOURCES_URI_LIKE_FILTER: "git://github.com/vaultradarcv/hcp-terraform-provider-test-resource.git"
         run: |
           go test \
             ./internal/provider/vaultradar \


### PR DESCRIPTION
VAULT-37310: Enable ACC for Radar's `data_source_radar_resources_test` and `resource_radar_resource_iam_policy_test`.

Output from running workflow.
https://github.com/hashicorp/terraform-provider-hcp/actions/runs/15861860583/job/44720697922

![ss](https://github.com/user-attachments/assets/d43e29bb-7856-42b7-a08f-82aa469d8074)
