### PR TITLE
Correct rotate_triggers attribute of hcp_service_principal_key example

### DIFF
--- a/.changelog/1361.txt
+++ b/.changelog/1361.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix the example documentation for `hcp_service_principal_key`.
+```

--- a/docs/resources/service_principal_key.md
+++ b/docs/resources/service_principal_key.md
@@ -38,7 +38,7 @@ resource "time_rotating" "key_rotation" {
 
 resource "hcp_service_principal_key" "key" {
   service_principal = hcp_service_principal.example.resource_name
-  rotation_triggers {
+  rotate_triggers = {
     rotation_time = time_rotating.key_rotation.rotation_rfc3339
   }
 }

--- a/examples/resources/hcp_service_principal_key/resource_rotation.tf
+++ b/examples/resources/hcp_service_principal_key/resource_rotation.tf
@@ -9,7 +9,7 @@ resource "time_rotating" "key_rotation" {
 
 resource "hcp_service_principal_key" "key" {
   service_principal = hcp_service_principal.example.resource_name
-  rotation_triggers {
+  rotate_triggers = {
     rotation_time = time_rotating.key_rotation.rotation_rfc3339
   }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixing example code for `hcp_service_principal_key`.

