### PR TITLE
Clarified that cluster_id is actually cluster_name for Boundary cluster resource and data source

### DIFF
--- a/docs/data-sources/boundary_cluster.md
+++ b/docs/data-sources/boundary_cluster.md
@@ -13,7 +13,7 @@ The Boundary cluster data source provides information about an existing HCP Boun
 
 ```terraform
 data "hcp_boundary_cluster" "example" {
-  cluster_id = var.cluster_id
+  cluster_id = var.cluster_id   # Note: This is the Boundary cluster name, not its UUID. 
 }
 ```
 
@@ -22,11 +22,11 @@ data "hcp_boundary_cluster" "example" {
 
 ### Required
 
-- `cluster_id` (String) The ID of the Boundary cluster
+- `cluster_id` (String) The name of the Boundary cluster (not its UUID).  The cluster name is listed at the top of the HCP Boundary Cluster overview page. The variable `cluster_id` is used here because that's what the HCP API presently uses.
 
 ### Optional
 
-- `project_id` (String) The ID of the HCP project where the Boundary cluster is located. If not specified, the project configured in the HCP provider config block will be used.
+- `project_id` (String) The ID (UUID) of the HCP project where the Boundary cluster is located. If not specified, the project configured in the HCP provider config block will be used.
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
 If a project is not configured in the HCP Provider config block, the oldest project in the organization will be used.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/boundary_cluster.md
+++ b/docs/resources/boundary_cluster.md
@@ -13,7 +13,7 @@ This resource allows you to manage an HCP Boundary cluster
 
 ```terraform
 resource "hcp_boundary_cluster" "example" {
-  cluster_id = "boundary-cluster"
+  cluster_id = "boundary-cluster" # Note: This is the Boundary cluster name, not its UUID. 
   username   = "test-user"
   password   = "Password123!"
   maintenance_window_config {
@@ -32,7 +32,7 @@ resource "hcp_boundary_cluster" "example" {
 
 ### Required
 
-- `cluster_id` (String) The ID of the Boundary cluster
+- `cluster_id` (String) The name of the Boundary cluster (not its UUID).  The cluster name is listed at the top of the HCP Boundary Cluster overview page. The variable `cluster_id` is used here because that's what the HCP API presently uses.
 - `password` (String, Sensitive) The password of the initial admin user. This must be at least 8 characters in length. Note that this may show up in logs, and it will be stored in the state file.
 - `tier` (String) The tier that the HCP Boundary cluster will be provisioned as, 'Standard' or 'Plus'.
 - `username` (String) The username of the initial admin user. This must be at least 3 characters in length, alphanumeric, hyphen, or period.
@@ -42,7 +42,7 @@ resource "hcp_boundary_cluster" "example" {
 - `auth_token_time_to_live` (String) The time to live for the auth token in golang's time.Duration string format.
 - `auth_token_time_to_stale` (String) The time to stale for the auth token in golang's time.Duration string format.
 - `maintenance_window_config` (Block List, Max: 1) The maintenance window configuration for when cluster upgrades can take place. (see [below for nested schema](#nestedblock--maintenance_window_config))
-- `project_id` (String) The ID of the HCP project where the Boundary cluster is located.
+- `project_id` (String) The ID (UUID) of the HCP project where the Boundary cluster is located.
 If not specified, the project specified in the HCP Provider config block will be used, if configured.
 If a project is not configured in the HCP Provider config block, the oldest project in the organization will be used.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))


### PR DESCRIPTION
Updated Boundary cluster resource and data source README files to clarify that `cluster_id` is, in fact, `cluster_name` (although `project_id` IS, confusingly, project ID!) because the HCP API uses the variable `cluster_id` but it's not obvious to consumers of the provider that the terms are confuddled.

Ideally the HCP API will someday be updated to rename the variable `cluster_id` to `cluster_name` for clarity and--most importantly--consistency, but in the meantime, at least this documentation note will help users figure out why they're getting strange error messages when entering the correct cluster ID! ^_^


<!--
Adding a new resource or datasource? Use this checklist to get started: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/checklist-resource.md

Updating a resource? Avoid accidental breaking changes by reviewing this guide: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/breaking-changes.md
-->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If adding a new resource, what is it and what are its key features? If updating an existing resource, what new functionality was added? -->

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR. More info on acceptance tests here: https://github.com/hashicorp/terraform-provider-hcp/blob/main/contributing/writing-tests.md

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```sh
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.