### PR TITLE
Update DNS forwarding acceptance tests to follow TestAcc_Platform_* regex.

### DIFF
--- a/internal/providersdkv2/data_source_dns_forwarding_rule_test.go
+++ b/internal/providersdkv2/data_source_dns_forwarding_rule_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccDNSForwardingRuleDataSource(t *testing.T) {
+// TestAcc_Platform_DNSForwardingDataSource tests the DNS forwarding data source.
+func TestAcc_Platform_DNSForwardingRuleDataSource(t *testing.T) {
 	uniqueName := testAccUniqueNameWithPrefix("dns-r")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/providersdkv2/data_source_dns_forwarding_test.go
+++ b/internal/providersdkv2/data_source_dns_forwarding_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccDNSForwardingDataSource(t *testing.T) {
+// TestAcc_Platform_DNSForwardingDataSource tests the DNS forwarding data source.
+func TestAcc_Platform_DNSForwardingDataSource(t *testing.T) {
 	uniqueName := testAccUniqueNameWithPrefix("dns-fwd")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/providersdkv2/resource_dns_forwarding_rule_test.go
+++ b/internal/providersdkv2/resource_dns_forwarding_rule_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// TestAccDNSForwardingRuleResource tests the DNS forwarding rule resource.
-func TestAccDNSForwardingRuleResource(t *testing.T) {
+// TestAcc_Platform_DNSForwardingRuleResource tests the DNS forwarding rule resource.
+func TestAcc_Platform_DNSForwardingRuleResource(t *testing.T) {
 	uniqueName := testAccUniqueNameWithPrefix("dns-rr")
 
 	resource.Test(t, resource.TestCase{

--- a/internal/providersdkv2/resource_dns_forwarding_test.go
+++ b/internal/providersdkv2/resource_dns_forwarding_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func TestAccDNSForwardingResource(t *testing.T) {
+// TestAcc_Platform_DNSForwardingResource tests the DNS forwarding resource.
+func TestAcc_Platform_DNSForwardingResource(t *testing.T) {
 	uniqueName := testAccUniqueNameWithPrefix("dns-fwd-res")
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

This PR renames DNS forwarding acceptance test functions to match the `-run=TestAcc_Platform.*` regex pattern used by the [platform test workflow](https://github.com/hashicorp/terraform-provider-hcp/blob/main/.github/workflows/_testacc_platform.yml#L108), ensuring these tests are discovered and executed during CI runs of [Platform tests](https://github.com/hashicorp/terraform-provider-hcp/blob/main/.github/workflows/_testacc_platform.yml).


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.