### PR TITLE
docs: update and correct hvn-azure peering example

### DIFF
--- a/docs/resources/azure_peering_connection.md
+++ b/docs/resources/azure_peering_connection.md
@@ -55,26 +55,26 @@ data "azurerm_subscription" "sub" {
   subscription_id = "<subscription UUID>"
 }
 
-resource "azurerm_resource_group" "rg" {
-  name     = "resource-group-test"
+resource "azurerm_resource_group" "default" {
+  name     = "rg-test"
   location = "West US"
 }
 
-resource "azurerm_virtual_network" "vnet" {
+resource "azurerm_virtual_network" "default" {
   name                = "vnet-test"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.default.location
+  resource_group_name = azurerm_resource_group.default.name
 
   address_space = [
     "10.0.0.0/16"
   ]
 }
 
-resource "azuread_service_principal" "principal" {
-  application_id = hcp_azure_peering_connection.peer.application_id
+resource "azuread_service_principal" "hcp" {
+  client_id = hcp_azure_peering_connection.peer.application_id
 }
 
-resource "azurerm_role_definition" "definition" {
+resource "azurerm_role_definition" "hcp_peering" {
   name  = "hcp-hvn-peering-access"
   scope = azurerm_virtual_network.vnet.id
 
@@ -91,10 +91,10 @@ resource "azurerm_role_definition" "definition" {
   }
 }
 
-resource "azurerm_role_assignment" "assignment" {
-  principal_id       = azuread_service_principal.principal.id
+resource "azurerm_role_assignment" "hcp_peering" {
+  principal_id       = azuread_service_principal.hcp.object_id
   scope              = azurerm_virtual_network.vnet.id
-  role_definition_id = azurerm_role_definition.definition.role_definition_resource_id
+  role_definition_id = azurerm_role_definition.hcp_peering.role_definition_resource_id
 }
 ```
 


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

Update the example in the documentation for the `hcp_azure_peering_connection` resource after testing if this example worked (it didn't).

* Use more "Azureified" resource names and update logical resource names to not repeat information already present in the resource type.
* Fix invalid argument name in the `azuread_service_principal` resource and invalid argument value in the `azurerm_role_assignment` resource.

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.