### PR TITLE
HCPCP-2321 add geography provider schema

### DIFF
--- a/.changelog/1354.txt
+++ b/.changelog/1354.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Add geography to provider configuration.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,7 @@ resource "hcp_vault_cluster" "example" {
 - `client_id` (String) The OAuth2 Client ID for API operations.
 - `client_secret` (String) The OAuth2 Client Secret for API operations.
 - `credential_file` (String) The path to an HCP credential file to use to authenticate the provider to HCP. You can alternatively set the HCP_CRED_FILE environment variable to point at a credential file as well. Using a credential file allows you to authenticate the provider as a service principal via client credentials or dynamically based on Workload Identity Federation.
+- `geography` (String) The geography in which HCP resources should be created. Default is `us`.
 - `project_id` (String) The default project in which resources should be created.
 - `skip_status_check` (Boolean) When set to true, the provider will skip checking the HCP status page for service outages or returning warnings.
 - `workload_identity` (Block List) Allows authenticating the provider by exchanging the OAuth 2.0 access token or OpenID Connect token specified in the `token_file` for a HCP service principal using Workload Identity Federation. (see [below for nested schema](#nestedblock--workload_identity))

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.151.0
+	github.com/hashicorp/hcp-sdk-go v0.154.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.15.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+O
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.151.0 h1:dPLgab1oihguGcOqjFoI8y+iZ05dwGK9euEvG5tzyXY=
-github.com/hashicorp/hcp-sdk-go v0.151.0/go.mod h1:HYHwfLOi7gvZwtqTQfPRYlK+XDup9NWhVRDU6N24tOs=
 github.com/hashicorp/hcp-sdk-go v0.154.0 h1:o8Sytq4cWF8kJXAUpN+bZbonKKUR8ZRS1yv3y5SCrGM=
 github.com/hashicorp/hcp-sdk-go v0.154.0/go.mod h1:HYHwfLOi7gvZwtqTQfPRYlK+XDup9NWhVRDU6N24tOs=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3q
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/hcp-sdk-go v0.151.0 h1:dPLgab1oihguGcOqjFoI8y+iZ05dwGK9euEvG5tzyXY=
 github.com/hashicorp/hcp-sdk-go v0.151.0/go.mod h1:HYHwfLOi7gvZwtqTQfPRYlK+XDup9NWhVRDU6N24tOs=
+github.com/hashicorp/hcp-sdk-go v0.154.0 h1:o8Sytq4cWF8kJXAUpN+bZbonKKUR8ZRS1yv3y5SCrGM=
+github.com/hashicorp/hcp-sdk-go v0.154.0/go.mod h1:HYHwfLOi7gvZwtqTQfPRYlK+XDup9NWhVRDU6N24tOs=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.23.0 h1:MUiBM1s0CNlRFsCLJuM5wXZrzA3MnPYEsiXmzATMW/I=

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/hcp-sdk-go/auth"
 	"github.com/hashicorp/hcp-sdk-go/auth/workload"
+	"github.com/hashicorp/hcp-sdk-go/config/geography"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -144,7 +145,11 @@ func NewClient(config ClientConfig) (*Client, error) {
 		opts = append(opts, hcpConfig.WithCredentialFile(cf))
 	}
 
-	if config.Geography != "" {
+	if config.Geography == "" {
+		// If geography is not set, default to the one used by the SDK.
+		// Currently default is us.
+		config.Geography = string(geography.Default)
+	} else {
 		opts = append(opts, hcpConfig.WithGeography(config.Geography))
 	}
 

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -127,6 +127,9 @@ type ClientConfig struct {
 	// SourceChannel denotes the client (channel) that originated the HCP cluster request.
 	// this is synonymous to a user-agent.
 	SourceChannel string
+
+	// Geography denotes the geography the HCP client should operate in.
+	Geography string
 }
 
 // NewClient creates a new Client that is capable of making HCP requests
@@ -139,6 +142,10 @@ func NewClient(config ClientConfig) (*Client, error) {
 		opts = append(opts, hcpConfig.WithCredentialFilePath(config.CredentialFile))
 	} else if cf := loadCredentialFile(config); cf != nil {
 		opts = append(opts, hcpConfig.WithCredentialFile(cf))
+	}
+
+	if config.Geography != "" {
+		opts = append(opts, hcpConfig.WithGeography(config.Geography))
 	}
 
 	// Create the HCP Config

--- a/internal/clients/client_test.go
+++ b/internal/clients/client_test.go
@@ -19,6 +19,11 @@ func Test_loadCredentialFile(t *testing.T) {
 		"empty config": {
 			config: ClientConfig{},
 		},
+		"load with geography": {
+			config: ClientConfig{
+				Geography: "eu",
+			},
+		},
 		"ignores with only resource": {
 			config: ClientConfig{
 				WorkloadIdentityResourceName: "my_resource",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -102,7 +102,7 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 			},
 			"geography": schema.StringAttribute{
 				Optional:    true,
-				Description: "The geography in which HCP resources should be created. Default is `us`",
+				Description: "The geography in which HCP resources should be created. Default is `us`.",
 				Validators: []validator.String{
 					stringvalidator.OneOf(string(geography.US), string(geography.EU)),
 				},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/hashicorp/hcp-sdk-go/config/geography"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/iam"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/logstreaming"
@@ -48,6 +49,7 @@ type ProviderFrameworkModel struct {
 	ProjectID        types.String `tfsdk:"project_id"`
 	WorkloadIdentity types.List   `tfsdk:"workload_identity"`
 	SkipStatusCheck  types.Bool   `tfsdk:"skip_status_check"`
+	Geography        types.String `tfsdk:"geography"`
 }
 
 type WorkloadIdentityFrameworkModel struct {
@@ -97,6 +99,13 @@ func (p *ProviderFramework) Schema(ctx context.Context, req provider.SchemaReque
 			"skip_status_check": schema.BoolAttribute{
 				Optional:    true,
 				Description: "When set to true, the provider will skip checking the HCP status page for service outages or returning warnings.",
+			},
+			"geography": schema.StringAttribute{
+				Optional:    true,
+				Description: "The geography in which HCP resources should be created. Default is `us`",
+				Validators: []validator.String{
+					stringvalidator.OneOf(string(geography.US), string(geography.EU)),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -253,6 +262,7 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 		CredentialFile: data.CredentialFile.ValueString(),
 		ProjectID:      data.ProjectID.ValueString(),
 		SourceChannel:  "terraform-provider-hcp",
+		Geography:      data.Geography.ValueString(),
 	}
 
 	// Read the workload_identity configuration.

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -115,6 +115,11 @@ func New() func() *schema.Provider {
 					Default:     false,
 					Description: "When set to true, the provider will skip checking the HCP status page for service outages or returning warnings.",
 				},
+				"geography": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The geography in which HCP resources should be created. Default is `us`",
+				},
 			},
 			ProviderMetaSchema: map[string]*schema.Schema{
 				"module_name": {
@@ -147,6 +152,7 @@ func configure(p *schema.Provider) func(context.Context, *schema.ResourceData) (
 			ClientSecret:   d.Get("client_secret").(string),
 			CredentialFile: d.Get("credential_file").(string),
 			ProjectID:      d.Get("project_id").(string),
+			Geography:      d.Get("geography").(string),
 			SourceChannel:  p.UserAgent("terraform-provider-hcp", version.ProviderVersion),
 		}
 

--- a/internal/providersdkv2/provider.go
+++ b/internal/providersdkv2/provider.go
@@ -118,7 +118,7 @@ func New() func() *schema.Provider {
 				"geography": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Description: "The geography in which HCP resources should be created. Default is `us`",
+					Description: "The geography in which HCP resources should be created. Default is `us`.",
 				},
 			},
 			ProviderMetaSchema: map[string]*schema.Schema{


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

This PR add a new configurable field to the HCP provider: `geography`. Currently the default is `us` as it depends on `hcp-sdk-go`.

### Test

Tested manually with both `us` and `eu`

```
provider "hcp" {
    geography = "eu"
}
```

or 

```
provider "hcp" {
    geography = "us"
}
```

Invalid value returns errors

```
provider "hcp" {
    geography = "ap"
}

│ Error: Invalid Attribute Value Match
│ 
│   with provider["hashicorp.com/test/hcp"],
│   on main.tf line 29, in provider "hcp":
│   29:     geography = "ap"
│ 
│ Attribute geography value must be one of: ["us" "eu"], got: "ap"
```

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.