### PR TITLE
Fix drift detection for sensitive fields in vault cluster observability config

### DIFF
--- a/.changelog/1466.txt
+++ b/.changelog/1466.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix potential drift detection issues for sensitive fields in `audit_log_config` and `metrics_config` by adding safe type assertion checks when API returns redacted values.
+```

--- a/internal/providersdkv2/resource_vault_cluster.go
+++ b/internal/providersdkv2/resource_vault_cluster.go
@@ -1284,7 +1284,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 		} else {
 			if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 				config := configParam.([]interface{})[0].(map[string]interface{})
-				configMap["grafana_password"] = config["grafana_password"].(string)
+				if password, exists := config["grafana_password"]; exists && password != nil {
+					configMap["grafana_password"] = password.(string)
+				}
 			}
 		}
 	}
@@ -1297,7 +1299,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 		} else {
 			if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 				config := configParam.([]interface{})[0].(map[string]interface{})
-				configMap["splunk_token"] = config["splunk_token"].(string)
+				if token, exists := config["splunk_token"]; exists && token != nil {
+					configMap["splunk_token"] = token.(string)
+				}
 			}
 		}
 	}
@@ -1310,7 +1314,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 		} else {
 			if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 				config := configParam.([]interface{})[0].(map[string]interface{})
-				configMap["datadog_api_key"] = config["datadog_api_key"].(string)
+				if apiKey, exists := config["datadog_api_key"]; exists && apiKey != nil {
+					configMap["datadog_api_key"] = apiKey.(string)
+				}
 			}
 		}
 	}
@@ -1333,7 +1339,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 		} else {
 			if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 				config := configParam.([]interface{})[0].(map[string]interface{})
-				configMap["cloudwatch_secret_access_key"] = config["cloudwatch_secret_access_key"].(string)
+				if secretKey, exists := config["cloudwatch_secret_access_key"]; exists && secretKey != nil {
+					configMap["cloudwatch_secret_access_key"] = secretKey.(string)
+				}
 			}
 		}
 	}
@@ -1349,7 +1357,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 		} else {
 			if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 				config := configParam.([]interface{})[0].(map[string]interface{})
-				configMap["elasticsearch_password"] = config["elasticsearch_password"].(string)
+				if password, exists := config["elasticsearch_password"]; exists && password != nil {
+					configMap["elasticsearch_password"] = password.(string)
+				}
 			}
 		}
 	}
@@ -1372,7 +1382,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 			} else {
 				if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 					config := configParam.([]interface{})[0].(map[string]interface{})
-					configMap["http_basic_password"] = config["http_basic_password"].(string)
+					if password, exists := config["http_basic_password"]; exists && password != nil {
+						configMap["http_basic_password"] = password.(string)
+					}
 				}
 			}
 		}
@@ -1384,7 +1396,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 			} else {
 				if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 					config := configParam.([]interface{})[0].(map[string]interface{})
-					configMap["http_bearer_token"] = config["http_bearer_token"].(string)
+					if token, exists := config["http_bearer_token"]; exists && token != nil {
+						configMap["http_bearer_token"] = token.(string)
+					}
 				}
 			}
 		}
@@ -1399,7 +1413,9 @@ func flattenObservabilityConfig(config *vaultmodels.HashicorpCloudVault20201125O
 			} else {
 				if configParam, ok := d.GetOk(propertyName); ok && len(configParam.([]interface{})) > 0 {
 					config := configParam.([]interface{})[0].(map[string]interface{})
-					configMap["newrelic_license_key"] = config["newrelic_license_key"].(string)
+					if licenseKey, exists := config["newrelic_license_key"]; exists && licenseKey != nil {
+						configMap["newrelic_license_key"] = licenseKey.(string)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ### Problem                                                                                                                                                                                                                                                                                                                                                                                                                    
  When the HCP API returns "redacted" for sensitive fields in `audit_log_config` and `metrics_config`, the provider attempts to retrieve the value from the existing state. However, the code performs unsafe type assertions without checking if the key exists in the state map, which can cause:                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  1. Potential panics when the key doesn't exist (nil type assertion)                                                                                                                                                                                                                                                                                                                                                            
  2. Drift detection issues when empty strings are set instead of actual values                                                                                                                                                                                                                                                                                                                                                  
  3. Problems during initial configuration when fields haven't been saved to state yet                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ### Affected Fields                                                                                                                                                                                                                                                                                                                                                                                                            
  Both `audit_log_config` and `metrics_config`:                                                                                                                                                                                                                                                                                                                                                                                  
  - `grafana_password`                                                                                                                                                                                                                                                                                                                                                                                                           
  - `splunk_token`                                                                                                                                                                                                                                                                                                                                                                                                               
  - `datadog_api_key`                                                                                                                                                                                                                                                                                                                                                                                                            
  - `cloudwatch_secret_access_key`                                                                                                                                                                                                                                                                                                                                                                                               
  - `elasticsearch_password`                                                                                                                                                                                                                                                                                                                                                                                                     
  - `http_basic_password`                                                                                                                                                                                                                                                                                                                                                                                                        
  - `http_bearer_token`                                                                                                                                                                                                                                                                                                                                                                                                          
  - `newrelic_license_key`                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ### Solution                                                                                                                                                                                                                                                                                                                                                                                                                   
  Added existence checks before type assertions for all sensitive fields. The code now only sets the value if:                                                                                                                                                                                                                                                                                                                   
  1. The key exists in the state map                                                                                                                                                                                                                                                                                                                                                                                             
  2. The value is not nil                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  This prevents panics and ensures proper drift detection behavior.                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ### Testing                                                                                                                                                                                                                                                                                                                                                                                                                    
  Existing acceptance tests should continue to pass. This fix prevents edge cases that could occur when:                                                                                                                                                                                                                                                                                                                         
  - Adding sensitive fields to existing clusters                                                                                                                                                                                                                                                                                                                                                                                 
  - Updating clusters where state hasn't been fully populated                                                                                                                                                                                                                                                                                                                                                                    
  - Running operations when API returns redacted values                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ### Changelog                                                                                                                                                                                                                                                                                                                                                                                                                  
  The changelog entry is included in `.changelog/1466.txt` as per contributing guidelines.