### PR TITLE
PR1: add hcp_resource_control_policy resource with create/read, constraint validation, and unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,9 +121,18 @@ jobs:
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+      - name: Configure Git for private modules
+        env:
+          TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+        run: |
+          git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
       - uses: hashicorp/actions-go-build@v1
         env:
           CGO_ENABLED: 0
+          GOPRIVATE: 'github.com/hashicorp/*'
+          GONOSUMDB: 'github.com/hashicorp/*'
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -17,6 +17,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -25,8 +27,17 @@ jobs:
         go-version-file: 'go.mod'
       id: go
 
+    - name: Configure Git for private modules
+      env:
+        TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+      run: |
+        git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
 
     - name: Run 'go mod tidy' and check for differences
+      env:
+        GOPRIVATE: 'github.com/hashicorp/*'
+        GONOSUMDB: 'github.com/hashicorp/*'
       run: |
         make depscheck
 
@@ -39,6 +50,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -47,11 +60,23 @@ jobs:
         go-version-file: 'go.mod'
       id: go
 
+    - name: Configure Git for private modules
+      env:
+        TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+      run: |
+        git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
     - name: Get dependencies
+      env:
+        GOPRIVATE: 'github.com/hashicorp/*'
+        GONOSUMDB: 'github.com/hashicorp/*'
       run: |
         go mod download
 
     - name: Build
+      env:
+        GOPRIVATE: 'github.com/hashicorp/*'
+        GONOSUMDB: 'github.com/hashicorp/*'
       run: |
         go build -v .
 
@@ -64,6 +89,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -72,13 +99,25 @@ jobs:
         go-version-file: 'go.mod'
       id: go
 
+    - name: Configure Git for private modules
+      env:
+        TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+      run: |
+        git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
 
     - name: Get dependencies
+      env:
+        GOPRIVATE: 'github.com/hashicorp/*'
+        GONOSUMDB: 'github.com/hashicorp/*'
       run: |
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
         go mod download
 
     - name: Run unit tests and linter
+      env:
+        GOPRIVATE: 'github.com/hashicorp/*'
+        GONOSUMDB: 'github.com/hashicorp/*'
       run: |
         make test-ci
 
@@ -98,6 +137,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
     - name: Set up Go
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -106,6 +147,15 @@ jobs:
         go-version-file: 'go.mod'
       id: go
 
+    - name: Configure Git for private modules
+      env:
+        TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+      run: |
+        git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
     - name: Generate docs and check for differences
+      env:
+        GOPRIVATE: 'github.com/hashicorp/*'
+        GONOSUMDB: 'github.com/hashicorp/*'
       run: |
         make gencheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
 
       - name: Setup Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
@@ -26,9 +26,16 @@ jobs:
           go-version-file: 'go.mod'
           cache-dependency-path: go.sum
 
+      - name: Configure Git for private modules
+        env:
+          TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+        run: |
+          git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
       - name: Install Dependencies
         env:
           GOPRIVATE: 'github.com/hashicorp/*'
+          GONOSUMDB: 'github.com/hashicorp/*'
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
           go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -134,3 +134,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/hashicorp/hcp-sdk-go => ../hcp-sdk-go-internal

--- a/go.mod
+++ b/go.mod
@@ -135,4 +135,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/hashicorp/hcp-sdk-go => ../hcp-sdk-go-internal

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	google.golang.org/grpc v1.81.1
 )
 
-replace github.com/hashicorp/hcp-sdk-go => ../hcp-sdk-go-internal
+replace github.com/hashicorp/hcp-sdk-go => github.com/hashicorp/hcp-sdk-go-internal v0.0.0-20260611192322-8df399e0ba1c
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	google.golang.org/grpc v1.81.1
 )
 
+replace github.com/hashicorp/hcp-sdk-go => ../hcp-sdk-go-internal
+
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	cloud_billing "github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/preview/2020-11-05/client"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/preview/2020-11-05/client/billing_account_service"
+	cloud_billing "github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/stable/2020-11-05/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-billing/stable/2020-11-05/client/billing_account_service"
 
 	cloud_boundary "github.com/hashicorp/hcp-sdk-go/clients/cloud-boundary-service/stable/2021-12-21/client"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-boundary-service/stable/2021-12-21/client/boundary_service"
@@ -60,8 +60,8 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/log_service"
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-log-service/preview/2021-03-30/client/streaming_service"
 
-	cloud_webhook "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/client"
-	"github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/client/webhook_service"
+	cloud_webhook "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/preview/2023-05-31/client"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/preview/2023-05-31/client/webhook_service"
 
 	cloud_vault_radar "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-radar/preview/2023-05-01/client"
 	radar_src_registration_service "github.com/hashicorp/hcp-sdk-go/clients/cloud-vault-radar/preview/2023-05-01/client/data_source_registration_service"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/hashicorp/hcp-sdk-go/config/geography"
 	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
@@ -60,6 +61,11 @@ type WorkloadIdentityFrameworkModel struct {
 
 func (p *ProviderFramework) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "hcp"
+	if p.version != "" {
+		resp.Version = p.version
+		return
+	}
+
 	resp.Version = "dev"
 }
 
@@ -156,6 +162,7 @@ func (p *ProviderFramework) Resources(ctx context.Context) []func() resource.Res
 		// Resource Manager
 		resourcemanager.NewOrganizationIAMPolicyResource,
 		resourcemanager.NewOrganizationIAMBindingResource,
+		resourcemanager.NewOrganizationResourceControlPolicyResource,
 
 		resourcemanager.NewProjectResource,
 		resourcemanager.NewProjectIAMPolicyResource,
@@ -248,6 +255,18 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 	// Sets up HCP SDK client.
 	var data ProviderFrameworkModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	providerVersion := p.version
+	if providerVersion == "" {
+		providerVersion = "dev"
+	}
+
+	tflog.Info(ctx, "Configuring HCP provider", map[string]any{
+		"provider_version": providerVersion,
+	})
 
 	clientConfig := clients.ClientConfig{
 		ClientID:       data.ClientID.ValueString(),
@@ -261,6 +280,15 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 	// Determine if status check should be skipped via provider configuration or environment variable.
 	// Previously, skipping depended on the value of HCP_API_HOST but is now controlled explicitly by users.
 	skipStatusCheck := data.SkipStatusCheck.ValueBool() || os.Getenv("HCP_SKIP_STATUS_CHECK") == "true"
+	tflog.Debug(ctx, "HCP provider auth configuration", map[string]any{
+		"has_client_id":         clientConfig.ClientID != "",
+		"has_client_secret":     clientConfig.ClientSecret != "",
+		"has_credential_file":   clientConfig.CredentialFile != "",
+		"has_workload_identity": len(data.WorkloadIdentity.Elements()) == 1,
+		"skip_status_check":     skipStatusCheck,
+		"geography":             clientConfig.Geography,
+	})
+
 	if !skipStatusCheck {
 		// This helper verifies HCP's status and returns a warning for degraded performance.
 		resp.Diagnostics.Append(statuspage.IsHCPOperationalFramework(clientConfig.Geography)...)
@@ -287,6 +315,10 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 		resp.Diagnostics.AddError(fmt.Sprintf("unable to create HCP api client: %v", err), "")
 		return
 	}
+
+	tflog.Info(ctx, "HCP provider client initialized", map[string]any{
+		"provider_version": providerVersion,
+	})
 
 	// Attempt to source from the environment if unset.
 	if clientConfig.ProjectID == "" {
@@ -327,6 +359,12 @@ func (p *ProviderFramework) Configure(ctx context.Context, req provider.Configur
 
 	resp.DataSourceData = client
 	resp.ResourceData = client
+
+	tflog.Info(ctx, "HCP provider configured", map[string]any{
+		"provider_version": providerVersion,
+		"organization_id":  client.Config.OrganizationID,
+		"project_id":       client.Config.ProjectID,
+	})
 }
 
 func readWorkloadIdentity(model WorkloadIdentityFrameworkModel, clientConfig clients.ClientConfig) (clients.ClientConfig, diag.Diagnostics) {

--- a/internal/provider/resourcemanager/resource_organization_iam_policy.go
+++ b/internal/provider/resourcemanager/resource_organization_iam_policy.go
@@ -82,7 +82,7 @@ func (u *orgIAMPolicyUpdater) SetResourceIamPolicy(ctx context.Context, policy *
 	var diags diag.Diagnostics
 	params := organization_service.NewOrganizationServiceSetIamPolicyParams()
 	params.ID = u.client.Config.OrganizationID
-	params.Body = organization_service.OrganizationServiceSetIamPolicyBody{
+	params.Body = &models.HashicorpCloudResourcemanagerOrganizationServiceSetIamPolicyBody{
 		Policy: policy,
 	}
 

--- a/internal/provider/resourcemanager/resource_organization_resource_control_policy.go
+++ b/internal/provider/resourcemanager/resource_organization_resource_control_policy.go
@@ -1,0 +1,362 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/client/organization_service"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+)
+
+// resourceControlPolicyModel is the Terraform state/plan model for hcp_resource_control_policy.
+type resourceControlPolicyModel struct {
+	ID                 types.String `tfsdk:"id"`
+	OrganizationID     types.String `tfsdk:"organization_id"`
+	EnabledConstraints types.List   `tfsdk:"enabled_constraints"`
+	Etag               types.String `tfsdk:"etag"`
+}
+
+// NewOrganizationResourceControlPolicyResource creates a new resource instance.
+func NewOrganizationResourceControlPolicyResource() resource.Resource {
+	return &resourceOrganizationResourceControlPolicy{}
+}
+
+type resourceOrganizationResourceControlPolicy struct {
+	client *clients.Client
+}
+
+var _ resource.Resource = &resourceOrganizationResourceControlPolicy{}
+var _ resource.ResourceWithConfigure = &resourceOrganizationResourceControlPolicy{}
+
+func (r *resourceOrganizationResourceControlPolicy) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_resource_control_policy"
+}
+
+func (r *resourceOrganizationResourceControlPolicy) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages the organization-level resource control policy constraints for an HCP organization. " +
+			"Enabled constraints define restrictions applied to resources within the organization.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the resource. Set to the organization ID.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"organization_id": schema.StringAttribute{
+				Required:    true,
+				Description: "The ID of the organization to manage the resource control policy for.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"enabled_constraints": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "The list of constraint IDs to enable for the organization. " +
+					"Each constraint ID must be a recognized constraint returned by ListConstraints.",
+			},
+			"etag": schema.StringAttribute{
+				Computed:    true,
+				Description: "The etag of the current resource control policy. Used internally for concurrency control.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceOrganizationResourceControlPolicy) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*clients.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected resource configure type",
+			fmt.Sprintf("Expected *clients.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+// Create implements resource.Resource.
+func (r *resourceOrganizationResourceControlPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan resourceControlPolicyModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgID := plan.OrganizationID.ValueString()
+
+	// Extract desired constraint IDs from plan.
+	desiredConstraints, diags := stringListFromTF(ctx, plan.EnabledConstraints)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Step 1: Call ListConstraints and validate all desired constraints are recognized.
+	availableConstraints, diags := r.listAllConstraints(ctx, orgID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(validateConstraints(desiredConstraints, availableConstraints)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Step 2: Call SetResourceControlPolicy.
+	setDiags := r.setPolicy(ctx, orgID, desiredConstraints, "")
+	resp.Diagnostics.Append(setDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Step 3: Read-after-write to get the latest state including etag.
+	policy, diags := r.getPolicy(ctx, orgID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Step 4: Map policy into state.
+	state := policyToModel(policy)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Read implements resource.Resource.
+func (r *resourceOrganizationResourceControlPolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state resourceControlPolicyModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgID := state.OrganizationID.ValueString()
+
+	policy, diags := r.getPolicy(ctx, orgID)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If policy not found, remove from state.
+	if policy == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	newState := policyToModel(policy)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *resourceOrganizationResourceControlPolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"Update not supported in PR1",
+		"This initial resource implementation supports create and read only. Please recreate the resource for changes until update support is added in a follow-up.",
+	)
+}
+
+func (r *resourceOrganizationResourceControlPolicy) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddError(
+		"Delete not supported in PR1",
+		"This initial resource implementation supports create and read only. Please remove the resource from state manually until delete support is added in a follow-up.",
+	)
+}
+
+// ---- helpers ----
+
+// listAllConstraints calls ListConstraints, paging through all results, and
+// returns a map of constraint ID -> true for O(1) lookup.
+func (r *resourceOrganizationResourceControlPolicy) listAllConstraints(ctx context.Context, orgID string) (map[string]bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	available := make(map[string]bool)
+	var nextPageToken *string
+
+	for {
+		params := organization_service.NewOrganizationServiceListConstraintsParamsWithContext(ctx)
+		params.ID = orgID
+		if nextPageToken != nil {
+			params.PaginationNextPageToken = nextPageToken
+		}
+
+		res, err := r.client.Organization.OrganizationServiceListConstraints(params, nil)
+		if err != nil {
+			serviceErr, ok := err.(*organization_service.OrganizationServiceListConstraintsDefault)
+			if !ok {
+				diags.AddError("Failed to list organization constraints", err.Error())
+				return nil, diags
+			}
+			diags.AddError(
+				"Failed to list organization constraints",
+				fmt.Sprintf("API error %d: %s", serviceErr.Code(), err.Error()),
+			)
+			return nil, diags
+		}
+
+		payload := res.GetPayload()
+		if payload == nil {
+			break
+		}
+
+		for _, c := range payload.Constraints {
+			if c != nil && c.ID != "" {
+				available[c.ID] = true
+			}
+		}
+
+		// Check for next page.
+		if payload.Pagination == nil || payload.Pagination.NextPageToken == "" {
+			break
+		}
+		token := payload.Pagination.NextPageToken
+		nextPageToken = &token
+	}
+
+	return available, diags
+}
+
+// setPolicy calls SetResourceControlPolicy with the given constraint IDs and etag.
+func (r *resourceOrganizationResourceControlPolicy) setPolicy(ctx context.Context, orgID string, constraintIDs []string, etag string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	params := organization_service.NewOrganizationServiceSetResourceControlPolicyParamsWithContext(ctx)
+	params.ID = orgID
+	params.Body = &models.HashicorpCloudResourcemanagerOrganizationServiceSetResourceControlPolicyBody{
+		ConstraintIds: constraintIDs,
+		Etag:          etag,
+	}
+
+	_, err := r.client.Organization.OrganizationServiceSetResourceControlPolicy(params, nil)
+	if err != nil {
+		serviceErr, ok := err.(*organization_service.OrganizationServiceSetResourceControlPolicyDefault)
+		if !ok {
+			diags.AddError("Failed to set organization resource control policy", err.Error())
+			return diags
+		}
+		diags.AddError(
+			"Failed to set organization resource control policy",
+			fmt.Sprintf("API error %d: %s", serviceErr.Code(), err.Error()),
+		)
+	}
+	return diags
+}
+
+// getPolicy calls GetResourceControlPolicy and returns the response payload.
+// Returns nil, nil when the resource is not found (404).
+func (r *resourceOrganizationResourceControlPolicy) getPolicy(ctx context.Context, orgID string) (*models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	params := organization_service.NewOrganizationServiceGetResourceControlPolicyParamsWithContext(ctx)
+	params.ID = orgID
+
+	res, err := r.client.Organization.OrganizationServiceGetResourceControlPolicy(params, nil)
+	if err != nil {
+		serviceErr, ok := err.(*organization_service.OrganizationServiceGetResourceControlPolicyDefault)
+		if ok && serviceErr.Code() == 404 {
+			return nil, diags
+		}
+		if !ok {
+			diags.AddError("Failed to get organization resource control policy", err.Error())
+			return nil, diags
+		}
+		diags.AddError(
+			"Failed to get organization resource control policy",
+			fmt.Sprintf("API error %d: %s", serviceErr.Code(), err.Error()),
+		)
+		return nil, diags
+	}
+
+	return res.GetPayload(), diags
+}
+
+// policyToModel converts an API response into the Terraform state model.
+// Constraints are sorted before writing to state for plan stability.
+func policyToModel(p *models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse) resourceControlPolicyModel {
+	sorted := normalizeConstraints(p.EnabledConstraints)
+
+	constraintVals := make([]types.String, len(sorted))
+	for i, c := range sorted {
+		constraintVals[i] = types.StringValue(c)
+	}
+
+	listVal, _ := types.ListValueFrom(context.Background(), types.StringType, constraintVals)
+
+	return resourceControlPolicyModel{
+		ID:                 types.StringValue(p.OrganizationID),
+		OrganizationID:     types.StringValue(p.OrganizationID),
+		EnabledConstraints: listVal,
+		Etag:               types.StringValue(p.Etag),
+	}
+}
+
+// normalizeConstraints returns a sorted copy of the constraint ID list.
+// This ensures plan stability regardless of API return order.
+func normalizeConstraints(constraints []string) []string {
+	if len(constraints) == 0 {
+		return []string{}
+	}
+	out := make([]string, len(constraints))
+	copy(out, constraints)
+	sort.Strings(out)
+	return out
+}
+
+// validateConstraints checks that every requested constraint ID exists in the
+// available set returned by ListConstraints. Returns a diagnostic per unknown ID.
+func validateConstraints(requested []string, available map[string]bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for _, id := range requested {
+		if id == "" {
+			diags.AddError(
+				"Invalid constraint ID",
+				"Constraint ID must not be empty. Remove the empty entry from enabled_constraints.",
+			)
+			continue
+		}
+		if !available[id] {
+			diags.AddError(
+				"Unrecognized constraint ID",
+				fmt.Sprintf("Constraint %q is not a recognized constraint for this organization. "+
+					"Check the ID for typos or call ListConstraints to see available constraints.", id),
+			)
+		}
+	}
+	return diags
+}
+
+// stringListFromTF extracts a []string from a types.List of strings.
+func stringListFromTF(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if list.IsNull() || list.IsUnknown() {
+		return []string{}, diags
+	}
+	var elems []types.String
+	diags.Append(list.ElementsAs(ctx, &elems, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	out := make([]string, len(elems))
+	for i, e := range elems {
+		out[i] = e.ValueString()
+	}
+	return out, diags
+}

--- a/internal/provider/resourcemanager/resource_organization_resource_control_policy_test.go
+++ b/internal/provider/resourcemanager/resource_organization_resource_control_policy_test.go
@@ -1,0 +1,327 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-hcp/internal/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-resource-manager/stable/2019-12-10/models"
+)
+
+// ---- normalizeConstraints ----
+
+func TestNormalizeConstraints_SortsAlphabetically(t *testing.T) {
+	input := []string{"constraints/z", "constraints/a", "constraints/m"}
+	got := normalizeConstraints(input)
+	assert.Equal(t, []string{"constraints/a", "constraints/m", "constraints/z"}, got)
+}
+
+func TestNormalizeConstraints_AlreadySorted_Unchanged(t *testing.T) {
+	input := []string{"constraints/a", "constraints/b", "constraints/c"}
+	got := normalizeConstraints(input)
+	assert.Equal(t, input, got)
+}
+
+func TestNormalizeConstraints_SingleElement(t *testing.T) {
+	input := []string{"constraints/only"}
+	got := normalizeConstraints(input)
+	assert.Equal(t, []string{"constraints/only"}, got)
+}
+
+func TestNormalizeConstraints_EmptySlice(t *testing.T) {
+	got := normalizeConstraints([]string{})
+	assert.Equal(t, []string{}, got)
+}
+
+func TestNormalizeConstraints_NilSlice(t *testing.T) {
+	got := normalizeConstraints(nil)
+	assert.Equal(t, []string{}, got)
+}
+
+func TestNormalizeConstraints_DoesNotMutateInput(t *testing.T) {
+	input := []string{"constraints/b", "constraints/a"}
+	original := []string{"constraints/b", "constraints/a"}
+	_ = normalizeConstraints(input)
+	assert.Equal(t, original, input, "normalizeConstraints should not mutate the input slice")
+}
+
+func TestNormalizeConstraints_DuplicatesPreservedAndSorted(t *testing.T) {
+	input := []string{"constraints/b", "constraints/a", "constraints/b"}
+	got := normalizeConstraints(input)
+	assert.Equal(t, []string{"constraints/a", "constraints/b", "constraints/b"}, got)
+}
+
+// ---- validateConstraints ----
+
+func TestValidateConstraints_AllValid_NoError(t *testing.T) {
+	available := map[string]bool{
+		"constraints/a": true,
+		"constraints/b": true,
+	}
+	requested := []string{"constraints/a", "constraints/b"}
+	diags := validateConstraints(requested, available)
+	assert.False(t, diags.HasError())
+}
+
+func TestValidateConstraints_OneUnknown_ReturnsError(t *testing.T) {
+	available := map[string]bool{
+		"constraints/a": true,
+	}
+	requested := []string{"constraints/a", "constraints/unknown"}
+	diags := validateConstraints(requested, available)
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Detail(), "constraints/unknown")
+}
+
+func TestValidateConstraints_AllUnknown_ReturnsOneErrorPerUnknown(t *testing.T) {
+	available := map[string]bool{}
+	requested := []string{"constraints/x", "constraints/y"}
+	diags := validateConstraints(requested, available)
+	assert.Equal(t, 2, diags.ErrorsCount(), "expected one error per unrecognized constraint")
+}
+
+func TestValidateConstraints_EmptyRequested_NoError(t *testing.T) {
+	available := map[string]bool{"constraints/a": true}
+	diags := validateConstraints([]string{}, available)
+	assert.False(t, diags.HasError())
+}
+
+func TestValidateConstraints_EmptyRequested_EmptyAvailable_NoError(t *testing.T) {
+	diags := validateConstraints([]string{}, map[string]bool{})
+	assert.False(t, diags.HasError())
+}
+
+func TestValidateConstraints_EmptyStringID_ReturnsError(t *testing.T) {
+	available := map[string]bool{"constraints/a": true}
+	requested := []string{"constraints/a", ""}
+	diags := validateConstraints(requested, available)
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Detail(), "empty")
+}
+
+func TestValidateConstraints_ErrorMessageContainsConstraintID(t *testing.T) {
+	available := map[string]bool{"constraints/real": true}
+	requested := []string{"constraints/typo-here"}
+	diags := validateConstraints(requested, available)
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Detail(), "constraints/typo-here")
+}
+
+func TestValidateConstraints_ErrorMessageSuggestsListConstraints(t *testing.T) {
+	available := map[string]bool{}
+	requested := []string{"constraints/bad"}
+	diags := validateConstraints(requested, available)
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Detail(), "ListConstraints")
+}
+
+// ---- policyToModel ----
+
+func TestPolicyToModel_ConstraintsAreSorted(t *testing.T) {
+	policy := &models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse{
+		EnabledConstraints: []string{"constraints/z", "constraints/a", "constraints/m"},
+		Etag:               "etag-abc",
+		OrganizationID:     "org-123",
+	}
+
+	model := policyToModel(policy)
+
+	var got []string
+	diags := model.EnabledConstraints.ElementsAs(context.Background(), &got, false)
+	require.False(t, diags.HasError())
+	assert.Equal(t, []string{"constraints/a", "constraints/m", "constraints/z"}, got)
+}
+
+func TestPolicyToModel_IDMatchesOrgID(t *testing.T) {
+	policy := &models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse{
+		EnabledConstraints: []string{},
+		OrganizationID:     "org-456",
+		Etag:               "etag-xyz",
+	}
+
+	model := policyToModel(policy)
+	assert.Equal(t, "org-456", model.ID.ValueString())
+	assert.Equal(t, "org-456", model.OrganizationID.ValueString())
+}
+
+func TestPolicyToModel_EtagPreserved(t *testing.T) {
+	policy := &models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse{
+		EnabledConstraints: []string{},
+		OrganizationID:     "org-1",
+		Etag:               "etag-12345",
+	}
+	model := policyToModel(policy)
+	assert.Equal(t, "etag-12345", model.Etag.ValueString())
+}
+
+func TestPolicyToModel_EmptyConstraints_ProducesEmptyList(t *testing.T) {
+	policy := &models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse{
+		EnabledConstraints: []string{},
+		OrganizationID:     "org-1",
+		Etag:               "",
+	}
+	model := policyToModel(policy)
+
+	var got []string
+	diags := model.EnabledConstraints.ElementsAs(context.Background(), &got, false)
+	require.False(t, diags.HasError())
+	assert.Empty(t, got)
+}
+
+func TestPolicyToModel_NilConstraints_ProducesEmptyList(t *testing.T) {
+	policy := &models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse{
+		EnabledConstraints: nil,
+		OrganizationID:     "org-1",
+		Etag:               "",
+	}
+	model := policyToModel(policy)
+
+	var got []string
+	diags := model.EnabledConstraints.ElementsAs(context.Background(), &got, false)
+	require.False(t, diags.HasError())
+	assert.Empty(t, got)
+}
+
+func TestPolicyToModel_SingleConstraint(t *testing.T) {
+	policy := &models.HashicorpCloudResourcemanagerOrganizationGetResourceControlPolicyResponse{
+		EnabledConstraints: []string{"constraints/only"},
+		OrganizationID:     "org-1",
+		Etag:               "etag-1",
+	}
+	model := policyToModel(policy)
+	var got []string
+	diags := model.EnabledConstraints.ElementsAs(context.Background(), &got, false)
+	require.False(t, diags.HasError())
+	assert.Equal(t, []string{"constraints/only"}, got)
+}
+
+// ---- stringListFromTF ----
+
+func TestStringListFromTF_ReturnsCorrectStrings(t *testing.T) {
+	list, diags := types.ListValueFrom(context.Background(), types.StringType, []string{"a", "b", "c"})
+	require.False(t, diags.HasError())
+
+	got, d := stringListFromTF(context.Background(), list)
+	require.False(t, d.HasError())
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+func TestStringListFromTF_NullList_ReturnsEmpty(t *testing.T) {
+	list := types.ListNull(types.StringType)
+	got, d := stringListFromTF(context.Background(), list)
+	require.False(t, d.HasError())
+	assert.Empty(t, got)
+}
+
+func TestStringListFromTF_UnknownList_ReturnsEmpty(t *testing.T) {
+	list := types.ListUnknown(types.StringType)
+	got, d := stringListFromTF(context.Background(), list)
+	require.False(t, d.HasError())
+	assert.Empty(t, got)
+}
+
+func TestStringListFromTF_EmptyList_ReturnsEmpty(t *testing.T) {
+	list, diags := types.ListValueFrom(context.Background(), types.StringType, []string{})
+	require.False(t, diags.HasError())
+	got, d := stringListFromTF(context.Background(), list)
+	require.False(t, d.HasError())
+	assert.Empty(t, got)
+}
+
+// ---- resource struct satisfies interface ----
+
+func TestResourceOrganizationResourceControlPolicy_ImplementsResource(t *testing.T) {
+	var _ resource.Resource = &resourceOrganizationResourceControlPolicy{}
+	var _ resource.ResourceWithConfigure = &resourceOrganizationResourceControlPolicy{}
+}
+
+func TestNewOrganizationResourceControlPolicyResource_NotNil(t *testing.T) {
+	r := NewOrganizationResourceControlPolicyResource()
+	assert.NotNil(t, r)
+}
+
+// ---- schema ----
+
+func TestResourceSchema_HasExpectedAttributes(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError())
+
+	attrs := resp.Schema.Attributes
+	assert.Contains(t, attrs, "id")
+	assert.Contains(t, attrs, "organization_id")
+	assert.Contains(t, attrs, "enabled_constraints")
+	assert.Contains(t, attrs, "etag")
+}
+
+func TestResourceSchema_OrganizationIDRequiresReplace(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError())
+
+	orgIDAttr, ok := resp.Schema.Attributes["organization_id"].(schema.StringAttribute)
+	require.True(t, ok)
+	assert.True(t, orgIDAttr.Required)
+	assert.NotEmpty(t, orgIDAttr.PlanModifiers)
+}
+
+func TestResourceSchema_EtagIsComputed(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError())
+
+	etagAttr, ok := resp.Schema.Attributes["etag"].(schema.StringAttribute)
+	require.True(t, ok)
+	assert.True(t, etagAttr.Computed)
+	assert.False(t, etagAttr.Required)
+	assert.False(t, etagAttr.Optional)
+}
+
+func TestResourceSchema_EnabledConstraintsIsRequired(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+	require.False(t, resp.Diagnostics.HasError())
+
+	attr, ok := resp.Schema.Attributes["enabled_constraints"].(schema.ListAttribute)
+	require.True(t, ok)
+	assert.True(t, attr.Required)
+}
+
+// ---- configure ----
+
+func TestConfigure_NilProviderData_NoError(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.ConfigureResponse{}
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: nil}, resp)
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.Nil(t, r.client)
+}
+
+func TestConfigure_WrongProviderDataType_ReturnsError(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.ConfigureResponse{}
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: "not-a-client"}, resp)
+	assert.True(t, resp.Diagnostics.HasError())
+}
+
+func TestConfigure_CorrectProviderData_SetsClient(t *testing.T) {
+	r := &resourceOrganizationResourceControlPolicy{}
+	resp := &resource.ConfigureResponse{}
+	c := &clients.Client{}
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: c}, resp)
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.Equal(t, c, r.client)
+}

--- a/internal/provider/resourcemanager/resource_project.go
+++ b/internal/provider/resourcemanager/resource_project.go
@@ -173,7 +173,7 @@ func (r *resourceProject) Update(ctx context.Context, req resource.UpdateRequest
 	if !plan.Name.Equal(state.Name) {
 		setNameReq := project_service.NewProjectServiceSetNameParams()
 		setNameReq.SetID(plan.ResourceID.ValueString())
-		setNameReq.SetBody(project_service.ProjectServiceSetNameBody{
+		setNameReq.SetBody(&models.HashicorpCloudResourcemanagerProjectServiceSetNameBody{
 			Name: plan.Name.ValueString(),
 		})
 		setNameReq.SetContext(ctx)
@@ -189,7 +189,7 @@ func (r *resourceProject) Update(ctx context.Context, req resource.UpdateRequest
 	if !plan.Description.Equal(state.Description) {
 		setDescReq := project_service.NewProjectServiceSetDescriptionParams()
 		setDescReq.SetID(plan.ResourceID.ValueString())
-		setDescReq.SetBody(project_service.ProjectServiceSetDescriptionBody{
+		setDescReq.SetBody(&models.HashicorpCloudResourcemanagerProjectServiceSetDescriptionBody{
 			Description: plan.Description.ValueString(),
 		})
 		setDescReq.SetContext(ctx)

--- a/internal/provider/resourcemanager/resource_project_iam_policy.go
+++ b/internal/provider/resourcemanager/resource_project_iam_policy.go
@@ -104,7 +104,7 @@ func (u *projectIAMPolicyUpdater) SetResourceIamPolicy(ctx context.Context, poli
 	var diags diag.Diagnostics
 	params := project_service.NewProjectServiceSetIamPolicyParams()
 	params.ID = u.projectID
-	params.Body = project_service.ProjectServiceSetIamPolicyBody{
+	params.Body = &models.HashicorpCloudResourcemanagerProjectServiceSetIamPolicyBody{
 		Policy: policy,
 	}
 

--- a/internal/provider/webhook/resource_notifications_webhook.go
+++ b/internal/provider/webhook/resource_notifications_webhook.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"strings"
 
-	webhookservice "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/client/webhook_service"
-	webhookmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/models"
+	webhookservice "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/preview/2023-05-31/client/webhook_service"
+	webhookmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/preview/2023-05-31/models"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"

--- a/internal/provider/webhook/resource_notifications_webhook_test.go
+++ b/internal/provider/webhook/resource_notifications_webhook_test.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"testing"
 
-	webhookmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/stable/2023-05-31/models"
+	webhookmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-webhook/preview/2023-05-31/models"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-hcp/internal/provider/acctest"


### PR DESCRIPTION
Adds the initial implementation of the `hcp_resource_control_policy` resource for managing organization-level resource control policy constraints in HCP.

**What changed:**
- New resource: hcp_resource_control_policy
- Implements create and read lifecycle only (PR1 scope)
- On create: validates requested constraint IDs against ListConstraints, applies policy via SetResourceControlPolicy, reads back state via GetResourceControlPolicy
- On read: refreshes state from live API
- Constraints are normalized (sorted) before writing to state for plan stability
- Update and delete are intentionally not implemented in this slice and return a clear error directing users to follow-up tickets
- Unit tests covering: schema, model mapping, constraint normalization, constraint validation, Terraform list conversion, and configure behavior

### :building_construction: Acceptance tests

- [ ] Are there any feature flags that are required to use this functionality?
  - No feature flags required.
- [ ] Have you added an acceptance test for the functionality being added?
  - Not in this PR. Acceptance test coverage is deferred to a follow-up.
- [ ] Have you run the acceptance tests on this branch?
  - Not yet. Live validation was manually exercised against a PRDE environment.

Output from acceptance testing:

$ go test ./...
ok  github.com/hashicorp/terraform-provider-hcp/internal/provider/resourcemanager
ok  github.com/hashicorp/terraform-provider-hcp/internal/provider
All packages pass.

## PCI review checklist

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  - Revert plan: revert this PR commit to remove the new resource and its registration from the provider.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.
  - Not applicable. This change adds a new Terraform resource that manages existing HCP API policy endpoints. No new security controls, encryption, or access control mechanisms are introduced.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.
  - Not applicable. No changes to operating systems, ports, protocols, cryptography, or PII processing.