### PR TITLE
Correct typo in hcp_iam_workload_identity_provider examples

### DIFF
--- a/examples/resources/hcp_iam_workload_identity_provider/resource_aws.tf
+++ b/examples/resources/hcp_iam_workload_identity_provider/resource_aws.tf
@@ -7,7 +7,7 @@ resource "hcp_iam_workload_identity_provider" "example" {
   service_principal = hcp_service_principal.workload_sp.resource_name
   description       = "Allow my-app on AWS to act as my-app-runtime service principal"
 
-  aws {
+  aws = {
     # Only allow workloads from this AWS Account to exchange identity
     account_id = "123456789012"
   }

--- a/examples/resources/hcp_iam_workload_identity_provider/resource_azure.tf
+++ b/examples/resources/hcp_iam_workload_identity_provider/resource_azure.tf
@@ -7,7 +7,7 @@ resource "hcp_iam_workload_identity_provider" "example" {
   service_principal = hcp_service_principal.workload_sp.resource_name
   description       = "Allow my-app on Azure to act as my-app-runtime service principal"
 
-  oidc {
+  oidc = {
     # The issuer uri should be as follows where the ID in the path is replaced
     # with your Azure Tenant ID
     issuer_uri = "https://sts.windows.net/60a0d497-45cd-413d-95ca-e154bbb9129b"

--- a/examples/resources/hcp_iam_workload_identity_provider/resource_gcp.tf
+++ b/examples/resources/hcp_iam_workload_identity_provider/resource_gcp.tf
@@ -7,7 +7,7 @@ resource "hcp_iam_workload_identity_provider" "example" {
   service_principal = hcp_service_principal.workload_sp.resource_name
   description       = "Allow my-app on GCP to act as my-app-runtime service principal"
 
-  oidc {
+  oidc = {
     issuer_uri = "https://accounts.google.com"
   }
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Small documentation / examples fix for `hcp_iam_workload_identity_provider` resource. I found this while using the resource in the field.

