### PR TITLE
added private link test paths to gh workflow

### DIFF
--- a/.github/workflows/_testacc_platform.yml
+++ b/.github/workflows/_testacc_platform.yml
@@ -105,7 +105,7 @@ jobs:
             -test.v \
             -parallel=10 \
             -timeout=360m \
-            -run="TestAcc_Platform.*" \
+            -run=TestAcc_Platform.* \
             -coverprofile=testacc-platform.out
 
           go tool cover \


### PR DESCRIPTION
added back private link tests to ci after increasing vault cluster quota to 21 in launch darkly from the default 6 limit

Note:- currently to make platform acc tests pass we have to skip azure tests (for peering,hvnroute) since those are still failing and will be addressed in future as meniotned [here](https://github.com/hashicorp/terraform-provider-hcp/pull/1366#issuecomment-3311615529) 

<img width="1512" height="354" alt="Screenshot 2025-09-22 at 1 38 31 PM" src="https://github.com/user-attachments/assets/6e9c9993-b5a4-47fb-a1ab-8509f7e9304f" />


<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.