### PR TITLE
Add Azure BGP propagation support for HVN

### DIFF
--- a/.changelog/1473.txt
+++ b/.changelog/1473.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Add support for `bgp_propagation_enabled` on Azure HVNs in `hcp_hvn`, expose it in `hcp_hvn` data source state, and document the new attribute.
+```

--- a/docs/data-sources/hvn.md
+++ b/docs/data-sources/hvn.md
@@ -33,6 +33,7 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 
 ### Read-Only
 
+- `bgp_propagation_enabled` (Boolean) Whether the HVN subnet route table accepts BGP-propagated routes from the attached Azure gateway.
 - `cidr_block` (String) The CIDR range of the HVN.
 - `cloud_provider` (String) The provider where the HVN is located.
 - `created_at` (String) The time that the HVN was created.

--- a/docs/resources/hvn.md
+++ b/docs/resources/hvn.md
@@ -43,6 +43,7 @@ resource "hcp_hvn" "example" {
 
 ### Optional
 
+- `bgp_propagation_enabled` (Boolean) Whether to accept BGP-propagated routes from the attached Azure gateway. Applies only when `cloud_provider` is `azure`.
 - `cidr_block` (String) The CIDR range of the HVN. If this is not provided, the service will provide a default value.
 - `project_id` (String) The ID of the HCP project where the HVN is located.
 If not specified, the project specified in the HCP Provider config block will be used, if configured.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/hcp-sdk-go v0.166.0
+	github.com/hashicorp/hcp-sdk-go v0.170.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.15.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3q
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/hcp-sdk-go v0.166.0 h1:8UDe6oKrKI0ZFSNwIxLTGwbIr/QYznYlt2yBeG9lWB4=
 github.com/hashicorp/hcp-sdk-go v0.166.0/go.mod h1:v2vbpNIrmgUTelW4Z+ur+aQuSPxeaVK3xytFdpEXvSg=
+github.com/hashicorp/hcp-sdk-go v0.170.0 h1:ucPwcUK9bgI1Dc6IwIjyOI2M9DX5q6pIeRCShZhqcUg=
+github.com/hashicorp/hcp-sdk-go v0.170.0/go.mod h1:v2vbpNIrmgUTelW4Z+ur+aQuSPxeaVK3xytFdpEXvSg=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.23.0 h1:MUiBM1s0CNlRFsCLJuM5wXZrzA3MnPYEsiXmzATMW/I=

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,6 @@ github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+O
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
-github.com/hashicorp/hcp-sdk-go v0.166.0 h1:8UDe6oKrKI0ZFSNwIxLTGwbIr/QYznYlt2yBeG9lWB4=
-github.com/hashicorp/hcp-sdk-go v0.166.0/go.mod h1:v2vbpNIrmgUTelW4Z+ur+aQuSPxeaVK3xytFdpEXvSg=
 github.com/hashicorp/hcp-sdk-go v0.170.0 h1:ucPwcUK9bgI1Dc6IwIjyOI2M9DX5q6pIeRCShZhqcUg=
 github.com/hashicorp/hcp-sdk-go v0.170.0/go.mod h1:v2vbpNIrmgUTelW4Z+ur+aQuSPxeaVK3xytFdpEXvSg=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=

--- a/internal/providersdkv2/data_source_hvn.go
+++ b/internal/providersdkv2/data_source_hvn.go
@@ -66,6 +66,11 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"bgp_propagation_enabled": {
+				Description: "Whether the HVN subnet route table accepts BGP-propagated routes from the attached Azure gateway.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
 			"created_at": {
 				Description: "The time that the HVN was created.",
 				Type:        schema.TypeString,

--- a/internal/providersdkv2/resource_hvn.go
+++ b/internal/providersdkv2/resource_hvn.go
@@ -93,6 +93,12 @@ If a project is not configured in the HCP Provider config block, the oldest proj
 				ValidateFunc: validation.IsUUID,
 				Computed:     true,
 			},
+			"bgp_propagation_enabled": {
+				Description: "Whether to accept BGP-propagated routes from the attached Azure gateway. Applies only when cloud_provider is 'azure'.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+			},
 			// Computed outputs
 			"organization_id": {
 				Description: "The ID of the HCP organization where the HVN is located.",
@@ -128,6 +134,12 @@ func resourceHvnCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	hvnID := d.Get("hvn_id").(string)
 	cidrBlock := d.Get("cidr_block").(string)
+	cloudProvider := d.Get("cloud_provider").(string)
+
+	bgpPropagationEnabled, bgpPropagationEnabledSet := d.GetOkExists("bgp_propagation_enabled")
+	if bgpPropagationEnabledSet && cloudProvider != "azure" {
+		return diag.Errorf("bgp_propagation_enabled can only be set when cloud_provider is 'azure'")
+	}
 
 	projectID, err := GetProjectID(d.Get("project_id").(string), client.Config.ProjectID)
 	if err != nil {
@@ -138,7 +150,7 @@ func resourceHvnCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		OrganizationID: client.Config.OrganizationID,
 		ProjectID:      projectID,
 		Region: &sharedmodels.HashicorpCloudLocationRegion{
-			Provider: d.Get("cloud_provider").(string),
+			Provider: cloudProvider,
 			Region:   d.Get("region").(string),
 		},
 	}
@@ -157,13 +169,19 @@ func resourceHvnCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	createNetworkParams := network_service.NewCreateParams()
 	createNetworkParams.Context = ctx
-	createNetworkParams.Body = &networkmodels.HashicorpCloudNetwork20200907CreateRequest{
+	createRequest := &networkmodels.HashicorpCloudNetwork20200907CreateRequest{
 		Network: &networkmodels.HashicorpCloudNetwork20200907Network{
 			ID:        hvnID,
 			CidrBlock: cidrBlock,
 			Location:  loc,
 		},
 	}
+	if cloudProvider == "azure" && bgpPropagationEnabledSet {
+		createRequest.AzureConfig = &networkmodels.HashicorpCloudNetwork20200907AzureCreateConfig{
+			BgpPropagationEnabled: bgpPropagationEnabled.(bool),
+		}
+	}
+	createNetworkParams.Body = createRequest
 	createNetworkParams.NetworkLocationOrganizationID = loc.OrganizationID
 	createNetworkParams.NetworkLocationProjectID = loc.ProjectID
 	log.Printf("[INFO] Creating HVN (%s)", hvnID)
@@ -298,6 +316,14 @@ func setHvnResourceData(d *schema.ResourceData, hvn *networkmodels.HashicorpClou
 	}
 	if err := d.Set("state", hvn.State); err != nil {
 		return err
+	}
+
+	if hvn.Location.Region.Provider == "azure" &&
+		hvn.ProviderNetworkData != nil &&
+		hvn.ProviderNetworkData.AzureNetworkData != nil {
+		if err := d.Set("bgp_propagation_enabled", hvn.ProviderNetworkData.AzureNetworkData.BgpPropagationEnabled); err != nil {
+			return err
+		}
 	}
 
 	var providerAccountID string

--- a/internal/providersdkv2/resource_hvn_test.go
+++ b/internal/providersdkv2/resource_hvn_test.go
@@ -37,6 +37,7 @@ resource "hcp_hvn" "test" {
 	hvn_id         = "%[1]s"
 	cloud_provider = "azure"
 	region         = "eastus"
+	bgp_propagation_enabled = false
 }
 
 data "hcp_hvn" "test" {
@@ -148,6 +149,7 @@ func TestAcc_Platform_AzureHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_propagation_enabled", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
 					testLink(resourceName, "self_link", hvnUniqueIDAzure, HvnResourceType, resourceName),
 				),
@@ -178,6 +180,7 @@ func TestAcc_Platform_AzureHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "organization_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_propagation_enabled", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "state"),
 					testLink(resourceName, "self_link", hvnUniqueIDAzure, HvnResourceType, resourceName),
 				),
@@ -192,6 +195,7 @@ func TestAcc_Platform_AzureHvnOnly(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "cidr_block", dataSourceName, "cidr_block"),
 					resource.TestCheckResourceAttrPair(resourceName, "organization_id", dataSourceName, "organization_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "project_id", dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bgp_propagation_enabled", dataSourceName, "bgp_propagation_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "created_at", dataSourceName, "created_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "self_link", dataSourceName, "self_link"),
 					resource.TestCheckResourceAttrPair(resourceName, "state", dataSourceName, "state"),


### PR DESCRIPTION
## Summary
This PR adds support for configuring and reading `bgp_propagation_enabled` for Azure HVNs.

### What changed
- Added `bgp_propagation_enabled` to `hcp_hvn` resource schema as optional, `ForceNew`.
- Added validation in HVN create flow to allow `bgp_propagation_enabled` only when `cloud_provider = "azure"`.
- Included `azure_config.bgp_propagation_enabled` in HVN create API request when applicable.
- Added `bgp_propagation_enabled` as a computed field to `hcp_hvn` data source.
- Persisted/read the value from Azure network data in resource state.
- Updated HVN resource/data source docs for the new field.
- Added acceptance test assertions for the Azure HVN path and resource/data source parity.
- Updated `hcp-sdk-go` from `v0.166.0` to `v0.170.0`.

## Behavior notes
- `bgp_propagation_enabled` is only valid for Azure HVNs.
- Attempting to set it for non-Azure providers returns a clear Terraform diagnostic.

## Testing
- Updated existing Azure HVN acceptance coverage with checks for `bgp_propagation_enabled`.
- Local acceptance test execution was not performed in this change set.

## Documentation
- Updated:
  - `docs/resources/hvn.md`
  - `docs/data-sources/hvn.md`